### PR TITLE
Add retroactive release notes for v0.1.0 and v0.1.1

### DIFF
--- a/docs/releases/v0.1.0.md
+++ b/docs/releases/v0.1.0.md
@@ -1,0 +1,92 @@
+## Version 0.1.0
+
+This is the initial release of Canvas Chat, a visual non-linear chat interface where conversations are nodes on an infinite canvas, allowing branching, merging, and exploration of topics as a directed acyclic graph (DAG).
+
+### Core Features
+
+- **Infinite Canvas**: Pan and zoom interface with native trackpad/touch gesture support for navigating conversations
+- **Node-based Conversations**: Chat messages rendered as draggable, resizable nodes with support for branching and merging
+- **Multi-model Support**: Works with OpenAI, Anthropic Claude, Google, Groq, GitHub Copilot, and local Ollama models
+- **Session Management**: Create, save, and switch between multiple canvas sessions
+
+### Canvas & Navigation
+
+- Add semantic zoom with auto-generated summaries for nodes when zoomed out (5531ab0, Eric Ma)
+- Add BM25 keyword search for nodes with Cmd/Ctrl+K shortcut (7e07769, Eric Ma)
+- Add smooth animated transitions for auto-layout and pan operations (2b370f4, c5883a9, Eric Ma)
+- Add one-click node resize to 80% viewport with scrollable content (84e86ea, Eric Ma)
+- Add subtle fade effect on non-selected nodes to focus attention (61cd855, Eric Ma)
+- Improve node fading: ancestors less faded than non-ancestors (2202429, Eric Ma)
+- Make selected nodes more visually obvious with dashed outline (76046c9, Eric Ma)
+
+### AI & LLM Features
+
+- Support multiple concurrent AI streams with per-node abort controllers (1e69803, Eric Ma)
+- Add stop/continue buttons for LLM generation in node header (308e150, Eric Ma)
+- Add auto-title generation for conversations (d0ab531, Eric Ma)
+- Auto-populate models from provider APIs dynamically (c4229b3, Eric Ma)
+- Filter models by available API keys and fetch Ollama dynamically (053cbb0, Eric Ma)
+- Add GitHub Copilot support and new Claude models (a174566, Eric Ma)
+
+### Matrix Evaluation
+
+- Add /matrix command for cross-product evaluation tables (8efe873, Eric Ma)
+- Support single-node /matrix command with two-list extraction (482e137, Eric Ma)
+- Allow matrix creation with N context nodes instead of just 2 (a856bc2, Eric Ma)
+- Add matrix row/column extraction with preview modal (d24dd19, Eric Ma)
+- Improve matrix creation and editing experience with editable rows/columns (a20a805, Eric Ma)
+- Add undo/redo support for matrix cell fills (e00049d, Eric Ma)
+
+### Research & Search
+
+- Add Exa web search with /search slash command (398099b, Eric Ma)
+- Add Exa research for deep topic exploration (a48932d, Eric Ma)
+- Add contextual search query refinement using LLM (f826308, Eric Ma)
+- Add fetch & summarize for Reference nodes (e35eeeb, Eric Ma)
+- Split Fetch & Summarize into two nodes: FETCH_RESULT and SUMMARY (22ebbec, Eric Ma)
+- Add editable FETCH_RESULT nodes with versioning and re-summarize (b3ab838, Eric Ma)
+
+### Editing & Interaction
+
+- Add inline reply tooltip for text selection branching (fbe26df, Eric Ma)
+- Add slash command autocomplete menu with keyboard navigation (9232882, Eric Ma)
+- Add split-pane markdown editor with live preview for content editing (a2e3d77, Eric Ma)
+- Add 'c' keyboard shortcut to copy node content (6282c51, Eric Ma)
+- Add 'r' keyboard shortcut to focus reply input (9eeeae9, Eric Ma)
+- Add copy button to nodes for easy content copying (c215ba4, Eric Ma)
+- Add highlight source text feature for excerpt nodes (6a17401, Eric Ma)
+
+### Usability Improvements
+
+- Add undo/redo system for node operations (02f6cec, Eric Ma)
+- Add help modal with keyboard shortcuts and tips (02f6cec, Eric Ma)
+- Add node tagging system with color-coded tags and drawer UI (a3a57d6, Eric Ma)
+- Add layout algorithm selection with force-directed option (719a9e2, Eric Ma)
+- Fixed-size scrollable nodes for AI, Summary, Research, Fetch Result (518b01d, Eric Ma)
+
+### Infrastructure
+
+- Add Modal deployment with CI/CD (240b72c, Eric Ma)
+- Add streaming architecture with SSE (da6d8c7, Eric Ma)
+- Add shared SSE utility with text normalization (d15e7b9, Eric Ma)
+
+### Bug Fixes
+
+- Fix force-directed layout edge spring to respect node sizes (7ff72f5, Eric Ma)
+- Fix force-directed layout overlap detection for rectangles (7c2ca1d, Eric Ma)
+- Fix resolveOverlaps to properly separate large nodes (53686c4, Eric Ma)
+- Fix zoomed-out summary text not updating after content loads (2830112, Eric Ma)
+- Fix SSE data parsing to handle standard 'data: ' format (7e0f5da, Eric Ma)
+- Fix SSE parsing to preserve newlines in multi-line content (9701825, Eric Ma)
+- Fix markdown rendering to preserve code block formatting (1866164, Eric Ma)
+- Fix edge rendering after auto-layout and node resize constraints (9f5a382, Eric Ma)
+- Fix auto-layout to use actual node dimensions from canvas (6eb8088, Eric Ma)
+- Fix settings modal scrolling on small screens (4088976, Eric Ma)
+- Fix matrix cell SSE streaming with CRLF normalization (58473c3, Eric Ma)
+
+### Documentation
+
+- Add streaming architecture design decision doc (da6d8c7, Eric Ma)
+- Add how-to documentation for matrix evaluation feature (e31a3a0, Eric Ma)
+- Document concurrent state isolation pattern (eb0a5d3, Eric Ma)
+- Add post-task review guidance to AGENTS.md (e6bbf27, Eric Ma)

--- a/docs/releases/v0.1.1.md
+++ b/docs/releases/v0.1.1.md
@@ -1,0 +1,21 @@
+## Version 0.1.1
+
+This release brings major improvements to the Canvas Chat experience, including a robust CI/CD pipeline, automatic PyPI publishing, a refactored Python package structure, and significant enhancements to the force-directed layout and node overlap handling. It also introduces LLM-generated release notes, improved test coverage, and a more reliable and maintainable codebase.
+
+### New Features
+
+- Add LLM-generated release notes using llamabot, with automated storage and GitHub release integration. (116346, Eric Ma)
+- Add tests workflow for Python (3.11, 3.12, 3.13) and JavaScript, and update all GitHub Actions to latest versions. (9155ef, Eric Ma)
+- Add automatic PyPI publishing on merge to main, with trusted publishing and version management. (e3afef, Eric Ma)
+- Refactor to a proper Python package structure for PyPI publishing, including CLI entry point and improved test imports. (f836a6, Eric Ma)
+
+### Bug Fixes
+
+- Fix force-directed layout edge spring to respect node sizes, preventing large nodes from overlapping when connected by edges. (7ff72f, Eric Ma)
+- Fix force-directed layout overlap detection for rectangles, ensuring repulsion only when bounding boxes actually intersect. (7c2ca1, Eric Ma)
+- Fix resolveOverlaps to properly separate large nodes, improving convergence speed and correctness for heavily overlapping nodes. (53686c, Eric Ma)
+- Fix handleNodeResummarize to use correct streaming pattern, and document API verification steps for agents. (3367d9, Eric Ma)
+
+### Deprecations
+
+- No deprecations in this release.


### PR DESCRIPTION
## Summary

Add release notes for the first two versions of Canvas Chat.

### v0.1.0 (Initial Release)
Comprehensive release notes covering all 79 commits from the initial commit, including:
- Core canvas features (pan, zoom, node-based conversations)
- Multi-model LLM support (OpenAI, Anthropic, Google, Groq, Ollama)
- Matrix evaluation feature
- Research & search with Exa
- Usability improvements (undo/redo, help modal, tagging)

### v0.1.1 (Packaging Release)
- PyPI packaging with `canvas-chat` CLI
- CI/CD automation (tests, auto-release, Modal deploy)
- Bug fixes for force-directed layout

Generated using `llamabot git write-release-notes` for v0.1.1, and manually curated from commit history for v0.1.0.