### PR TITLE
Add LLM Committee feature for multi-model consultation

### DIFF
--- a/src/canvas_chat/static/css/style.css
+++ b/src/canvas_chat/static/css/style.css
@@ -33,6 +33,12 @@
     --node-research-border: #b39ddb;
     --node-highlight: #fffde7;
     --node-highlight-border: #ffd54f;
+    --node-opinion: #e8eaf6;
+    --node-opinion-border: #7986cb;
+    --node-synthesis: #fce4ec;
+    --node-synthesis-border: #f06292;
+    --node-review: #fff8e1;
+    --node-review-border: #ffb74d;
     
     /* UI colors */
     --edge-color: #495057;
@@ -91,6 +97,12 @@
         --node-research-border: #7c3aed;
         --node-highlight: #3d3a20;
         --node-highlight-border: #fbc02d;
+        --node-opinion: #2d2d45;
+        --node-opinion-border: #5c6bc0;
+        --node-synthesis: #3d2d35;
+        --node-synthesis-border: #ec407a;
+        --node-review: #3d3520;
+        --node-review-border: #ffa726;
         
         --edge-color: #9ca3af;
         --edge-color-light: #4b5563;
@@ -469,6 +481,21 @@ html, body {
     background: var(--node-highlight);
     border-color: var(--node-highlight-border);
     border-style: dashed;
+}
+
+.node.opinion {
+    background: var(--node-opinion);
+    border-color: var(--node-opinion-border);
+}
+
+.node.synthesis {
+    background: var(--node-synthesis);
+    border-color: var(--node-synthesis-border);
+}
+
+.node.review {
+    background: var(--node-review);
+    border-color: var(--node-review-border);
 }
 
 /* Source text highlight - shown in parent node when a highlight excerpt is selected */
@@ -1938,6 +1965,178 @@ kbd {
     border-radius: var(--radius-sm);
     font-size: 12px;
     color: var(--warning);
+}
+
+/* Committee Modal */
+.committee-question-group {
+    margin-bottom: 20px;
+}
+
+.committee-question-group label {
+    display: block;
+    font-size: 13px;
+    font-weight: 500;
+    margin-bottom: 6px;
+    color: var(--text-primary);
+}
+
+.committee-question-group textarea {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid var(--bg-secondary);
+    border-radius: var(--radius-sm);
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    font-size: 13px;
+    font-family: var(--font-sans);
+    resize: none;
+}
+
+.committee-models-group {
+    margin-bottom: 20px;
+}
+
+.committee-models-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.committee-models-header label {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.committee-models-count {
+    font-size: 12px;
+    color: var(--text-muted);
+}
+
+.committee-models-count.valid {
+    color: var(--success);
+}
+
+.committee-models-count.invalid {
+    color: var(--danger);
+}
+
+.committee-models-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 8px;
+    max-height: 200px;
+    overflow-y: auto;
+    padding: 12px;
+    border: 1px solid var(--bg-secondary);
+    border-radius: var(--radius-md);
+    background: var(--bg-secondary);
+}
+
+.committee-model-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    border-radius: var(--radius-sm);
+    background: var(--bg-primary);
+    cursor: pointer;
+    transition: all 0.15s;
+    border: 1px solid transparent;
+}
+
+.committee-model-item:hover {
+    border-color: var(--accent);
+}
+
+.committee-model-item.selected {
+    border-color: var(--accent);
+    background: var(--selection-bg);
+}
+
+.committee-model-item input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    cursor: pointer;
+    accent-color: var(--accent);
+}
+
+.committee-model-item .model-name {
+    font-size: 12px;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.committee-chairman-group {
+    margin-bottom: 20px;
+}
+
+.committee-chairman-group label {
+    display: block;
+    font-size: 13px;
+    font-weight: 500;
+    margin-bottom: 6px;
+    color: var(--text-primary);
+}
+
+.committee-chairman-select {
+    width: 100%;
+    padding: 10px 12px;
+    border: 1px solid var(--bg-secondary);
+    border-radius: var(--radius-sm);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font-size: 13px;
+    cursor: pointer;
+}
+
+.committee-chairman-select:focus {
+    outline: none;
+    border-color: var(--accent);
+}
+
+.committee-options-group {
+    margin-bottom: 8px;
+}
+
+.committee-checkbox-label {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    padding: 12px;
+    border: 1px solid var(--bg-secondary);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: background 0.15s;
+}
+
+.committee-checkbox-label:hover {
+    background: var(--bg-secondary);
+}
+
+.committee-checkbox-label input[type="checkbox"] {
+    width: 18px;
+    height: 18px;
+    margin-top: 2px;
+    cursor: pointer;
+    accent-color: var(--accent);
+    flex-shrink: 0;
+}
+
+.committee-checkbox-label .checkbox-text {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
+.committee-checkbox-label .checkbox-hint {
+    display: block;
+    font-size: 12px;
+    color: var(--text-muted);
+    margin-top: 2px;
 }
 
 .modal-actions {

--- a/src/canvas_chat/static/index.html
+++ b/src/canvas_chat/static/index.html
@@ -423,6 +423,7 @@
                             <tr><td><code>/search</code> <em>query</em></td><td>Search the web with Exa AI</td></tr>
                             <tr><td><code>/research</code> <em>topic</em></td><td>Deep research with multiple sources</td></tr>
                             <tr><td><code>/matrix</code> <em>context</em></td><td>Create a comparison matrix</td></tr>
+                            <tr><td><code>/committee</code> <em>question</em></td><td>Consult multiple LLMs and synthesize</td></tr>
                         </tbody>
                     </table>
                 </section>
@@ -461,6 +462,52 @@
             <div class="modal-actions">
                 <button class="secondary-btn" id="edit-content-cancel">Cancel</button>
                 <button class="primary-btn" id="edit-content-save">Save</button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Committee Modal -->
+    <div id="committee-modal" class="modal" style="display: none;">
+        <div class="modal-content modal-wide">
+            <div class="modal-header">
+                <h2>LLM Committee</h2>
+                <button class="modal-close" id="committee-close">&times;</button>
+            </div>
+            <div class="modal-body">
+                <div class="committee-question-group">
+                    <label for="committee-question">Question</label>
+                    <textarea id="committee-question" rows="3" readonly placeholder="Your question will appear here..."></textarea>
+                </div>
+                
+                <div class="committee-models-group">
+                    <div class="committee-models-header">
+                        <label>Committee Members</label>
+                        <span class="committee-models-count" id="committee-models-count">0 selected (2-5 required)</span>
+                    </div>
+                    <div class="committee-models-grid" id="committee-models-grid">
+                        <!-- Model checkboxes will be populated by JS -->
+                    </div>
+                </div>
+                
+                <div class="committee-chairman-group">
+                    <label for="committee-chairman">Chairman (synthesizes opinions)</label>
+                    <select id="committee-chairman" class="committee-chairman-select">
+                        <!-- Options populated by JS -->
+                    </select>
+                </div>
+                
+                <div class="committee-options-group">
+                    <label class="committee-checkbox-label">
+                        <input type="checkbox" id="committee-include-review">
+                        <span class="checkbox-text">Include review stage</span>
+                        <span class="checkbox-hint">Each model reviews all other opinions before synthesis</span>
+                    </label>
+                </div>
+                
+                <div class="modal-actions">
+                    <button id="committee-cancel-btn" class="secondary-btn">Cancel</button>
+                    <button id="committee-execute-btn" class="primary-btn" disabled>Consult Committee</button>
+                </div>
             </div>
         </div>
     </div>

--- a/src/canvas_chat/static/js/app.js
+++ b/src/canvas_chat/static/js/app.js
@@ -78,6 +78,7 @@ const SLASH_COMMANDS = [
     { command: '/search', description: 'Search the web with Exa AI', placeholder: 'query' },
     { command: '/research', description: 'Deep research with multiple sources', placeholder: 'topic' },
     { command: '/matrix', description: 'Create a comparison matrix', placeholder: 'context for matrix' },
+    { command: '/committee', description: 'Consult multiple LLMs and synthesize', placeholder: 'question' },
 ];
 
 /**
@@ -744,6 +745,19 @@ class App {
             this.addAxisItem('edit-col-items');
         });
         
+        // Committee modal
+        document.getElementById('committee-close').addEventListener('click', () => {
+            document.getElementById('committee-modal').style.display = 'none';
+            this._committeeData = null;
+        });
+        document.getElementById('committee-cancel-btn').addEventListener('click', () => {
+            document.getElementById('committee-modal').style.display = 'none';
+            this._committeeData = null;
+        });
+        document.getElementById('committee-execute-btn').addEventListener('click', () => {
+            this.executeCommittee();
+        });
+        
         // Cell detail modal
         document.getElementById('cell-close').addEventListener('click', () => {
             document.getElementById('cell-modal').style.display = 'none';
@@ -929,6 +943,15 @@ class App {
             const matrixContext = content.slice(8).trim();
             if (matrixContext) {
                 await this.handleMatrix(matrixContext);
+                return true;
+            }
+        }
+        
+        // Check for /committee command
+        if (content.startsWith('/committee ')) {
+            const question = content.slice(11).trim();
+            if (question) {
+                await this.handleCommittee(question, context);
                 return true;
             }
         }
@@ -1373,6 +1396,449 @@ class App {
             this.graph.updateNode(researchNode.id, { content: errorContent });
             this.saveSession();
         }
+    }
+
+    /**
+     * Handle /committee slash command - show modal to configure LLM committee
+     */
+    async handleCommittee(question, context = null) {
+        // Store data for the modal
+        this._committeeData = {
+            question: question,
+            context: context,
+            selectedModels: [],
+            chairmanModel: this.modelPicker.value,
+            includeReview: false
+        };
+        
+        // Get the question textarea and populate it
+        const questionTextarea = document.getElementById('committee-question');
+        questionTextarea.value = question;
+        
+        // Populate model checkboxes
+        const modelsGrid = document.getElementById('committee-models-grid');
+        modelsGrid.innerHTML = '';
+        
+        // Get recently used models for pre-selection
+        const recentModels = storage.getRecentModels();
+        const currentModel = this.modelPicker.value;
+        
+        // Get all available models from the model picker
+        const availableModels = Array.from(this.modelPicker.options).map(opt => ({
+            id: opt.value,
+            name: opt.textContent
+        }));
+        
+        // Pre-select up to 3 models: current + 2 most recent (excluding current)
+        const preSelected = new Set();
+        preSelected.add(currentModel);
+        for (const modelId of recentModels) {
+            if (preSelected.size >= 3) break;
+            if (availableModels.some(m => m.id === modelId)) {
+                preSelected.add(modelId);
+            }
+        }
+        
+        // Create checkboxes for each model
+        for (const model of availableModels) {
+            const item = document.createElement('label');
+            item.className = 'committee-model-item';
+            if (preSelected.has(model.id)) {
+                item.classList.add('selected');
+            }
+            
+            const checkbox = document.createElement('input');
+            checkbox.type = 'checkbox';
+            checkbox.value = model.id;
+            checkbox.checked = preSelected.has(model.id);
+            checkbox.addEventListener('change', () => this.updateCommitteeSelection());
+            
+            const nameSpan = document.createElement('span');
+            nameSpan.className = 'model-name';
+            nameSpan.textContent = model.name;
+            
+            item.appendChild(checkbox);
+            item.appendChild(nameSpan);
+            modelsGrid.appendChild(item);
+            
+            // Click on label toggles checkbox
+            item.addEventListener('click', (e) => {
+                if (e.target !== checkbox) {
+                    checkbox.checked = !checkbox.checked;
+                    checkbox.dispatchEvent(new Event('change'));
+                }
+            });
+        }
+        
+        // Populate chairman dropdown
+        const chairmanSelect = document.getElementById('committee-chairman');
+        chairmanSelect.innerHTML = '';
+        for (const model of availableModels) {
+            const option = document.createElement('option');
+            option.value = model.id;
+            option.textContent = model.name;
+            chairmanSelect.appendChild(option);
+        }
+        chairmanSelect.value = currentModel;
+        
+        // Reset review checkbox
+        document.getElementById('committee-include-review').checked = false;
+        
+        // Update selection state
+        this.updateCommitteeSelection();
+        
+        // Show modal
+        document.getElementById('committee-modal').style.display = 'flex';
+    }
+    
+    /**
+     * Update committee selection UI and validation
+     */
+    updateCommitteeSelection() {
+        const checkboxes = document.querySelectorAll('#committee-models-grid input[type="checkbox"]');
+        const selectedModels = [];
+        
+        checkboxes.forEach(cb => {
+            const item = cb.closest('.committee-model-item');
+            if (cb.checked) {
+                selectedModels.push(cb.value);
+                item.classList.add('selected');
+            } else {
+                item.classList.remove('selected');
+            }
+        });
+        
+        // Update count display
+        const countEl = document.getElementById('committee-models-count');
+        const count = selectedModels.length;
+        const isValid = count >= 2 && count <= 5;
+        
+        countEl.textContent = `${count} selected (2-5 required)`;
+        countEl.classList.toggle('valid', isValid);
+        countEl.classList.toggle('invalid', !isValid);
+        
+        // Enable/disable execute button
+        document.getElementById('committee-execute-btn').disabled = !isValid;
+        
+        // Store selected models
+        if (this._committeeData) {
+            this._committeeData.selectedModels = selectedModels;
+        }
+    }
+    
+    /**
+     * Execute the committee consultation
+     */
+    async executeCommittee() {
+        if (!this._committeeData) return;
+        
+        const { question, context, selectedModels } = this._committeeData;
+        const chairmanModel = document.getElementById('committee-chairman').value;
+        const includeReview = document.getElementById('committee-include-review').checked;
+        
+        // Close modal
+        document.getElementById('committee-modal').style.display = 'none';
+        
+        // Track recently used models
+        for (const modelId of selectedModels) {
+            storage.addRecentModel(modelId);
+        }
+        storage.addRecentModel(chairmanModel);
+        
+        // Get selected nodes for conversation context
+        const selectedIds = this.canvas.getSelectedNodeIds();
+        
+        // Build conversation context from selected nodes
+        const messages = [];
+        if (selectedIds.length > 0) {
+            for (const id of selectedIds) {
+                const node = this.graph.getNode(id);
+                if (node && node.content) {
+                    const role = node.type === NodeType.HUMAN ? 'user' : 'assistant';
+                    messages.push({ role, content: node.content });
+                }
+            }
+        }
+        
+        // Add the question as the final user message
+        messages.push({ role: 'user', content: question });
+        
+        // Create human node for the question
+        const humanNode = createNode(NodeType.HUMAN, `/committee ${question}`, {
+            position: this.graph.autoPosition(selectedIds)
+        });
+        this.graph.addNode(humanNode);
+        this.canvas.renderNode(humanNode);
+        
+        // Create edges from selected nodes
+        for (const parentId of selectedIds) {
+            const edge = createEdge(parentId, humanNode.id, EdgeType.REPLY);
+            this.graph.addEdge(edge);
+            const parentNode = this.graph.getNode(parentId);
+            this.canvas.renderEdge(edge, parentNode.position, humanNode.position);
+        }
+        
+        // Calculate positions for opinion nodes (fan layout)
+        const basePos = humanNode.position;
+        const spacing = 380;
+        const verticalOffset = 200;
+        const totalWidth = (selectedModels.length - 1) * spacing;
+        const startX = basePos.x - totalWidth / 2;
+        
+        // Create opinion nodes for each model
+        const opinionNodes = [];
+        const opinionNodeMap = {}; // index -> nodeId
+        
+        for (let i = 0; i < selectedModels.length; i++) {
+            const modelId = selectedModels[i];
+            const modelName = this.getModelDisplayName(modelId);
+            
+            const opinionNode = createNode(NodeType.OPINION, `*Waiting for ${modelName}...*`, {
+                position: { 
+                    x: startX + i * spacing, 
+                    y: basePos.y + verticalOffset 
+                },
+                model: modelId
+            });
+            
+            this.graph.addNode(opinionNode);
+            this.canvas.renderNode(opinionNode);
+            
+            // Edge from human to opinion
+            const edge = createEdge(humanNode.id, opinionNode.id, EdgeType.OPINION);
+            this.graph.addEdge(edge);
+            this.canvas.renderEdge(edge, humanNode.position, opinionNode.position);
+            
+            opinionNodes.push(opinionNode);
+            opinionNodeMap[i] = opinionNode.id;
+        }
+        
+        // Create synthesis node (will be connected after opinions complete)
+        const synthesisY = basePos.y + verticalOffset * (includeReview ? 3 : 2);
+        const synthesisNode = createNode(NodeType.SYNTHESIS, '*Waiting for opinions...*', {
+            position: { x: basePos.x, y: synthesisY },
+            model: chairmanModel
+        });
+        this.graph.addNode(synthesisNode);
+        this.canvas.renderNode(synthesisNode);
+        
+        // Review nodes (if enabled) - will be created when review starts
+        const reviewNodes = [];
+        const reviewNodeMap = {}; // reviewer_index -> nodeId
+        
+        // Clear input and save
+        this.chatInput.value = '';
+        this.chatInput.style.height = 'auto';
+        this.canvas.clearSelection();
+        this.saveSession();
+        this.updateEmptyState();
+        
+        // Pan to see the committee
+        this.canvas.centerOnAnimated(basePos.x, basePos.y + verticalOffset, 300);
+        
+        // Collect API keys by provider for all models (uses canonical mapping from storage.js)
+        const apiKeys = storage.getApiKeysForModels([...selectedModels, chairmanModel]);
+        
+        // Get base URL if configured
+        const baseUrl = storage.getBaseUrl() || null;
+        
+        // Track accumulated content for each opinion/review
+        const opinionContents = {};
+        const reviewContents = {};
+        let synthesisContent = '';
+        
+        // Create abort controller for this committee session
+        const abortController = new AbortController();
+        
+        // Show stop buttons on all opinion nodes
+        for (const node of opinionNodes) {
+            this.canvas.showStopButton(node.id);
+        }
+        
+        // Store streaming state for potential abort
+        this._activeCommittee = {
+            abortController,
+            opinionNodeIds: opinionNodes.map(n => n.id),
+            reviewNodeIds: [],
+            synthesisNodeId: synthesisNode.id
+        };
+        
+        try {
+            const response = await fetch('/api/committee', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    question,
+                    context: messages,
+                    models: selectedModels,
+                    chairman_model: chairmanModel,
+                    api_keys: apiKeys,
+                    base_url: baseUrl,
+                    include_review: includeReview
+                }),
+                signal: abortController.signal
+            });
+            
+            if (!response.ok) {
+                throw new Error(`Committee request failed: ${response.statusText}`);
+            }
+            
+            // Process SSE stream
+            await SSE.readSSEStream(response, {
+                onEvent: (eventType, data) => {
+                    let parsed;
+                    try {
+                        parsed = JSON.parse(data);
+                    } catch {
+                        parsed = data;
+                    }
+                    
+                    if (eventType === 'opinion_start') {
+                        const nodeId = opinionNodeMap[parsed.index];
+                        const modelName = this.getModelDisplayName(parsed.model);
+                        opinionContents[parsed.index] = '';
+                        this.canvas.updateNodeContent(nodeId, `**${modelName}**\n\n*Thinking...*`, true);
+                        this.canvas.showStopButton(nodeId);
+                        
+                    } else if (eventType === 'opinion_chunk') {
+                        const nodeId = opinionNodeMap[parsed.index];
+                        opinionContents[parsed.index] = (opinionContents[parsed.index] || '') + parsed.content;
+                        const model = selectedModels[parsed.index];
+                        const modelName = this.getModelDisplayName(model);
+                        this.canvas.updateNodeContent(nodeId, `**${modelName}**\n\n${opinionContents[parsed.index]}`, true);
+                        
+                    } else if (eventType === 'opinion_done') {
+                        const nodeId = opinionNodeMap[parsed.index];
+                        const model = selectedModels[parsed.index];
+                        const modelName = this.getModelDisplayName(model);
+                        const finalContent = `**${modelName}**\n\n${parsed.full_content}`;
+                        this.canvas.updateNodeContent(nodeId, finalContent, false);
+                        this.canvas.hideStopButton(nodeId);
+                        this.graph.updateNode(nodeId, { content: finalContent });
+                        
+                    } else if (eventType === 'review_start') {
+                        // Create review node for this reviewer
+                        const reviewerIndex = parsed.reviewer_index;
+                        const modelName = this.getModelDisplayName(parsed.model);
+                        
+                        // Position review nodes between opinions and synthesis
+                        const reviewY = basePos.y + verticalOffset * 2;
+                        const reviewNode = createNode(NodeType.REVIEW, `**${modelName} Review**\n\n*Reviewing other opinions...*`, {
+                            position: { 
+                                x: startX + reviewerIndex * spacing, 
+                                y: reviewY 
+                            },
+                            model: parsed.model
+                        });
+                        
+                        this.graph.addNode(reviewNode);
+                        this.canvas.renderNode(reviewNode);
+                        reviewNodes.push(reviewNode);
+                        reviewNodeMap[reviewerIndex] = reviewNode.id;
+                        
+                        // Edge from opinion to its review
+                        const opinionNodeId = opinionNodeMap[reviewerIndex];
+                        const opinionNode = this.graph.getNode(opinionNodeId);
+                        const reviewEdge = createEdge(opinionNodeId, reviewNode.id, EdgeType.REVIEW);
+                        this.graph.addEdge(reviewEdge);
+                        this.canvas.renderEdge(reviewEdge, opinionNode.position, reviewNode.position);
+                        
+                        this.canvas.showStopButton(reviewNode.id);
+                        reviewContents[reviewerIndex] = '';
+                        
+                        if (this._activeCommittee) {
+                            this._activeCommittee.reviewNodeIds.push(reviewNode.id);
+                        }
+                        
+                    } else if (eventType === 'review_chunk') {
+                        const nodeId = reviewNodeMap[parsed.reviewer_index];
+                        if (nodeId) {
+                            reviewContents[parsed.reviewer_index] = (reviewContents[parsed.reviewer_index] || '') + parsed.content;
+                            const model = selectedModels[parsed.reviewer_index];
+                            const modelName = this.getModelDisplayName(model);
+                            this.canvas.updateNodeContent(nodeId, `**${modelName} Review**\n\n${reviewContents[parsed.reviewer_index]}`, true);
+                        }
+                        
+                    } else if (eventType === 'review_done') {
+                        const nodeId = reviewNodeMap[parsed.reviewer_index];
+                        if (nodeId) {
+                            const model = selectedModels[parsed.reviewer_index];
+                            const modelName = this.getModelDisplayName(model);
+                            const finalContent = `**${modelName} Review**\n\n${parsed.full_content}`;
+                            this.canvas.updateNodeContent(nodeId, finalContent, false);
+                            this.canvas.hideStopButton(nodeId);
+                            this.graph.updateNode(nodeId, { content: finalContent });
+                        }
+                        
+                    } else if (eventType === 'synthesis_start') {
+                        // Connect all opinion/review nodes to synthesis
+                        const sourceNodes = reviewNodes.length > 0 ? reviewNodes : opinionNodes;
+                        for (const node of sourceNodes) {
+                            const synthEdge = createEdge(node.id, synthesisNode.id, EdgeType.SYNTHESIS);
+                            this.graph.addEdge(synthEdge);
+                            this.canvas.renderEdge(synthEdge, node.position, synthesisNode.position);
+                        }
+                        
+                        const chairmanName = this.getModelDisplayName(parsed.model);
+                        synthesisContent = '';
+                        this.canvas.updateNodeContent(synthesisNode.id, `**Synthesis (${chairmanName})**\n\n*Synthesizing opinions...*`, true);
+                        this.canvas.showStopButton(synthesisNode.id);
+                        
+                    } else if (eventType === 'synthesis_chunk') {
+                        synthesisContent += parsed.content;
+                        const chairmanName = this.getModelDisplayName(chairmanModel);
+                        this.canvas.updateNodeContent(synthesisNode.id, `**Synthesis (${chairmanName})**\n\n${synthesisContent}`, true);
+                        
+                    } else if (eventType === 'synthesis_done') {
+                        const chairmanName = this.getModelDisplayName(chairmanModel);
+                        const finalContent = `**Synthesis (${chairmanName})**\n\n${parsed.full_content}`;
+                        this.canvas.updateNodeContent(synthesisNode.id, finalContent, false);
+                        this.canvas.hideStopButton(synthesisNode.id);
+                        this.graph.updateNode(synthesisNode.id, { content: finalContent });
+                        
+                    } else if (eventType === 'error') {
+                        console.error('Committee error:', parsed.message);
+                    }
+                },
+                onDone: () => {
+                    // Hide all stop buttons
+                    for (const nodeId of Object.values(opinionNodeMap)) {
+                        this.canvas.hideStopButton(nodeId);
+                    }
+                    for (const nodeId of Object.values(reviewNodeMap)) {
+                        this.canvas.hideStopButton(nodeId);
+                    }
+                    this.canvas.hideStopButton(synthesisNode.id);
+                    
+                    this._activeCommittee = null;
+                    this.saveSession();
+                },
+                onError: (err) => {
+                    console.error('Committee stream error:', err);
+                    this._activeCommittee = null;
+                }
+            });
+            
+        } catch (err) {
+            if (err.name === 'AbortError') {
+                console.log('Committee request aborted');
+            } else {
+                console.error('Committee error:', err);
+                // Update synthesis node with error
+                this.canvas.updateNodeContent(synthesisNode.id, `**Error**\n\n${err.message}`, false);
+                this.canvas.hideStopButton(synthesisNode.id);
+            }
+            this._activeCommittee = null;
+            this.saveSession();
+        }
+    }
+    
+    /**
+     * Get display name for a model ID
+     */
+    getModelDisplayName(modelId) {
+        const option = this.modelPicker.querySelector(`option[value="${modelId}"]`);
+        return option ? option.textContent : modelId.split('/').pop();
     }
 
     async handleMatrix(matrixContext) {

--- a/src/canvas_chat/static/js/canvas.js
+++ b/src/canvas_chat/static/js/canvas.js
@@ -1063,15 +1063,15 @@ class Canvas {
                     </div>
                     <span class="node-type">${node.type === NodeType.CELL && node.title ? node.title : this.getNodeTypeLabel(node.type)}</span>
                     <span class="node-model">${node.model || ''}</span>
-                    ${node.type === NodeType.AI ? '<button class="header-btn stop-btn" title="Stop generating" style="display:none;">⏹</button>' : ''}
-                    ${node.type === NodeType.AI ? '<button class="header-btn continue-btn" title="Continue generating" style="display:none;">▶</button>' : ''}
+                    ${[NodeType.AI, NodeType.OPINION, NodeType.SYNTHESIS, NodeType.REVIEW].includes(node.type) ? '<button class="header-btn stop-btn" title="Stop generating" style="display:none;">⏹</button>' : ''}
+                    ${[NodeType.AI, NodeType.OPINION, NodeType.SYNTHESIS, NodeType.REVIEW].includes(node.type) ? '<button class="header-btn continue-btn" title="Continue generating" style="display:none;">▶</button>' : ''}
                     <button class="header-btn fit-viewport-btn" title="Fit to viewport (f)">⤢</button>
                     <button class="node-action delete-btn" title="Delete node">🗑️</button>
                 </div>
                 <div class="node-content">${this.renderMarkdown(node.content)}</div>
                 <div class="node-actions">
                     <button class="node-action reply-btn" title="Reply">↩️ Reply</button>
-                    ${node.type === NodeType.AI ? '<button class="node-action summarize-btn" title="Summarize">📝 Summarize</button>' : ''}
+                    ${[NodeType.AI, NodeType.OPINION, NodeType.SYNTHESIS, NodeType.REVIEW].includes(node.type) ? '<button class="node-action summarize-btn" title="Summarize">📝 Summarize</button>' : ''}
                     ${node.type === NodeType.REFERENCE ? '<button class="node-action fetch-summarize-btn" title="Fetch full content and summarize">📄 Fetch & Summarize</button>' : ''}
                     ${node.type === NodeType.FETCH_RESULT ? '<button class="node-action edit-content-btn" title="Edit fetched content">✏️ Edit</button>' : ''}
                     ${node.type === NodeType.FETCH_RESULT ? '<button class="node-action resummarize-btn" title="Create new summary from edited content">📝 Re-summarize</button>' : ''}
@@ -2143,7 +2143,10 @@ class Canvas {
             [NodeType.CELL]: 'Cell',
             [NodeType.ROW]: 'Row',
             [NodeType.COLUMN]: 'Column',
-            [NodeType.FETCH_RESULT]: 'Fetched Content'
+            [NodeType.FETCH_RESULT]: 'Fetched Content',
+            [NodeType.OPINION]: 'Opinion',
+            [NodeType.SYNTHESIS]: 'Synthesis',
+            [NodeType.REVIEW]: 'Review'
         };
         return labels[type] || type;
     }
@@ -2162,7 +2165,10 @@ class Canvas {
             [NodeType.CELL]: '📦',
             [NodeType.ROW]: '↔️',
             [NodeType.COLUMN]: '↕️',
-            [NodeType.FETCH_RESULT]: '📄'
+            [NodeType.FETCH_RESULT]: '📄',
+            [NodeType.OPINION]: '🗣️',
+            [NodeType.SYNTHESIS]: '⚖️',
+            [NodeType.REVIEW]: '🔍'
         };
         return icons[type] || '📄';
     }

--- a/src/canvas_chat/static/js/graph.js
+++ b/src/canvas_chat/static/js/graph.js
@@ -18,7 +18,10 @@ const NodeType = {
     CELL: 'cell',          // Pinned cell from a matrix
     ROW: 'row',            // Extracted row from a matrix
     COLUMN: 'column',      // Extracted column from a matrix
-    FETCH_RESULT: 'fetch_result' // Fetched content from URL (via Exa)
+    FETCH_RESULT: 'fetch_result', // Fetched content from URL (via Exa)
+    OPINION: 'opinion',    // Committee member's opinion
+    SYNTHESIS: 'synthesis', // Chairman's synthesized answer
+    REVIEW: 'review'       // Committee member's review of other opinions
 };
 
 /**
@@ -29,7 +32,10 @@ const SCROLLABLE_NODE_TYPES = [
     NodeType.AI,
     NodeType.SUMMARY,
     NodeType.RESEARCH,
-    NodeType.FETCH_RESULT
+    NodeType.FETCH_RESULT,
+    NodeType.OPINION,
+    NodeType.SYNTHESIS,
+    NodeType.REVIEW
 ];
 
 /**
@@ -51,7 +57,10 @@ const EdgeType = {
     REFERENCE: 'reference',   // Reference link
     SEARCH_RESULT: 'search_result', // Link from search to results
     HIGHLIGHT: 'highlight',   // Link from source to highlighted excerpt
-    MATRIX_CELL: 'matrix_cell' // Link from pinned cell to matrix
+    MATRIX_CELL: 'matrix_cell', // Link from pinned cell to matrix
+    OPINION: 'opinion',       // Human → OPINION nodes (committee)
+    SYNTHESIS: 'synthesis',   // OPINION/REVIEW → SYNTHESIS node (committee)
+    REVIEW: 'review'          // OPINION → REVIEW nodes (committee)
 };
 
 /**


### PR DESCRIPTION
## Summary

- Adds `/committee <question>` slash command that queries 2-5 LLMs in parallel
- Optional peer review stage where each model critiques others' opinions  
- Chairman model synthesizes all opinions/reviews into a final answer

## Features

### Backend (`app.py`)
- New `/api/committee` SSE endpoint with parallel streaming
- Three phases: opinion gathering → optional review → synthesis
- Uses asyncio queues for concurrent LLM streaming

### Frontend
- Committee modal for selecting models and chairman
- New node types: OPINION (🗣️), SYNTHESIS (⚖️), REVIEW (🔍)
- Fan layout positioning for visual clarity
- Per-node stop buttons for parallel generation control

### Refactoring
- Consolidated provider-to-storage-key mapping in `storage.js`
- New `getApiKeysForModels()` helper reduces duplication in `executeCommittee()`

## Testing
- **Python:** 18 tests (8 new for CommitteeRequest)
- **JavaScript:** 70 tests (12 new for provider mapping)

## Usage
1. Select context nodes (optional)
2. Type `/committee What are the pros and cons of X?`
3. Select 2-5 models in the modal
4. Choose chairman model for synthesis
5. Toggle "Include review stage" for peer critique
6. Click Execute