### PR TITLE
Add /note command for standalone markdown nodes

### DIFF
--- a/src/canvas_chat/static/js/canvas.js
+++ b/src/canvas_chat/static/js/canvas.js
@@ -1073,7 +1073,7 @@ class Canvas {
                     <button class="node-action reply-btn" title="Reply">↩️ Reply</button>
                     ${[NodeType.AI, NodeType.OPINION, NodeType.SYNTHESIS, NodeType.REVIEW].includes(node.type) ? '<button class="node-action summarize-btn" title="Summarize">📝 Summarize</button>' : ''}
                     ${node.type === NodeType.REFERENCE ? '<button class="node-action fetch-summarize-btn" title="Fetch full content and summarize">📄 Fetch & Summarize</button>' : ''}
-                    ${node.type === NodeType.FETCH_RESULT ? '<button class="node-action edit-content-btn" title="Edit fetched content">✏️ Edit</button>' : ''}
+                    ${[NodeType.FETCH_RESULT, NodeType.NOTE].includes(node.type) ? '<button class="node-action edit-content-btn" title="Edit content">✏️ Edit</button>' : ''}
                     ${node.type === NodeType.FETCH_RESULT ? '<button class="node-action resummarize-btn" title="Create new summary from edited content">📝 Re-summarize</button>' : ''}
                     <button class="node-action copy-btn" title="Copy content">📋 Copy</button>
                 </div>

--- a/src/canvas_chat/static/js/graph.js
+++ b/src/canvas_chat/static/js/graph.js
@@ -35,7 +35,8 @@ const SCROLLABLE_NODE_TYPES = [
     NodeType.FETCH_RESULT,
     NodeType.OPINION,
     NodeType.SYNTHESIS,
-    NodeType.REVIEW
+    NodeType.REVIEW,
+    NodeType.NOTE
 ];
 
 /**


### PR DESCRIPTION
## Summary

- Adds `/note` slash command to create standalone NOTE nodes without triggering an LLM response
- Enables pasting content (papers, abstracts, notes) as source material for later exploration
- Users can select a note and branch from it to ask questions with the note as context

## Changes

- **New slash command**: `/note <markdown content>` creates a yellow NOTE node
- **Standalone positioning**: Notes don't auto-attach to existing nodes (unlike regular messages)
- **4:3 aspect ratio**: Notes use 640x480 default size with scrollable content
- **Editable**: Notes have an Edit button to modify content after creation

## Usage

1. Type `/note Your paper abstract or notes here...`
2. Press Enter → standalone NOTE node appears
3. Select the note → type a question → AI responds with the note as context