### PR TITLE
Improve layout UX: keep viewport, add hint, enable zoomed-out dragging

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,54 @@
 
 Instructions for AI coding agents working on this project.
 
+## Codebase map
+
+Quick reference for which files to edit for common tasks:
+
+### Frontend (Vanilla JS)
+
+| File | Purpose | Edit for... |
+|------|---------|-------------|
+| `src/canvas_chat/static/js/app.js` | Main application, orchestrates everything | Slash commands, keyboard shortcuts, feature handlers, App class methods |
+| `src/canvas_chat/static/js/canvas.js` | SVG canvas, pan/zoom, node rendering | Node appearance, drag behavior, viewport logic, node event handlers |
+| `src/canvas_chat/static/js/graph.js` | Data model, node/edge types, layout algorithms | Node types, edge types, graph traversal, auto-positioning |
+| `src/canvas_chat/static/js/chat.js` | LLM API calls, streaming | API integration, message formatting, token estimation |
+| `src/canvas_chat/static/js/storage.js` | localStorage persistence | Session storage, API key storage, settings |
+| `src/canvas_chat/static/js/search.js` | Node search functionality | Search UI, filtering logic |
+| `src/canvas_chat/static/js/sse.js` | Server-sent events utilities | Streaming connection handling |
+
+### Frontend (HTML/CSS)
+
+| File | Purpose | Edit for... |
+|------|---------|-------------|
+| `src/canvas_chat/static/index.html` | Main HTML, modals, templates | New modals, toolbar buttons, HTML structure |
+| `src/canvas_chat/static/css/style.css` | All styles | Colors, layout, node styling, animations |
+
+### Backend (Python/FastAPI)
+
+| File | Purpose | Edit for... |
+|------|---------|-------------|
+| `src/canvas_chat/app.py` | FastAPI routes, LLM proxy | API endpoints, backend logic |
+| `modal_app.py` | Modal deployment config | Deployment settings |
+
+### Key constants and their locations
+
+| Constant | Location | Purpose |
+|----------|----------|---------|
+| `NodeType` | `graph.js:8-25` | All node type definitions |
+| `EdgeType` | `graph.js:53-64` | All edge type definitions |
+| `SCROLLABLE_NODE_TYPES` | `graph.js:31-40` | Node types with 4:3 fixed size |
+| `SLASH_COMMANDS` | `app.js:77-83` | Slash command definitions |
+| CSS variables | `style.css:10-80` | Colors, sizing, theming |
+
+### Zoom levels (semantic zoom)
+
+| Scale | Class | Behavior |
+|-------|-------|----------|
+| > 0.6 | `zoom-full` | Full node content visible |
+| 0.35 - 0.6 | `zoom-summary` | Summary text shown, drag anywhere |
+| <= 0.35 | `zoom-mini` | Minimal view, drag anywhere |
+
 ## Documentation
 
 All documentation must follow the [Diataxis framework](https://diataxis.fr/):

--- a/src/canvas_chat/static/css/style.css
+++ b/src/canvas_chat/static/css/style.css
@@ -358,6 +358,43 @@ html, body {
     background-position: center center;
 }
 
+/* Hint overlay when no nodes visible */
+.no-nodes-hint {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity 0.5s ease-in;
+}
+
+.no-nodes-hint.visible {
+    opacity: 1;
+}
+
+.no-nodes-hint .hint-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 24px 32px;
+    background: var(--bg-primary);
+    border: 1px solid var(--bg-secondary);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+}
+
+.no-nodes-hint .hint-icon {
+    font-size: 32px;
+}
+
+.no-nodes-hint .hint-text {
+    color: var(--text-secondary);
+    font-size: 14px;
+    text-align: center;
+}
+
 /* Edges */
 .edge {
     fill: none;

--- a/src/canvas_chat/static/index.html
+++ b/src/canvas_chat/static/index.html
@@ -69,6 +69,14 @@
             <g id="nodes-layer"></g>
         </svg>
         
+        <!-- Hint overlay when no nodes visible -->
+        <div id="no-nodes-hint" class="no-nodes-hint" style="display: none;">
+            <div class="hint-content">
+                <span class="hint-icon">👆</span>
+                <span class="hint-text">Double-click to zoom out and see all nodes</span>
+            </div>
+        </div>
+        
         <!-- Node template (cloned when creating nodes) -->
         <template id="node-template">
             <foreignObject class="node-wrapper" width="320" height="auto">

--- a/src/canvas_chat/static/js/app.js
+++ b/src/canvas_chat/static/js/app.js
@@ -2577,14 +2577,10 @@ class App {
             this.graph.autoLayout(dimensions);
         }
         
-        // Check if any node is selected - if so, keep focus on it
-        const selectedNodeIds = this.canvas.getSelectedNodeIds();
-        const focusNodeId = selectedNodeIds.length === 1 ? selectedNodeIds[0] : null;
-        
-        // Animate nodes to their new positions
+        // Animate nodes to their new positions (keep current viewport)
         this.canvas.animateToLayout(this.graph, {
             duration: 500,
-            focusNodeId
+            keepViewport: true
         });
         
         // Save the new positions


### PR DESCRIPTION
## Summary

- **Apply Layout keeps current viewport** - no more jarring zoom-out after clicking the button
- **Hint overlay when nodes not visible** - progressive fade-in tooltip suggesting double-click to zoom out
- **Drag nodes from anywhere when zoomed out** - easier node manipulation in summary/mini zoom levels

## Changes

### Apply Layout behavior
- Added `keepViewport` option to `animateToLayout()` in canvas.js
- `handleAutoLayout()` now uses `keepViewport: true` to preserve the current view

### No-nodes-visible hint
- New HTML overlay element in index.html
- CSS styles with 0.5s fade-in animation
- `hasVisibleNodes()` checks if any node rectangles intersect the viewport
- `updateNoNodesHint()` shows hint after 300ms delay when nodes exist but none are visible

### Zoomed-out dragging
- Added mousedown handler on node div that initiates dragging when `scale <= 0.6`
- Buttons and resize handles are excluded from this behavior
- Works for all node types including matrix nodes

### Documentation
- Added codebase map to AGENTS.md with file purposes and key constants locations