### PR TITLE
Add URL fetching support to /note command

### DIFF
--- a/docs/explanation/url-fetching.md
+++ b/docs/explanation/url-fetching.md
@@ -1,0 +1,73 @@
+# URL fetching architecture
+
+Canvas Chat provides two ways to fetch web content into the canvas, each designed for different use cases and user configurations.
+
+## The two URL fetching paths
+
+### 1. `/note <url>` — zero-config fetching
+
+When a user types `/note https://example.com/article`, the content is fetched via `/api/fetch-url`. This endpoint uses a fallback strategy:
+
+1. **Try Jina Reader API first** (`r.jina.ai`) — free, good markdown conversion
+2. **Fall back to direct fetch + html2text** — if Jina fails (rate limits, blocked domains)
+
+This path:
+
+- Requires no API key or configuration
+- Works immediately for any user
+- Returns content as clean markdown
+- Creates a standalone `FETCH_RESULT` node
+
+The design philosophy here is **progressive disclosure**: new users can start fetching web content into their canvas without any setup friction. They discover the feature, try it, and it just works.
+
+### 2. Fetch + Summarize button — premium extraction
+
+When a user clicks the "Fetch & Summarize" button on a `REFERENCE` node (from search results), the content is fetched using **Exa API** (`/api/exa/get-contents`). This path:
+
+- Requires an Exa API key configured in Settings
+- Provides higher quality content extraction
+- Creates two linked nodes: `FETCH_RESULT` → `SUMMARY`
+- Automatically generates an LLM summary of the content
+
+Users who have invested in configuring their Exa API key get a more powerful workflow with automatic summarization.
+
+## Why two separate implementations?
+
+The intentional duplication serves the user experience:
+
+1. **Zero friction for beginners**: A user discovering `/note` shouldn't need to configure API keys before they can try it. The zero-config path uses free services that require no authentication.
+
+2. **Robustness through fallback**: Jina Reader occasionally blocks domains or rate-limits requests. The direct fetch fallback ensures `/note <url>` works reliably even when Jina is unavailable.
+
+3. **Premium quality for power users**: Users who configure Exa get better content extraction. Exa specializes in web content retrieval and handles edge cases (paywalls, dynamic content, etc.) better than generic solutions.
+
+4. **Consistent output format**: Both paths create `FETCH_RESULT` nodes with the same structure (`**[Title](url)**\n\n<content>`), so downstream features (editing, re-summarizing) work identically regardless of how the content was fetched.
+
+## Trade-offs
+
+| Aspect | `/note <url>` | Exa API (Fetch + Summarize) |
+|--------|---------------|----------------------------|
+| Setup required | None | Exa API key |
+| Cost | Free | Paid (per request) |
+| Fetch strategy | Jina Reader → direct fetch | Exa API only |
+| Content quality | Good for most public pages | Better for complex pages |
+| Output | Raw markdown only | Markdown + AI summary |
+| Use case | Quick capture | Deep reading workflow |
+
+## Dependencies
+
+The zero-config path uses:
+
+- **Jina Reader API** (`r.jina.ai`) — free service, no authentication required
+- **html2text** — Python library for HTML-to-markdown conversion (fallback)
+- **httpx** — async HTTP client (already a dependency)
+
+## Future considerations
+
+The current architecture could be extended:
+
+- Offering a "summarize" action on any `FETCH_RESULT` node (not just Exa-fetched ones)
+- Adding user preference for preferred fetch method
+- Caching fetched content to avoid redundant requests
+
+However, keeping the paths separate maintains clarity about what each feature does and avoids surprising users with different behavior based on their configuration state.

--- a/pixi.lock
+++ b/pixi.lock
@@ -79,6 +79,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl
@@ -259,6 +260,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/2d/22338486473df5923a9ab7107d375dbef9173c338ebef5098ef593d2b560/hf_xet-1.2.0-cp37-abi3-macosx_10_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl
@@ -435,6 +437,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/69/b2/119f6e6dcbd96f9069ce9a2665e0146588dc9f88f29549711853645e736a/h2-4.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7f/8c/c5becfa53234299bc2210ba314eaaae36c2875e0045809b82e40a9544f0c/hf_xet-1.2.0-cp37-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/07/c6/80c95b1b2b94682a72cbdbfb85b81ae2daffa4291fbfa1b1464502ede10d/hpack-4.1.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl
@@ -874,7 +877,7 @@ packages:
 - pypi: ./
   name: canvas-chat
   version: 0.1.4
-  sha256: 8f5b200a59d83eee4e261073e76d0b61b4d38aaa5a3db193bdfd123e9369331c
+  sha256: 718f00b2be505f76d6bd9be077ab85e55b2b6d0a3c741d619b4a28f5953403cb
   requires_dist:
   - fastapi>=0.115.0
   - uvicorn>=0.32.0
@@ -887,6 +890,7 @@ packages:
   - httpx>=0.28.1,<0.29
   - pytest>=9.0.2,<10
   - build>=1.3.0,<2
+  - html2text>=2025.4.15,<2026
   - pytest>=8.0.0 ; extra == 'dev'
   - httpx>=0.27.0 ; extra == 'dev'
   requires_python: '>=3.11'
@@ -1770,6 +1774,11 @@ packages:
   name: hpack
   version: 4.1.0
   sha256: 157ac792668d995c657d93111f46b4535ed114f0c9c8d672271bbec7eae1b496
+  requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/1d/84/1a0f9555fd5f2b1c924ff932d99b40a0f8a6b12f6dd625e2a47f415b00ea/html2text-2025.4.15-py3-none-any.whl
+  name: html2text
+  version: 2025.4.15
+  sha256: 00569167ffdab3d7767a4cdf589b7f57e777a5ed28d12907d8c58769ec734acc
   requires_python: '>=3.9'
 - pypi: https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl
   name: httpcore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "litellm>=1.50.0",
     "llamabot>=0.17.0",
     "pydantic>=2.0.0",
-    "sse-starlette>=2.0.0", "exa-py>=2.0.2,<3", "modal>=1.3.0.post1,<2", "httpx>=0.28.1,<0.29", "pytest>=9.0.2,<10", "build>=1.3.0,<2",
+    "sse-starlette>=2.0.0", "exa-py>=2.0.2,<3", "modal>=1.3.0.post1,<2", "httpx>=0.28.1,<0.29", "pytest>=9.0.2,<10", "build>=1.3.0,<2", "html2text>=2025.4.15,<2026",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,8 @@ from canvas_chat.app import (
     CommitteeRequest,
     ExaContentsResult,
     ExaGetContentsRequest,
+    FetchUrlRequest,
+    FetchUrlResult,
     Message,
     RefineQueryRequest,
 )
@@ -218,3 +220,42 @@ def test_committee_request_missing_api_keys():
             models=["openai/gpt-4o", "anthropic/claude-sonnet-4-20250514"],
             chairman_model="openai/gpt-4o",
         )
+
+
+# --- FetchUrlRequest and FetchUrlResult tests ---
+
+
+def test_fetch_url_request_valid():
+    """Test that FetchUrlRequest validates correct input."""
+    request = FetchUrlRequest(url="https://example.com/article")
+    assert request.url == "https://example.com/article"
+
+
+def test_fetch_url_request_missing_url():
+    """Test that FetchUrlRequest requires url."""
+    with pytest.raises(ValidationError):
+        FetchUrlRequest()
+
+
+def test_fetch_url_result_valid():
+    """Test that FetchUrlResult validates correct input."""
+    result = FetchUrlResult(
+        url="https://example.com/article",
+        title="Test Article",
+        content="# Test Article\n\nThis is the content.",
+    )
+    assert result.url == "https://example.com/article"
+    assert result.title == "Test Article"
+    assert result.content == "# Test Article\n\nThis is the content."
+
+
+def test_fetch_url_result_missing_required():
+    """Test that FetchUrlResult requires url, title, and content."""
+    with pytest.raises(ValidationError):
+        FetchUrlResult(url="https://example.com", title="Test")
+
+    with pytest.raises(ValidationError):
+        FetchUrlResult(url="https://example.com", content="content")
+
+    with pytest.raises(ValidationError):
+        FetchUrlResult(title="Test", content="content")

--- a/tests/test_utils.js
+++ b/tests/test_utils.js
@@ -1401,6 +1401,75 @@ test('getApiKeysForModels: empty array returns empty object', () => {
 });
 
 // ============================================================
+// URL detection tests (for /note command)
+// ============================================================
+
+/**
+ * Detect if content is a URL (used by handleNote to route to handleNoteFromUrl)
+ * This is a copy of the logic from app.js for testing
+ */
+function isUrl(content) {
+    const urlPattern = /^https?:\/\/[^\s]+$/;
+    return urlPattern.test(content.trim());
+}
+
+test('isUrl: detects http URL', () => {
+    assertTrue(isUrl('http://example.com'));
+});
+
+test('isUrl: detects https URL', () => {
+    assertTrue(isUrl('https://example.com'));
+});
+
+test('isUrl: detects URL with path', () => {
+    assertTrue(isUrl('https://example.com/path/to/page'));
+});
+
+test('isUrl: detects URL with query params', () => {
+    assertTrue(isUrl('https://example.com/page?id=123&ref=abc'));
+});
+
+test('isUrl: detects URL with fragment', () => {
+    assertTrue(isUrl('https://example.com/page#section'));
+});
+
+test('isUrl: detects complex URL', () => {
+    assertTrue(isUrl('https://pmc.ncbi.nlm.nih.gov/articles/PMC12514551/'));
+});
+
+test('isUrl: trims whitespace', () => {
+    assertTrue(isUrl('  https://example.com  '));
+});
+
+test('isUrl: rejects plain text', () => {
+    assertFalse(isUrl('This is just some text'));
+});
+
+test('isUrl: rejects markdown', () => {
+    assertFalse(isUrl('# Heading\n\nSome content'));
+});
+
+test('isUrl: rejects URL embedded in text', () => {
+    assertFalse(isUrl('Check out https://example.com for more'));
+});
+
+test('isUrl: rejects URL without protocol', () => {
+    assertFalse(isUrl('example.com'));
+});
+
+test('isUrl: rejects ftp URLs', () => {
+    assertFalse(isUrl('ftp://files.example.com'));
+});
+
+test('isUrl: rejects empty string', () => {
+    assertFalse(isUrl(''));
+});
+
+test('isUrl: rejects whitespace only', () => {
+    assertFalse(isUrl('   '));
+});
+
+// ============================================================
 // Summary
 // ============================================================
 


### PR DESCRIPTION
## Summary
- Add `/note <url>` support to fetch web content as markdown into a note node
- Uses Jina Reader API with html2text fallback for robustness
- Zero-config: works without any API keys

## Changes
- **Backend**: New `/api/fetch-url` endpoint with fallback strategy (Jina Reader → direct fetch + html2text)
- **Frontend**: `handleNote()` detects URLs and routes to new `handleNoteFromUrl()` method
- **Docs**: Added `docs/explanation/url-fetching.md` explaining the architecture
- **Tests**: Added tests for new Pydantic models and URL detection logic

## Design rationale
See `docs/explanation/url-fetching.md` for full explanation. Key points:
- `/note <url>` should "just work" without API configuration
- Jina Reader provides good markdown conversion for most sites
- html2text fallback handles cases where Jina is blocked/rate-limited
- Separate from Exa-based fetch+summarize which requires API key but offers higher quality