### PR TITLE
Add PDF upload feature and fix pinch-to-zoom on nodes

### DIFF
--- a/docs/how-to/import-pdfs.md
+++ b/docs/how-to/import-pdfs.md
@@ -1,0 +1,67 @@
+# How to import PDFs
+
+Canvas Chat can extract text from PDF files and create notes from them. This is useful for bringing research papers, reports, and documents into your canvas for discussion and analysis.
+
+## Import methods
+
+There are three ways to import a PDF:
+
+### From a URL
+
+Use the `/note` command with a PDF URL:
+
+```
+/note https://arxiv.org/pdf/2301.12345.pdf
+```
+
+The application detects `.pdf` URLs automatically and routes them through the PDF extraction pipeline instead of the standard URL fetcher.
+
+### From the paperclip button
+
+1. Click the paperclip button next to the chat input
+2. Select a PDF file from your computer
+3. The file uploads and text extraction begins
+
+### Drag and drop
+
+1. Drag a PDF file from your file manager
+2. Drop it anywhere on the canvas
+3. A note node appears at the drop location with the extracted content
+
+## What happens during import
+
+When you import a PDF:
+
+1. The file is uploaded to the server (maximum 25 MB)
+2. Text is extracted from all pages using PyMuPDF
+3. A warning banner is prepended to the content
+4. A PDF note node (teal colored) appears on the canvas
+
+## The warning banner
+
+All PDF imports include a warning banner at the top:
+
+> **PDF Import** — Text was extracted automatically and may contain errors. Consider sourcing the original if precision is critical. Edit this note to correct any issues.
+
+This reminds you that:
+
+- OCR and text extraction can introduce errors
+- Complex layouts (tables, multi-column) may not extract cleanly
+- Mathematical formulas often don't survive extraction
+- You should verify critical information against the original
+
+## Working with imported PDFs
+
+Once imported, PDF notes work like any other note:
+
+- Select them as context for questions
+- Include them in matrix evaluations
+- Ask the AI to summarize or analyze them
+- Edit the content to fix extraction errors
+
+## Limits
+
+- Maximum file size: 25 MB
+- Only PDF files are supported for direct import (use `/note` with a URL for web pages)
+- Scanned PDFs with no embedded text may extract as empty or garbled content
+- Password-protected PDFs cannot be processed

--- a/pixi.lock
+++ b/pixi.lock
@@ -141,6 +141,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2c/94/93b7f5981aa04f922e0d9ce7326a4587866ec7e39f7c180ffcf408e66ee8/pydocket-0.16.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/2a/6b/3de1714d734ff949be1e90a22375d0598d3540b22ae73eb85c2d7d1f36a9/pymupdf-1.26.7-cp310-abi3-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/9b/eef01392be945c0fe86a8d084ba9188b1e2b22af037d7109b9f40a962cd0/pyprojroot-0.3.0-py3-none-any.whl
@@ -321,6 +322,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2c/94/93b7f5981aa04f922e0d9ce7326a4587866ec7e39f7c180ffcf408e66ee8/pydocket-0.16.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/94/35/cd74cea1787b2247702ef8522186bdef32e9cb30a099e6bb864627ef6045/pymupdf-1.26.7-cp310-abi3-macosx_10_9_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/9b/eef01392be945c0fe86a8d084ba9188b1e2b22af037d7109b9f40a962cd0/pyprojroot-0.3.0-py3-none-any.whl
@@ -498,6 +500,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/2c/94/93b7f5981aa04f922e0d9ce7326a4587866ec7e39f7c180ffcf408e66ee8/pydocket-0.16.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/72/74/448b6172927c829c6a3fba80078d7b0a016ebbe2c9ee528821f5ea21677a/pymupdf-1.26.7-cp310-abi3-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/53/9b/eef01392be945c0fe86a8d084ba9188b1e2b22af037d7109b9f40a962cd0/pyprojroot-0.3.0-py3-none-any.whl
@@ -877,7 +880,7 @@ packages:
 - pypi: ./
   name: canvas-chat
   version: 0.1.7
-  sha256: 5ed61ee57140433a3befe5285f0bf38d7791596dbcb65bae3e9298f9aa386cac
+  sha256: 9fdb7110bc24446cc65f5ebba026b11c8da876df1e847f7b839f921714641d20
   requires_dist:
   - fastapi>=0.115.0
   - uvicorn>=0.32.0
@@ -891,9 +894,12 @@ packages:
   - pytest>=9.0.2,<10
   - build>=1.3.0,<2
   - html2text>=2025.4.15,<2026
+  - pymupdf>=1.24.0
+  - python-multipart>=0.0.9
   - pytest>=8.0.0 ; extra == 'dev'
   - httpx>=0.27.0 ; extra == 'dev'
   requires_python: '>=3.11'
+  editable: true
 - pypi: https://files.pythonhosted.org/packages/4b/0c/0654233d7543ac8a50f4785f172430ddc97538ba418eb305d6e529d1a120/cbor2-5.8.0-cp314-cp314-macosx_11_0_arm64.whl
   name: cbor2
   version: 5.8.0
@@ -3229,6 +3235,21 @@ packages:
   - coverage[toml]==5.0.4 ; extra == 'tests'
   - pytest>=6.0.0,<7.0.0 ; extra == 'tests'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/2a/6b/3de1714d734ff949be1e90a22375d0598d3540b22ae73eb85c2d7d1f36a9/pymupdf-1.26.7-cp310-abi3-manylinux_2_28_x86_64.whl
+  name: pymupdf
+  version: 1.26.7
+  sha256: 69dfc78f206a96e5b3ac22741263ebab945fdf51f0dbe7c5757c3511b23d9d72
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/72/74/448b6172927c829c6a3fba80078d7b0a016ebbe2c9ee528821f5ea21677a/pymupdf-1.26.7-cp310-abi3-macosx_11_0_arm64.whl
+  name: pymupdf
+  version: 1.26.7
+  sha256: 31aa9c8377ea1eea02934b92f4dcf79fb2abba0bf41f8a46d64c3e31546a3c02
+  requires_python: '>=3.10'
+- pypi: https://files.pythonhosted.org/packages/94/35/cd74cea1787b2247702ef8522186bdef32e9cb30a099e6bb864627ef6045/pymupdf-1.26.7-cp310-abi3-macosx_10_9_x86_64.whl
+  name: pymupdf
+  version: 1.26.7
+  sha256: 07085718dfdae5ab83b05eb5eb397f863bcc538fe05135318a01ea353e7a1353
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/df/80/fc9d01d5ed37ba4c42ca2b55b4339ae6e200b456be3a1aaddf4a9fa99b8c/pyperclip-1.11.0-py3-none-any.whl
   name: pyperclip
   version: 1.11.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,8 @@ dependencies = [
     "llamabot>=0.17.0",
     "pydantic>=2.0.0",
     "sse-starlette>=2.0.0", "exa-py>=2.0.2,<3", "modal>=1.3.0.post1,<2", "httpx>=0.28.1,<0.29", "pytest>=9.0.2,<10", "build>=1.3.0,<2", "html2text>=2025.4.15,<2026",
+    "pymupdf>=1.24.0",
+    "python-multipart>=0.0.9",
 ]
 
 [project.optional-dependencies]

--- a/src/canvas_chat/static/css/style.css
+++ b/src/canvas_chat/static/css/style.css
@@ -39,6 +39,8 @@
     --node-synthesis-border: #f06292;
     --node-review: #fff8e1;
     --node-review-border: #ffb74d;
+    --node-pdf: #e8f4f8;
+    --node-pdf-border: #4db6ac;
     
     /* UI colors */
     --edge-color: #495057;
@@ -103,6 +105,8 @@
         --node-synthesis-border: #ec407a;
         --node-review: #3d3520;
         --node-review-border: #ffa726;
+        --node-pdf: #1a3d3d;
+        --node-pdf-border: #26a69a;
         
         --edge-color: #9ca3af;
         --edge-color-light: #4b5563;
@@ -395,6 +399,40 @@ html, body {
     text-align: center;
 }
 
+/* Drop zone overlay for PDF drag & drop */
+.drop-zone-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(34, 139, 230, 0.1);
+    border: 3px dashed var(--accent);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 50;
+    pointer-events: none;
+}
+
+.drop-zone-content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    padding: 24px 48px;
+    background: var(--bg-primary);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+}
+
+.drop-zone-icon {
+    font-size: 48px;
+}
+
+.drop-zone-text {
+    font-size: 18px;
+    font-weight: 500;
+    color: var(--text-primary);
+}
+
 /* Edges */
 .edge {
     fill: none;
@@ -533,6 +571,11 @@ html, body {
 .node.review {
     background: var(--node-review);
     border-color: var(--node-review-border);
+}
+
+.node.pdf {
+    background: var(--node-pdf);
+    border-color: var(--node-pdf-border);
 }
 
 /* Source text highlight - shown in parent node when a highlight excerpt is selected */
@@ -1037,6 +1080,8 @@ html, body {
     flex: 1;
     overflow: auto;
     min-height: 0;
+    /* Prevent scroll chaining - don't pan canvas when reaching scroll boundaries */
+    overscroll-behavior: contain;
 }
 
 /* Node Actions */
@@ -1400,6 +1445,30 @@ html, body {
 .send-btn:disabled {
     opacity: 0.5;
     cursor: not-allowed;
+}
+
+.attach-btn {
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition: color 0.15s, background 0.15s;
+    flex-shrink: 0;
+}
+
+.attach-btn:hover {
+    color: var(--accent);
+    background: var(--bg-secondary);
+}
+
+.attach-btn:active {
+    transform: scale(0.95);
 }
 
 /* Modals */

--- a/src/canvas_chat/static/index.html
+++ b/src/canvas_chat/static/index.html
@@ -77,6 +77,14 @@
             </div>
         </div>
         
+        <!-- Drop zone overlay for PDF drag & drop -->
+        <div id="drop-zone-overlay" class="drop-zone-overlay" style="display: none;">
+            <div class="drop-zone-content">
+                <span class="drop-zone-icon">📄</span>
+                <span class="drop-zone-text">Drop PDF here</span>
+            </div>
+        </div>
+        
         <!-- Node template (cloned when creating nodes) -->
         <template id="node-template">
             <foreignObject class="node-wrapper" width="320" height="auto">
@@ -119,6 +127,11 @@
             <button id="clear-selection-btn">✕</button>
         </div>
         <div class="chat-input-wrapper">
+            <button id="attach-btn" class="attach-btn" title="Attach PDF (drag & drop also supported)">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/>
+                </svg>
+            </button>
             <textarea 
                 id="chat-input" 
                 placeholder="Type a message... (Enter to send, Shift+Enter for newline)"
@@ -213,6 +226,9 @@
 
     <!-- Hidden file input for import -->
     <input type="file" id="import-file-input" accept=".canvaschat" style="display: none;">
+    
+    <!-- Hidden file input for PDF upload -->
+    <input type="file" id="pdf-file-input" accept=".pdf,application/pdf" style="display: none;">
 
     <!-- Matrix Axis Confirmation Modal -->
     <div id="matrix-modal" class="modal" style="display: none;">
@@ -428,6 +444,7 @@
                     <h3>Slash Commands</h3>
                     <table class="shortcuts-table">
                         <tbody>
+                            <tr><td><code>/note</code> <em>text or URL</em></td><td>Create a note (supports PDF URLs)</td></tr>
                             <tr><td><code>/search</code> <em>query</em></td><td>Search the web with Exa AI</td></tr>
                             <tr><td><code>/research</code> <em>topic</em></td><td>Deep research with multiple sources</td></tr>
                             <tr><td><code>/matrix</code> <em>context</em></td><td>Create a comparison matrix</td></tr>
@@ -444,6 +461,7 @@
                         <li><strong>Context:</strong> The context budget bar shows how much of the model's context window is used</li>
                         <li><strong>Tags:</strong> Use the 🏷️ button to organize nodes with colored tags</li>
                         <li><strong>Stop generation:</strong> Click "⏹ Stop" on an AI response to stop and optionally continue later</li>
+                        <li><strong>PDF import:</strong> Click 📎 to upload a PDF, or drag & drop onto the canvas</li>
                     </ul>
                 </section>
             </div>

--- a/src/canvas_chat/static/js/graph.js
+++ b/src/canvas_chat/static/js/graph.js
@@ -19,6 +19,7 @@ const NodeType = {
     ROW: 'row',            // Extracted row from a matrix
     COLUMN: 'column',      // Extracted column from a matrix
     FETCH_RESULT: 'fetch_result', // Fetched content from URL (via Exa)
+    PDF: 'pdf',            // Imported PDF document
     OPINION: 'opinion',    // Committee member's opinion
     SYNTHESIS: 'synthesis', // Chairman's synthesized answer
     REVIEW: 'review'       // Committee member's review of other opinions
@@ -33,6 +34,7 @@ const SCROLLABLE_NODE_TYPES = [
     NodeType.SUMMARY,
     NodeType.RESEARCH,
     NodeType.FETCH_RESULT,
+    NodeType.PDF,
     NodeType.OPINION,
     NodeType.SYNTHESIS,
     NodeType.REVIEW,

--- a/tests/test_utils.js
+++ b/tests/test_utils.js
@@ -1470,6 +1470,95 @@ test('isUrl: rejects whitespace only', () => {
 });
 
 // ============================================================
+// isPdfUrl tests (for PDF URL detection)
+// ============================================================
+
+/**
+ * Detect if a URL points to a PDF file.
+ * This pattern is used in app.js to route /note commands with PDF URLs
+ * to handleNoteFromPdfUrl instead of handleNoteFromUrl.
+ */
+function isPdfUrl(url) {
+    return /\.pdf(\?.*)?$/i.test(url.trim());
+}
+
+test('isPdfUrl: detects .pdf extension', () => {
+    assertTrue(isPdfUrl('https://example.com/document.pdf'));
+});
+
+test('isPdfUrl: detects .PDF uppercase extension', () => {
+    assertTrue(isPdfUrl('https://example.com/DOCUMENT.PDF'));
+});
+
+test('isPdfUrl: detects mixed case .Pdf extension', () => {
+    assertTrue(isPdfUrl('https://example.com/Report.Pdf'));
+});
+
+test('isPdfUrl: detects .pdf with query parameters', () => {
+    assertTrue(isPdfUrl('https://example.com/doc.pdf?token=abc123'));
+});
+
+test('isPdfUrl: detects .pdf with multiple query parameters', () => {
+    assertTrue(isPdfUrl('https://example.com/doc.pdf?id=1&ref=abc&download=true'));
+});
+
+test('isPdfUrl: detects .pdf in path with subdirectories', () => {
+    assertTrue(isPdfUrl('https://example.com/files/reports/2024/annual.pdf'));
+});
+
+test('isPdfUrl: trims whitespace', () => {
+    assertTrue(isPdfUrl('  https://example.com/doc.pdf  '));
+});
+
+test('isPdfUrl: rejects non-PDF URLs', () => {
+    assertFalse(isPdfUrl('https://example.com/page.html'));
+});
+
+test('isPdfUrl: rejects .txt files', () => {
+    assertFalse(isPdfUrl('https://example.com/readme.txt'));
+});
+
+test('isPdfUrl: rejects .doc files', () => {
+    assertFalse(isPdfUrl('https://example.com/document.doc'));
+});
+
+test('isPdfUrl: rejects .docx files', () => {
+    assertFalse(isPdfUrl('https://example.com/document.docx'));
+});
+
+test('isPdfUrl: rejects URL with pdf in path but different extension', () => {
+    assertFalse(isPdfUrl('https://example.com/pdf-viewer/page.html'));
+});
+
+test('isPdfUrl: rejects URL with pdf in domain', () => {
+    assertFalse(isPdfUrl('https://pdf.example.com/page'));
+});
+
+test('isPdfUrl: rejects URL with pdf in query but no .pdf extension', () => {
+    assertFalse(isPdfUrl('https://example.com/view?file=document.pdf&format=html'));
+});
+
+test('isPdfUrl: rejects plain text', () => {
+    assertFalse(isPdfUrl('This is not a URL'));
+});
+
+test('isPdfUrl: rejects empty string', () => {
+    assertFalse(isPdfUrl(''));
+});
+
+test('isPdfUrl: rejects URL without extension', () => {
+    assertFalse(isPdfUrl('https://example.com/document'));
+});
+
+test('isPdfUrl: handles arxiv-style PDF URLs', () => {
+    assertTrue(isPdfUrl('https://arxiv.org/pdf/2301.12345.pdf'));
+});
+
+test('isPdfUrl: handles nature-style PDF URLs', () => {
+    assertTrue(isPdfUrl('https://www.nature.com/articles/s41586-024-12345-6.pdf'));
+});
+
+// ============================================================
 // Graph.isEmpty() tests
 // ============================================================
 


### PR DESCRIPTION
## Summary

- Add PDF text extraction support via PyMuPDF with 25MB size limit
- Support three import methods: `/note` with PDF URL, paperclip button upload, and drag & drop onto canvas
- Fix pinch-to-zoom gesture not working when zooming out over nodes (trackpad)
- Fix two-finger scroll inside nodes incorrectly panning the canvas

## Changes

### PDF Upload Feature
- Backend: New `/api/upload-pdf` and `/api/fetch-pdf` endpoints with `FetchPdfRequest` and `PdfResult` models
- Frontend: `handleNoteFromPdfUrl()`, `handlePdfUpload()`, `handlePdfDrop()` methods in app.js
- Canvas: Drag & drop handlers with visual drop zone overlay
- Graph: New `NodeType.PDF` with teal styling
- All PDF imports include a warning banner about OCR/extraction accuracy

### Pinch-to-Zoom Fix
- Check for `ctrlKey` (pinch gesture) BEFORE checking for scrollable content
- Pinch-to-zoom now works in both directions regardless of cursor position

### Scroll Fix
- Manually handle scroll inside foreignObject elements to prevent canvas pan
- Add `overscroll-behavior: contain` CSS to prevent scroll chaining

## Testing
- Added 9 Python tests for PDF models
- Added 20 JavaScript tests for `isPdfUrl()` pattern
- All 31 Python tests pass
- All 115 JavaScript tests pass

## Documentation
- Added `docs/how-to/import-pdfs.md` covering all import methods and limitations