### PR TITLE
Show API key setup prompt in empty state for new users

### DIFF
--- a/src/canvas_chat/static/css/style.css
+++ b/src/canvas_chat/static/css/style.css
@@ -1725,6 +1725,16 @@ html, body {
     font-size: 14px;
 }
 
+.empty-state a {
+    color: var(--accent-color);
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.empty-state a:hover {
+    color: var(--accent-hover);
+}
+
 /* Keyboard shortcut hints */
 kbd {
     display: inline-block;

--- a/src/canvas_chat/static/js/app.js
+++ b/src/canvas_chat/static/js/app.js
@@ -4295,15 +4295,35 @@ class App {
         let emptyState = container.querySelector('.empty-state');
         
         if (this.graph.isEmpty()) {
+            const hasApiKeys = storage.hasAnyLLMApiKey();
+            
             if (!emptyState) {
                 emptyState = document.createElement('div');
                 emptyState.className = 'empty-state';
+                container.appendChild(emptyState);
+            }
+            
+            if (hasApiKeys) {
+                // User has API keys configured - show normal onboarding
                 emptyState.innerHTML = `
                     <h2>Start a conversation</h2>
                     <p>Type a message below to begin exploring ideas on the canvas.</p>
                     <p><kbd>Cmd/Ctrl+Click</kbd> to multi-select nodes</p>
                 `;
-                container.appendChild(emptyState);
+            } else {
+                // No API keys - guide user to settings first
+                emptyState.innerHTML = `
+                    <h2>Welcome to Canvas Chat</h2>
+                    <p>To get started, add an API key in <a href="#" class="empty-state-settings-link">Settings</a>.</p>
+                `;
+                // Add click handler for the settings link
+                const settingsLink = emptyState.querySelector('.empty-state-settings-link');
+                if (settingsLink) {
+                    settingsLink.addEventListener('click', (e) => {
+                        e.preventDefault();
+                        this.showSettingsModal();
+                    });
+                }
             }
         } else if (emptyState) {
             emptyState.remove();
@@ -4575,6 +4595,9 @@ class App {
         
         // Reload models to reflect newly configured API keys
         this.loadModels();
+        
+        // Update empty state in case API key status changed
+        this.updateEmptyState();
         
         this.hideSettingsModal();
     }

--- a/src/canvas_chat/static/js/storage.js
+++ b/src/canvas_chat/static/js/storage.js
@@ -235,6 +235,16 @@ class Storage {
     }
 
     /**
+     * Check if any LLM API keys are configured (excludes Exa which is search-only)
+     * @returns {boolean} - True if at least one LLM provider key is configured
+     */
+    hasAnyLLMApiKey() {
+        const keys = this.getApiKeys();
+        const llmProviders = ['openai', 'anthropic', 'google', 'groq', 'github'];
+        return llmProviders.some(provider => keys[provider] && keys[provider].trim() !== '');
+    }
+
+    /**
      * Build an API keys dict for a list of models.
      * Used by endpoints that need multiple provider keys (e.g., committee).
      * @param {string[]} modelIds - Array of model IDs (e.g., ["openai/gpt-4o", "anthropic/claude-sonnet-4-20250514"])


### PR DESCRIPTION
## Summary

- Updates the empty state onboarding message to guide new users to set up an API key first
- Follows progressive disclosure: users only see what they need at each step

## Changes

- Added `hasAnyLLMApiKey()` helper in `storage.js` to check if any LLM provider keys are configured
- Updated `updateEmptyState()` to show contextual messages:
  - **No API keys**: "Welcome to Canvas Chat" with a clickable link to Settings
  - **Has API keys**: Original "Start a conversation" message with keyboard shortcut hint
- Empty state now updates immediately after saving settings

## User experience

| State | Message |
|-------|---------|
| New user (no keys) | "Welcome to Canvas Chat" + Settings link |
| After adding key | "Start a conversation" + shortcut hint |