### PR TITLE
Add IMAGE node support and fix copy/link behaviors

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -899,6 +899,7 @@ packages:
   - pytest>=8.0.0 ; extra == 'dev'
   - httpx>=0.27.0 ; extra == 'dev'
   requires_python: '>=3.11'
+  editable: true
 - pypi: https://files.pythonhosted.org/packages/4b/0c/0654233d7543ac8a50f4785f172430ddc97538ba418eb305d6e529d1a120/cbor2-5.8.0-cp314-cp314-macosx_11_0_arm64.whl
   name: cbor2
   version: 5.8.0

--- a/src/canvas_chat/static/css/style.css
+++ b/src/canvas_chat/static/css/style.css
@@ -41,6 +41,8 @@
     --node-review-border: #ffb74d;
     --node-pdf: #e8f4f8;
     --node-pdf-border: #4db6ac;
+    --node-image: #fce4ec;
+    --node-image-border: #f48fb1;
     
     /* UI colors */
     --edge-color: #495057;
@@ -107,6 +109,8 @@
         --node-review-border: #ffa726;
         --node-pdf: #1a3d3d;
         --node-pdf-border: #26a69a;
+        --node-image: #3d2d35;
+        --node-image-border: #f06292;
         
         --edge-color: #9ca3af;
         --edge-color-light: #4b5563;
@@ -433,6 +437,30 @@ html, body {
     color: var(--text-primary);
 }
 
+/* Canvas hint notification */
+#canvas-hint {
+    position: fixed;
+    bottom: 80px;
+    left: 50%;
+    transform: translateX(-50%) translateY(20px);
+    padding: 12px 24px;
+    background: var(--bg-primary);
+    border: 1px solid var(--bg-secondary);
+    border-radius: var(--radius-lg);
+    box-shadow: var(--shadow-lg);
+    font-size: 14px;
+    color: var(--text-primary);
+    z-index: 200;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+#canvas-hint.visible {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+}
+
 /* Edges */
 .edge {
     fill: none;
@@ -576,6 +604,11 @@ html, body {
 .node.pdf {
     background: var(--node-pdf);
     border-color: var(--node-pdf-border);
+}
+
+.node.image {
+    background: var(--node-image);
+    border-color: var(--node-image-border);
 }
 
 /* Source text highlight - shown in parent node when a highlight excerpt is selected */
@@ -854,6 +887,63 @@ html, body {
 }
 
 .reply-tooltip-btn:active {
+    transform: scale(0.98);
+}
+
+/* Image Action Tooltip */
+.image-tooltip {
+    position: fixed;
+    z-index: 10000;
+    background: var(--bg-primary);
+    border: 1px solid var(--edge-color-light);
+    border-radius: var(--radius-md);
+    box-shadow: var(--shadow-lg);
+    padding: 8px;
+    width: 200px;
+    animation: tooltipFadeIn 0.15s ease-out;
+}
+
+.image-tooltip-preview {
+    width: 100%;
+    height: 100px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-bottom: 8px;
+    background: var(--bg-secondary);
+    border-radius: var(--radius-sm);
+    overflow: hidden;
+}
+
+.image-tooltip-img {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+}
+
+.image-tooltip-actions {
+    display: flex;
+    gap: 6px;
+}
+
+.image-tooltip-btn {
+    flex: 1;
+    padding: 8px 12px;
+    border: none;
+    border-radius: var(--radius-sm);
+    background: var(--bg-secondary);
+    color: var(--text-primary);
+    font-size: 13px;
+    cursor: pointer;
+    transition: background 0.15s, transform 0.1s;
+}
+
+.image-tooltip-btn:hover {
+    background: var(--accent);
+    color: white;
+}
+
+.image-tooltip-btn:active {
     transform: scale(0.98);
 }
 
@@ -1342,6 +1432,29 @@ html, body {
     max-width: 100%;
     height: auto;
     border-radius: var(--radius-sm);
+}
+
+/* Image node content (for IMAGE type nodes) */
+.image-node-content {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 8px;
+    height: 100%;
+    min-height: 150px;
+}
+
+.node-image {
+    max-width: 100%;
+    max-height: 100%;
+    object-fit: contain;
+    border-radius: var(--radius-sm);
+    cursor: pointer;
+    transition: transform 0.15s ease;
+}
+
+.node-image:hover {
+    transform: scale(1.02);
 }
 
 /* Dark mode adjustments for markdown */

--- a/src/canvas_chat/static/index.html
+++ b/src/canvas_chat/static/index.html
@@ -77,11 +77,11 @@
             </div>
         </div>
         
-        <!-- Drop zone overlay for PDF drag & drop -->
+        <!-- Drop zone overlay for file drag & drop -->
         <div id="drop-zone-overlay" class="drop-zone-overlay" style="display: none;">
             <div class="drop-zone-content">
-                <span class="drop-zone-icon">📄</span>
-                <span class="drop-zone-text">Drop PDF here</span>
+                <span class="drop-zone-icon">📎</span>
+                <span class="drop-zone-text">Drop file here</span>
             </div>
         </div>
         
@@ -102,6 +102,11 @@
                 </div>
             </foreignObject>
         </template>
+    </div>
+    
+    <!-- Canvas hint (temporary notification) -->
+    <div id="canvas-hint" class="canvas-hint" style="display: none;">
+        <span class="hint-text"></span>
     </div>
     
     <!-- Tag Drawer (Right Side) -->
@@ -127,7 +132,7 @@
             <button id="clear-selection-btn">✕</button>
         </div>
         <div class="chat-input-wrapper">
-            <button id="attach-btn" class="attach-btn" title="Attach PDF (drag & drop also supported)">
+            <button id="attach-btn" class="attach-btn" title="Attach PDF or image (drag & drop also supported)">
                 <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <path d="M21.44 11.05l-9.19 9.19a6 6 0 0 1-8.49-8.49l9.19-9.19a4 4 0 0 1 5.66 5.66l-9.2 9.19a2 2 0 0 1-2.83-2.83l8.49-8.48"/>
                 </svg>
@@ -227,8 +232,8 @@
     <!-- Hidden file input for import -->
     <input type="file" id="import-file-input" accept=".canvaschat" style="display: none;">
     
-    <!-- Hidden file input for PDF upload -->
-    <input type="file" id="pdf-file-input" accept=".pdf,application/pdf" style="display: none;">
+    <!-- Hidden file input for PDF and image upload -->
+    <input type="file" id="pdf-file-input" accept=".pdf,application/pdf,image/*" style="display: none;">
 
     <!-- Matrix Axis Confirmation Modal -->
     <div id="matrix-modal" class="modal" style="display: none;">

--- a/src/canvas_chat/static/js/graph.js
+++ b/src/canvas_chat/static/js/graph.js
@@ -13,7 +13,7 @@ const NodeType = {
     REFERENCE: 'reference',
     SEARCH: 'search',      // Web search query node
     RESEARCH: 'research',  // Exa deep research node
-    HIGHLIGHT: 'highlight', // Excerpted text from another node
+    HIGHLIGHT: 'highlight', // Excerpted text or image from another node
     MATRIX: 'matrix',      // Cross-product evaluation table
     CELL: 'cell',          // Pinned cell from a matrix
     ROW: 'row',            // Extracted row from a matrix
@@ -22,7 +22,8 @@ const NodeType = {
     PDF: 'pdf',            // Imported PDF document
     OPINION: 'opinion',    // Committee member's opinion
     SYNTHESIS: 'synthesis', // Chairman's synthesized answer
-    REVIEW: 'review'       // Committee member's review of other opinions
+    REVIEW: 'review',      // Committee member's review of other opinions
+    IMAGE: 'image'         // Uploaded image for analysis
 };
 
 /**
@@ -38,7 +39,8 @@ const SCROLLABLE_NODE_TYPES = [
     NodeType.OPINION,
     NodeType.SYNTHESIS,
     NodeType.REVIEW,
-    NodeType.NOTE
+    NodeType.NOTE,
+    NodeType.IMAGE
 ];
 
 /**
@@ -534,12 +536,20 @@ class Graph {
         
         // Convert to message format for API
         // User-generated content types are mapped to 'user' role, AI-generated to 'assistant'
-        const userTypes = [NodeType.HUMAN, NodeType.HIGHLIGHT, NodeType.NOTE];
-        return sorted.map(node => ({
-            role: userTypes.includes(node.type) ? 'user' : 'assistant',
-            content: node.content,
-            nodeId: node.id
-        }));
+        const userTypes = [NodeType.HUMAN, NodeType.HIGHLIGHT, NodeType.NOTE, NodeType.IMAGE];
+        return sorted.map(node => {
+            const msg = {
+                role: userTypes.includes(node.type) ? 'user' : 'assistant',
+                content: node.content,
+                nodeId: node.id
+            };
+            // Include image data if present (for IMAGE and HIGHLIGHT nodes with images)
+            if (node.imageData) {
+                msg.imageData = node.imageData;
+                msg.mimeType = node.mimeType;
+            }
+            return msg;
+        });
     }
 
     /**


### PR DESCRIPTION
## Summary

- Add full IMAGE node type support: upload via paperclip, drag & drop onto canvas, and paste from clipboard
- Add multimodal message support so vision-capable LLMs can analyze images in context
- Fix image node copy functionality (was no-op because `node.content` is empty for images)
- Fix `/note` command not creating edges to selected parent nodes
- Fix empty summary fallback when LLM returns blank content

## Changes

### New Features

**IMAGE Node Type**
- Upload images via paperclip button (now accepts both PDF and images)
- Drag & drop images directly onto canvas
- Paste images from clipboard (Ctrl/Cmd+V when not in input)
- Click images in node content to extract or ask about them
- Images are resized to max 2048px and stored as base64

**Multimodal LLM Support**
- `buildMessagesForApi()` handles image+text messages for vision models
- Images in context are sent as `image_url` content parts

**Canvas Hints**
- Temporary notification system for user guidance (e.g., "Image added! Select it and type a message to ask about it.")

### Bug Fixes

1. **Image copy**: `copyNodeContent()` and copy button now detect `node.imageData` and copy image to clipboard as PNG
2. **`/note` linking**: `handleNote()`, `handleNoteFromUrl()`, and `handleNoteFromPdfUrl()` now create REPLY/MERGE edges when nodes are selected
3. **Empty summary**: Backend returns 422 if LLM returns empty; frontend keeps truncated content fallback instead of showing blank

## Files Changed

| File | Changes |
|------|---------|
| `app.py` | Multimodal Message type, empty summary validation |
| `app.js` | Image upload/paste handlers, buildMessagesForApi, /note linking fixes, copy fix |
| `canvas.js` | copyImageToClipboard, image tooltip, drop handlers |
| `graph.js` | IMAGE node type, resolveContext returns imageData |
| `style.css` | IMAGE node styling, image tooltip, canvas hint |
| `index.html` | Canvas hint element, file input accepts images |