### PR TITLE
Fix node resize behavior and add reset button

### DIFF
--- a/src/canvas_chat/static/css/style.css
+++ b/src/canvas_chat/static/css/style.css
@@ -1140,7 +1140,8 @@ html, body {
     background: #2f9e44;
 }
 
-.header-btn.fit-viewport-btn {
+.header-btn.fit-viewport-btn,
+.header-btn.reset-size-btn {
     display: inline-flex;
     background: var(--bg-secondary);
     color: var(--text-secondary);
@@ -1148,11 +1149,13 @@ html, body {
     transition: opacity 0.15s, background 0.15s;
 }
 
-.node:hover .header-btn.fit-viewport-btn {
+.node:hover .header-btn.fit-viewport-btn,
+.node:hover .header-btn.reset-size-btn {
     opacity: 0.6;
 }
 
-.header-btn.fit-viewport-btn:hover {
+.header-btn.fit-viewport-btn:hover,
+.header-btn.reset-size-btn:hover {
     opacity: 1;
     background: var(--accent);
     color: white;


### PR DESCRIPTION
## Changes

- **Fixed resize bugs:**
  - Dragging bottom border upward no longer makes nodes taller
  - Resizing width no longer causes height to grow unexpectedly

- **Improved resize behavior:**
  - Height can now shrink freely with scrollable content (100px minimum)
  - Width changes cause text wrapping
  - Content scrolls when it overflows (via `viewport-fitted` class)

- **New features:**
  - Reset-to-default-size button (↺) in node header
  - Keyboard shortcut hints: Reply (r) and Copy (c) buttons now show shortcuts

## Technical Details

- Removed `minContentHeight` constraint that prevented height shrinking
- Added `viewport-fitted` class when manually resizing to enable scrolling
- Width-only resize now keeps height constant and enables scrolling for overflow
- Reset button resets scrollable nodes to `SCROLLABLE_NODE_SIZE` (640×480) or calculates natural height for non-scrollable types