### PR TITLE
fix: prevent node jump when resizing after reset to default size

### DIFF
--- a/src/canvas_chat/static/js/app.js
+++ b/src/canvas_chat/static/js/app.js
@@ -4360,9 +4360,16 @@ class App {
         wrapper.setAttribute('width', defaultWidth);
         wrapper.setAttribute('height', defaultHeight);
 
-        // Remove viewport-fitted class to restore natural sizing
-        div.classList.remove('viewport-fitted');
-        div.style.height = '';
+        // For scrollable types, keep viewport-fitted so node renders at wrapper size with scrolling
+        // This prevents mismatch between wrapper dimensions and rendered dimensions during resize
+        if (isScrollableType) {
+            div.classList.add('viewport-fitted');
+            div.style.height = '100%';
+        } else {
+            // For non-scrollable types, remove constraints to allow natural sizing
+            div.classList.remove('viewport-fitted');
+            div.style.height = '';
+        }
 
         // Update edges
         const x = parseFloat(wrapper.getAttribute('x'));


### PR DESCRIPTION
## Summary

- Fixes #40: Node no longer jumps to default size when resizing after "Reset to default size"
- For scrollable node types (AI, Summary, Research, etc.), keeps `viewport-fitted` class and sets `height: 100%` so node renders at wrapper dimensions with scrollable content
- This ensures wrapper dimensions match visual dimensions, preventing the jump when resize starts

## Root Cause

Previously, `handleNodeResetSize()` removed the `viewport-fitted` class and cleared `div.style.height` for all node types. For scrollable nodes, this caused the node to render at its natural content height (often much larger than the 640x480 wrapper), creating a mismatch. When the user dragged to resize, the starting height was read from the wrapper (480px), not the visual height, causing an unexpected jump.

## Fix

For scrollable types, the reset now:
1. Adds `viewport-fitted` class (constrains node to wrapper)
2. Sets `div.style.height = '100%'` (node fills wrapper with scrolling)

Non-scrollable types retain the original behavior.