### PR TITLE
chore(dev-environment)🔧: update pixi.lock and pre-commit config for editable install

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,5 +25,4 @@ repos:
         name: Update pixi.lock
         entry: pixi lock
         language: system
-        files: ^pyproject\.toml$
         pass_filenames: false

--- a/pixi.lock
+++ b/pixi.lock
@@ -900,6 +900,7 @@ packages:
   - pytest>=8.0.0 ; extra == 'dev'
   - httpx>=0.27.0 ; extra == 'dev'
   requires_python: '>=3.11'
+  editable: true
 - pypi: https://files.pythonhosted.org/packages/4b/0c/0654233d7543ac8a50f4785f172430ddc97538ba418eb305d6e529d1a120/cbor2-5.8.0-cp314-cp314-macosx_11_0_arm64.whl
   name: cbor2
   version: 5.8.0


### PR DESCRIPTION
- Set 'editable: true' for the main package in pixi.lock to enable editable installs.
- Remove the 'files' restriction from the 'Update pixi.lock' pre-commit hook to allow broader triggering.