### PR TITLE
feat: Highlight nodes by tag on tag chip click

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -900,6 +900,7 @@ packages:
   - pytest>=8.0.0 ; extra == 'dev'
   - httpx>=0.27.0 ; extra == 'dev'
   requires_python: '>=3.11'
+  editable: true
 - pypi: https://files.pythonhosted.org/packages/4b/0c/0654233d7543ac8a50f4785f172430ddc97538ba418eb305d6e529d1a120/cbor2-5.8.0-cp314-cp314-macosx_11_0_arm64.whl
   name: cbor2
   version: 5.8.0

--- a/src/canvas_chat/static/css/style.css
+++ b/src/canvas_chat/static/css/style.css
@@ -640,6 +640,17 @@ html, body {
     opacity: 0.85;
 }
 
+/* Nodes highlighted by tag filter */
+.node.tag-highlighted {
+    box-shadow: 0 0 0 3px var(--selection-color), var(--shadow-md);
+}
+
+/* Edges faded during tag highlighting */
+.edge.faded {
+    opacity: 0.15;
+    transition: opacity 0.2s ease;
+}
+
 .node.dragging {
     opacity: 0.8;
     transform: scale(1.02);
@@ -3129,6 +3140,18 @@ kbd {
     border-color: var(--accent);
 }
 
+.tag-slot.highlighting {
+    background: var(--selection-bg);
+    box-shadow: inset 0 0 0 2px var(--selection-color);
+}
+
+.tag-slot.highlighting::after {
+    content: '🔍';
+    font-size: 12px;
+    margin-left: auto;
+    padding-right: 8px;
+}
+
 .tag-color-dot {
     width: 20px;
     height: 20px;
@@ -3237,6 +3260,13 @@ kbd {
     white-space: nowrap;
     box-shadow: var(--shadow-sm);
     position: relative;
+    cursor: pointer;
+    transition: transform 0.1s ease, box-shadow 0.1s ease;
+}
+
+.node-tag:hover {
+    transform: scale(1.05);
+    box-shadow: var(--shadow-md);
 }
 
 .node-tag::after {


### PR DESCRIPTION
## Summary

Implements the ability to highlight nodes that share a specific tag when interacting with that tag, as requested in #25.

- Click tag chips on nodes to highlight all nodes with that tag
- Non-matching nodes fade out (opacity 0.4), matching nodes get a highlight ring
- Edges between non-matching nodes also fade out
- Click the same tag again or click canvas background to clear highlighting
- Tag drawer also supports highlighting when no nodes are selected
- Shows 🔍 icon on the active filter in the tag drawer

## Changes

### canvas.js
- Added `onTagChipClick` callback property
- Added click handlers for tag chips in `setupNodeEvents()`
- Added `highlightNodesByTag(tagColor)` method
- Fixed: tag chip clicks no longer trigger node selection

### app.js
- Added `highlightedTagColor` state property
- Added `handleTagChipClick(color)` handler with toggle behavior
- Modified `handleNodeDeselect()` to clear tag highlighting when clicking canvas background
- Modified `handleTagSlotClick()` to trigger highlighting when no nodes selected
- Modified `renderTagSlots()` to show which tag is currently filtering

### style.css
- Added `.node.tag-highlighted` class with selection-colored ring
- Added `.edge.faded` class for fading edges
- Added cursor pointer and hover effect to tag chips
- Added `.tag-slot.highlighting` class for tag drawer

### Tests
Added 8 new tests in `tests/test_ui.js`:
- Tag highlighting: highlights nodes with matching tag
- Tag highlighting: fades nodes without matching tag
- Tag highlighting: clears all highlighting when null passed
- Tag highlighting: switching tags updates highlighting
- Tag highlighting: node with multiple tags matches any
- Tag chip click: does not select node when clicking tag chip
- Tag chip click: selects node when clicking node content
- Tag chip click: does not select node when clicking resize handle

Fixes #25