### PR TITLE
docs: add browser compatibility section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ Open your browser to the URL shown (usually `http://127.0.0.1:7865`).
 - **LLM**: LiteLLM (multi-provider support)
 - **Storage**: IndexedDB (browser-local)
 
+## Browser compatibility
+
+Canvas Chat works best on **Chromium-based browsers** (Chrome, Edge, Arc, Brave, etc.). Firefox and Safari have rendering issues with the SVG canvas that prevent full functionality.
+
 ## License
 
 MIT

--- a/pixi.lock
+++ b/pixi.lock
@@ -900,6 +900,7 @@ packages:
   - pytest>=8.0.0 ; extra == 'dev'
   - httpx>=0.27.0 ; extra == 'dev'
   requires_python: '>=3.11'
+  editable: true
 - pypi: https://files.pythonhosted.org/packages/4b/0c/0654233d7543ac8a50f4785f172430ddc97538ba418eb305d6e529d1a120/cbor2-5.8.0-cp314-cp314-macosx_11_0_arm64.whl
   name: cbor2
   version: 5.8.0


### PR DESCRIPTION
## Summary

- Adds a browser compatibility section to the README documenting that Canvas Chat works best on Chromium-based browsers (Chrome, Edge, Arc, Brave, etc.)
- Notes that Firefox and Safari have rendering issues with the SVG canvas