### PR TITLE
CI: Only deploy to Modal when app/deployment code changes

### DIFF
--- a/.github/workflows/modal-deploy.yaml
+++ b/.github/workflows/modal-deploy.yaml
@@ -9,8 +9,20 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'src/**'
+      - 'modal_app.py'
+      - 'pyproject.toml'
+      - 'pixi.lock'
+      - '.github/workflows/modal-deploy.yaml'
   pull_request:
     types: [opened, synchronize, reopened]
+    paths:
+      - 'src/**'
+      - 'modal_app.py'
+      - 'pyproject.toml'
+      - 'pixi.lock'
+      - '.github/workflows/modal-deploy.yaml'
 
 jobs:
   deploy:


### PR DESCRIPTION
## Summary

- Add path filters to `modal-deploy.yaml` so deployments only trigger when relevant files change
- Paths watched: `src/**`, `modal_app.py`, `pyproject.toml`, `pixi.lock`, and the workflow file itself
- Documentation-only changes (README, docs/, etc.) will no longer trigger unnecessary deployments

Closes #60