### PR TITLE
Fix: Use Smith-Waterman alignment for robust text highlighting

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -926,6 +926,7 @@ packages:
   - pytest>=8.0.0 ; extra == 'dev'
   - httpx>=0.27.0 ; extra == 'dev'
   requires_python: '>=3.11'
+  editable: true
 - pypi: https://files.pythonhosted.org/packages/4b/0c/0654233d7543ac8a50f4785f172430ddc97538ba418eb305d6e529d1a120/cbor2-5.8.0-cp314-cp314-macosx_11_0_arm64.whl
   name: cbor2
   version: 5.8.0

--- a/src/canvas_chat/static/js/highlight-utils.js
+++ b/src/canvas_chat/static/js/highlight-utils.js
@@ -7,14 +7,196 @@
  */
 
 /**
+ * Check if a node is inside an element that should be skipped for text matching.
+ * This handles KaTeX math rendering which duplicates text across MathML and visual spans.
+ *
+ * @param {Node} node - The node to check
+ * @returns {boolean} True if the node should be skipped
+ */
+function isInsideSkippedElement(node) {
+    let current = node.parentElement;
+    while (current) {
+        // Skip MathML elements (used by KaTeX for accessibility)
+        if (current.tagName && current.tagName.toLowerCase() === 'math') {
+            return true;
+        }
+        // Skip annotation elements inside MathML
+        if (current.tagName && current.tagName.toLowerCase() === 'annotation') {
+            return true;
+        }
+        // Skip katex-mathml container (contains duplicate text for screen readers)
+        if (current.classList && current.classList.contains('katex-mathml')) {
+            return true;
+        }
+        current = current.parentElement;
+    }
+    return false;
+}
+
+/**
+ * Normalize KaTeX text duplication artifacts in selected text.
+ * When users select text from KaTeX-rendered math, the browser often includes
+ * both the MathML and the visual representation, causing patterns like:
+ * "0.13 ± 0.13±" instead of just "0.13±"
+ *
+ * @param {string} text - The selected text that may contain duplicates
+ * @returns {string} Text with KaTeX duplication artifacts removed
+ */
+function normalizeKatexDuplication(text) {
+    // First normalize whitespace
+    let normalized = text.replace(/\s+/g, ' ');
+
+    // Pattern: (number) ± (same_number)± -> (number)±
+    // This matches the duplication from mathml annotation + katex-html
+    // E.g., "0.13 ± 0.13±" -> "0.13±"
+    normalized = normalized.replace(/(\d+\.?\d*)\s*±\s*\1±/g, '$1±');
+
+    return normalized;
+}
+
+/**
+ * Smith-Waterman local alignment to find where a query prefix best matches in target.
+ * Returns the target index where the match starts.
+ *
+ * @param {string} queryPrefix - The prefix of the query to align
+ * @param {string} target - The target string to search in
+ * @returns {number} The start index in target, or -1 if no match
+ */
+function alignStart(queryPrefix, target) {
+    const m = queryPrefix.length;
+    const n = target.length;
+
+    if (m === 0 || n === 0) return -1;
+
+    const MATCH = 2;
+    const MISMATCH = -1;
+    const GAP = -1;
+    const WS_MATCH = 1;
+
+    const isWs = (ch) => /\s/.test(ch);
+
+    const score = Array(m + 1).fill(null).map(() => Array(n + 1).fill(0));
+
+    let maxScore = 0;
+    let maxI = 0, maxJ = 0;
+
+    for (let i = 1; i <= m; i++) {
+        for (let j = 1; j <= n; j++) {
+            const qChar = queryPrefix[i - 1].toLowerCase();
+            const tChar = target[j - 1].toLowerCase();
+
+            let matchVal;
+            if (qChar === tChar) {
+                matchVal = isWs(qChar) ? WS_MATCH : MATCH;
+            } else if (isWs(qChar) && isWs(tChar)) {
+                matchVal = WS_MATCH;
+            } else {
+                matchVal = MISMATCH;
+            }
+
+            const diag = score[i - 1][j - 1] + matchVal;
+            const up = score[i - 1][j] + GAP;
+            const left = score[i][j - 1] + GAP;
+
+            score[i][j] = Math.max(0, diag, up, left);
+
+            if (score[i][j] > maxScore) {
+                maxScore = score[i][j];
+                maxI = i;
+                maxJ = j;
+            }
+        }
+    }
+
+    if (maxScore === 0) return -1;
+
+    // Traceback to find start position in target
+    let i = maxI, j = maxJ;
+    let targetStart = j;
+
+    while (i > 0 && j > 0 && score[i][j] > 0) {
+        const current = score[i][j];
+        const qChar = queryPrefix[i - 1].toLowerCase();
+        const tChar = target[j - 1].toLowerCase();
+
+        let matchVal;
+        if (qChar === tChar) {
+            matchVal = isWs(qChar) ? WS_MATCH : MATCH;
+        } else if (isWs(qChar) && isWs(tChar)) {
+            matchVal = WS_MATCH;
+        } else {
+            matchVal = MISMATCH;
+        }
+
+        if (i > 0 && j > 0 && score[i - 1][j - 1] + matchVal === current) {
+            targetStart = j - 1;
+            i--; j--;
+        } else if (i > 0 && score[i - 1][j] + GAP === current) {
+            i--;
+        } else {
+            targetStart = j - 1;
+            j--;
+        }
+    }
+
+    return targetStart;
+}
+
+/**
+ * Align the suffix of query to find where the match ends in target.
+ * Reverses both strings and uses alignStart, then converts back.
+ *
+ * @param {string} querySuffix - The suffix of the query to align
+ * @param {string} target - The target string to search in
+ * @returns {number} The end index in target (exclusive), or -1 if no match
+ */
+function alignEnd(querySuffix, target) {
+    const revQuery = querySuffix.split('').reverse().join('');
+    const revTarget = target.split('').reverse().join('');
+
+    const revStart = alignStart(revQuery, revTarget);
+    if (revStart === -1) return -1;
+
+    // Convert reversed start position to forward end position
+    return target.length - revStart;
+}
+
+/**
+ * Find match region in target using alignment at both ends.
+ * This handles whitespace differences, KaTeX duplication, and other artifacts.
+ *
+ * @param {string} query - The query string (may have artifacts)
+ * @param {string} target - The clean target string
+ * @returns {{start: number, end: number}|null} The match region or null
+ */
+function findMatchRegion(query, target) {
+    if (!query || !target) return null;
+
+    // Use first ~20 chars for start alignment, last ~20 for end
+    const prefixLen = Math.min(20, query.length);
+    const suffixLen = Math.min(20, query.length);
+
+    const prefix = query.slice(0, prefixLen);
+    const suffix = query.slice(-suffixLen);
+
+    const start = alignStart(prefix, target);
+    if (start === -1) return null;
+
+    const end = alignEnd(suffix, target);
+    if (end === -1 || end <= start) return null;
+
+    return { start, end };
+}
+
+/**
  * Highlight text within HTML without breaking tags.
  * Handles text that spans across multiple HTML elements (e.g., across <strong> boundaries).
- * Uses whitespace normalization to match text selected across block elements where
- * selection.toString() produces newlines but joined text nodes do not.
+ * Uses Smith-Waterman alignment to handle whitespace differences, KaTeX duplication,
+ * and other artifacts from browser text selection.
  *
  * @param {Document} document - The document object for DOM manipulation
  * @param {string} html - Original HTML content
- * @param {string} text - Text to highlight
+ * @param {string} text - Text to highlight (may contain selection artifacts)
  * @returns {string} HTML with highlighted text wrapped in <mark class="source-highlight">
  */
 function highlightTextInHtml(document, html, text) {
@@ -24,8 +206,7 @@ function highlightTextInHtml(document, html, text) {
     const temp = document.createElement('div');
     temp.innerHTML = html;
 
-    // Use TreeWalker to collect all text nodes
-    // NodeFilter.SHOW_TEXT = 4. Access from window if available (jsdom), else use constant.
+    // Use TreeWalker to collect all text nodes, filtering out duplicates from KaTeX
     const SHOW_TEXT = (document.defaultView && document.defaultView.NodeFilter)
         ? document.defaultView.NodeFilter.SHOW_TEXT
         : 4;
@@ -33,7 +214,10 @@ function highlightTextInHtml(document, html, text) {
     const textNodes = [];
     let node;
     while (node = walker.nextNode()) {
-        textNodes.push(node);
+        // Skip text nodes inside MathML/katex-mathml (they duplicate visible content)
+        if (!isInsideSkippedElement(node)) {
+            textNodes.push(node);
+        }
     }
 
     if (textNodes.length === 0) return html;
@@ -41,7 +225,6 @@ function highlightTextInHtml(document, html, text) {
     // Build the full text WITH position mapping
     // Add a space between text nodes to simulate block element boundaries
     // charMap[i] = { nodeIndex, charIndex } maps each char in fullText to its source
-    // charIndex of -1 means it's a synthetic space between nodes
     let fullText = '';
     const charMap = [];
 
@@ -59,44 +242,14 @@ function highlightTextInHtml(document, html, text) {
         }
     }
 
-    // Normalize whitespace: collapse all whitespace sequences to single space, trim
-    const normalizeWs = (str) => str.replace(/\s+/g, ' ').trim();
+    // Preprocess the search text to remove KaTeX duplication artifacts
+    const cleanedSearch = normalizeKatexDuplication(text);
 
-    const normalizedFull = normalizeWs(fullText);
-    const normalizedSearch = normalizeWs(text);
+    // Use alignment to find where the query matches in the target
+    const matchRegion = findMatchRegion(cleanedSearch, fullText);
+    if (!matchRegion) return html;
 
-    // Find match in normalized strings (case-insensitive)
-    const matchStartNorm = normalizedFull.toLowerCase().indexOf(normalizedSearch.toLowerCase());
-    if (matchStartNorm === -1) return html;
-    const matchEndNorm = matchStartNorm + normalizedSearch.length;
-
-    // Build mapping from normalized positions to original positions
-    // normalizedToOriginal[i] = original index in fullText for normalized char i
-    const normalizedToOriginal = [];
-    let inWhitespace = false;
-    let leadingTrimmed = true;
-
-    for (let i = 0; i < fullText.length; i++) {
-        const ch = fullText[i];
-        if (/\s/.test(ch)) {
-            if (!inWhitespace && !leadingTrimmed) {
-                // First whitespace char after non-whitespace maps to the normalized space
-                normalizedToOriginal.push(i);
-            }
-            inWhitespace = true;
-        } else {
-            leadingTrimmed = false;
-            inWhitespace = false;
-            normalizedToOriginal.push(i);
-        }
-    }
-
-    // Get original positions for match boundaries
-    if (matchStartNorm >= normalizedToOriginal.length) return html;
-    const origStart = normalizedToOriginal[matchStartNorm];
-    const origEnd = matchEndNorm <= normalizedToOriginal.length
-        ? normalizedToOriginal[matchEndNorm - 1] + 1
-        : fullText.length;
+    const { start: origStart, end: origEnd } = matchRegion;
 
     // Find which text nodes overlap with [origStart, origEnd)
     const nodesToProcess = [];
@@ -181,5 +334,13 @@ function extractExcerptText(content) {
 
 // Export for ES module usage (tests)
 if (typeof module !== 'undefined' && module.exports) {
-    module.exports = { highlightTextInHtml, extractExcerptText };
+    module.exports = {
+        highlightTextInHtml,
+        extractExcerptText,
+        isInsideSkippedElement,
+        normalizeKatexDuplication,
+        alignStart,
+        alignEnd,
+        findMatchRegion
+    };
 }


### PR DESCRIPTION
## Summary

- Replace complex normalization-based text matching with Smith-Waterman local alignment algorithm
- Fix highlighting failures when users select text from KaTeX-rendered markdown tables
- Add 11 new tests for alignment functions

## Problem

When users select text from markdown tables with rendered math (KaTeX), the browser selection includes artifacts that break text highlighting:

1. **Duplicated numbers**: KaTeX renders both MathML (for accessibility) and visual spans, so `0.13±` becomes `0.13 ± 0.13±` in the selection
2. **Whitespace variations**: Tabs between table cells, newlines within KaTeX spans
3. **Spacing around operators**: `±` may have different spacing in selection vs. HTML

The previous approach used multiple normalization layers with position mapping, but had bugs that caused highlights to stop early or highlight the wrong characters (e.g., " worl" instead of "world").

## Solution

Use **Smith-Waterman local alignment** - a classic bioinformatics algorithm for pairwise sequence alignment. Instead of trying to normalize strings and map positions back through multiple layers, we:

1. Align the **beginning** of the user's selection to find the start position in the HTML text
2. Align the **end** of the selection (by reversing both strings) to find the end position
3. Highlight the text between those positions

This handles insertions, deletions, and mismatches gracefully - exactly what we need for messy browser selections.

## Changes

- `src/canvas_chat/static/js/highlight-utils.js`:
  - Add `alignStart()` - Smith-Waterman alignment to find match start
  - Add `alignEnd()` - Reverse alignment to find match end
  - Add `findMatchRegion()` - Uses alignment at both ends
  - Simplify `highlightTextInHtml()` to use the new approach
  - Remove `normalizeMathSpacing()` (no longer needed)

- `tests/test_ui.js`:
  - Add 11 new tests for alignment functions
  - All 55 UI tests pass