### PR TITLE
feat: add zoom-to-selection keyboard shortcuts

### DIFF
--- a/src/canvas_chat/static/index.html
+++ b/src/canvas_chat/static/index.html
@@ -493,6 +493,8 @@
                             <tr><td><kbd>F</kbd></td><td>Fit node to viewport (when node selected)</td></tr>
                             <tr><td><kbd>-</kbd></td><td>Collapse children (when node selected)</td></tr>
                             <tr><td><kbd>=</kbd></td><td>Expand children (when node selected)</td></tr>
+                            <tr><td><kbd>Z</kbd></td><td>Zoom to selection (when node(s) selected)</td></tr>
+                            <tr><td><kbd>Shift</kbd> + <kbd>Z</kbd></td><td>Zoom out to fit all content</td></tr>
                             <tr><td><kbd>↑</kbd> / <kbd>↓</kbd> or <kbd>j</kbd> / <kbd>k</kbd></td><td>Navigate to parent/child nodes</td></tr>
                             <tr><td><kbd>Escape</kbd></td><td>Clear selection / Close dialogs</td></tr>
                             <tr><td><kbd>Enter</kbd></td><td>Send message</td></tr>

--- a/src/canvas_chat/static/js/app.js
+++ b/src/canvas_chat/static/js/app.js
@@ -1228,6 +1228,21 @@ class App {
                     }
                 }
             }
+
+            // 'z' to zoom to selected nodes (fit selection in viewport at 80%)
+            if (e.key === 'z' && !e.shiftKey && !e.target.matches('input, textarea') && !(e.metaKey || e.ctrlKey)) {
+                const selectedNodeIds = this.canvas.getSelectedNodeIds();
+                if (selectedNodeIds.length > 0) {
+                    e.preventDefault();
+                    this.canvas.zoomToSelectionAnimated(selectedNodeIds);
+                }
+            }
+
+            // 'Shift+Z' to zoom out to fit all content (same as double-click on canvas)
+            if (e.key === 'Z' && e.shiftKey && !e.target.matches('input, textarea')) {
+                e.preventDefault();
+                this.canvas.fitToContentAnimated(400);
+            }
         });
 
         // Clipboard paste handler for images


### PR DESCRIPTION
## Summary

- Add `z` shortcut to zoom viewport to fit selected node(s) at ~80% of viewport
- Add `Shift+Z` shortcut to zoom out and fit all content (same as double-click on canvas)
- Smooth ease-in-out cubic animation for combined zoom + pan transitions

## Changes

### New methods in `canvas.js`
- `getNodesBoundingBox(nodeIds, padding)` — Calculates bounding box for a set of nodes
- `animateViewport(options)` — Shared animation helper with smooth ease-in-out cubic easing
- `zoomToSelectionAnimated(nodeIds, targetFill, duration)` — Main feature: zoom to fit selection

### Refactoring
- `fitToContentAnimated()` now uses the shared `animateViewport()` helper (DRY)

### Keyboard shortcuts in `app.js`
- `z` — Zoom to selection (when node(s) selected)
- `Shift+Z` — Zoom out to fit all content

### Help modal in `index.html`
- Added new shortcuts to keyboard shortcuts table

## Testing
- Syntax checks pass
- All 346 JavaScript tests pass
- Manual testing confirms smooth zoom animations