### PR TITLE
feat: add base path support for load balancer deployments

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -82,6 +82,8 @@
 
     "isUrlContent": "writable",
     "extractUrlFromReferenceNode": "writable",
+    "getBasePath": "writable",
+    "apiUrl": "writable",
     "truncateText": "writable",
     "escapeHtmlText": "writable",
     "formatMatrixAsText": "writable",

--- a/pixi.lock
+++ b/pixi.lock
@@ -72,9 +72,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0d/67/8456d39484fcb7afd0defed21918e773ed59a98b39e5b633328527c88367/fastmcp-2.14.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/ef/33/4105ca574f6ded0af6a797d39add041bcfb468a1255fbbe82fcb6f592da2/fastuuid-0.14.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/30/ab407e2ec752aa541704ed8f93c11e2a5d92c168b8a755d818b74a3c5c2d/filelock-3.20.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a7/b2/fabede9fafd976b991e9f1b9c8c873ed86f202889b864756f240ce6dd855/frozenlist-1.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/51/c7/b64cae5dba3a1b138d7123ec36bb5ccd39d39939f18454407e5468f4763f/fsspec-2025.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b8/14/bab308fc2c1b5228c3224ec2bf928ce2e4d21d8046c161e44a2012b5203e/greenlet-3.3.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/43/28/40a5be3f9a86949b83e7d6a2ad6011d993cbe9b6bd27bea881f61c7788b6/grpcio-1.76.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl
@@ -259,9 +259,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0d/67/8456d39484fcb7afd0defed21918e773ed59a98b39e5b633328527c88367/fastmcp-2.14.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/30/ab407e2ec752aa541704ed8f93c11e2a5d92c168b8a755d818b74a3c5c2d/filelock-3.20.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/51/c7/b64cae5dba3a1b138d7123ec36bb5ccd39d39939f18454407e5468f4763f/fsspec-2025.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d7/7c/f0a6d0ede2c7bf092d00bc83ad5bafb7e6ec9b4aab2fbdfa6f134dc73327/greenlet-3.3.0-cp314-cp314-macosx_11_0_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/9c/f5/a4531f7fb8b4e2a60b94e39d5d924469b7a6988176b3422487be61fe2998/grpcio-1.76.0-cp314-cp314-macosx_11_0_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl
@@ -443,9 +443,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0d/67/8456d39484fcb7afd0defed21918e773ed59a98b39e5b633328527c88367/fastmcp-2.14.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/16/c9/8c7660d1fe3862e3f8acabd9be7fc9ad71eb270f1c65cce9a2b7a31329ab/fastuuid-0.14.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/9a/30/ab407e2ec752aa541704ed8f93c11e2a5d92c168b8a755d818b74a3c5c2d/filelock-3.20.2-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a1/93/72b1736d68f03fda5fdf0f2180fb6caaae3894f1b854d006ac61ecc727ee/frozenlist-1.8.0-cp314-cp314-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/51/c7/b64cae5dba3a1b138d7123ec36bb5ccd39d39939f18454407e5468f4763f/fsspec-2025.12.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9c/f5/a4531f7fb8b4e2a60b94e39d5d924469b7a6988176b3422487be61fe2998/grpcio-1.76.0-cp314-cp314-macosx_11_0_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/5c/90/b0cbbd9efcc82816c58f31a34963071aa19fb792a212a5d9caf8e0fc3097/grpclib-0.4.9-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl
@@ -930,6 +930,7 @@ packages:
   - pytest>=8.0.0 ; extra == 'dev'
   - httpx>=0.27.0 ; extra == 'dev'
   requires_python: '>=3.11'
+  editable: true
 - pypi: https://files.pythonhosted.org/packages/4b/0c/0654233d7543ac8a50f4785f172430ddc97538ba418eb305d6e529d1a120/cbor2-5.8.0-cp314-cp314-macosx_11_0_arm64.whl
   name: cbor2
   version: 5.8.0
@@ -1629,10 +1630,10 @@ packages:
   version: 0.14.0
   sha256: a8a0dfea3972200f72d4c7df02c8ac70bad1bb4c58d7e0ec1e6f341679073a7f
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/9a/30/ab407e2ec752aa541704ed8f93c11e2a5d92c168b8a755d818b74a3c5c2d/filelock-3.20.2-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/b5/36/7fb70f04bf00bc646cd5bb45aa9eddb15e19437a28b8fb2b4a5249fac770/filelock-3.20.3-py3-none-any.whl
   name: filelock
-  version: 3.20.2
-  sha256: fbba7237d6ea277175a32c54bb71ef814a8546d8601269e1bfc388de333974e8
+  version: 3.20.3
+  sha256: 4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/8e/e8/a1185e236ec66c20afd72399522f142c3724c785789255202d27ae992818/frozenlist-1.8.0-cp314-cp314-macosx_10_13_x86_64.whl
   name: frozenlist
@@ -1649,10 +1650,10 @@ packages:
   version: 1.8.0
   sha256: cba69cb73723c3f329622e34bdbf5ce1f80c21c290ff04256cff1cd3c2036ed2
   requires_python: '>=3.9'
-- pypi: https://files.pythonhosted.org/packages/51/c7/b64cae5dba3a1b138d7123ec36bb5ccd39d39939f18454407e5468f4763f/fsspec-2025.12.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/01/c9/97cc5aae1648dcb851958a3ddf73ccd7dbe5650d95203ecb4d7720b4cdbf/fsspec-2026.1.0-py3-none-any.whl
   name: fsspec
-  version: 2025.12.0
-  sha256: 8bf1fe301b7d8acfa6e8571e3b1c3d158f909666642431cc78a1b7b4dbc5ec5b
+  version: 2026.1.0
+  sha256: cb76aa913c2285a3b49bdd5fc55b1d7c708d7208126b60f2eb8194fe1b4cbdcc
   requires_dist:
   - adlfs ; extra == 'abfs'
   - adlfs ; extra == 'adl'
@@ -1676,7 +1677,7 @@ packages:
   - dropbox ; extra == 'full'
   - dropboxdrivefs ; extra == 'full'
   - fusepy ; extra == 'full'
-  - gcsfs ; extra == 'full'
+  - gcsfs>2024.2.0 ; extra == 'full'
   - libarchive-c ; extra == 'full'
   - ocifs ; extra == 'full'
   - panel ; extra == 'full'
@@ -1684,7 +1685,7 @@ packages:
   - pyarrow>=1 ; extra == 'full'
   - pygit2 ; extra == 'full'
   - requests ; extra == 'full'
-  - s3fs ; extra == 'full'
+  - s3fs>2024.2.0 ; extra == 'full'
   - smbprotocol ; extra == 'full'
   - tqdm ; extra == 'full'
   - fusepy ; extra == 'fuse'
@@ -1718,6 +1719,7 @@ packages:
   - xarray ; extra == 'test-downstream'
   - adlfs ; extra == 'test-full'
   - aiohttp!=4.0.0a0,!=4.0.0a1 ; extra == 'test-full'
+  - backports-zstd ; python_full_version < '3.14' and extra == 'test-full'
   - cloudpickle ; extra == 'test-full'
   - dask ; extra == 'test-full'
   - distributed ; extra == 'test-full'
@@ -1753,7 +1755,6 @@ packages:
   - tqdm ; extra == 'test-full'
   - urllib3 ; extra == 'test-full'
   - zarr ; extra == 'test-full'
-  - zstandard ; python_full_version < '3.14' and extra == 'test-full'
   - tqdm ; extra == 'tqdm'
   requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/b8/14/bab308fc2c1b5228c3224ec2bf928ce2e4d21d8046c161e44a2012b5203e/greenlet-3.3.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl

--- a/src/canvas_chat/static/index.html
+++ b/src/canvas_chat/static/index.html
@@ -4,6 +4,23 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Canvas Chat</title>
+    <!-- Set base path dynamically for load balancer support -->
+    <script>
+        (function() {
+            const pathname = window.location.pathname;
+            let basePath = '';
+            if (pathname !== '/' && pathname !== '') {
+                if (pathname.endsWith('/')) {
+                    basePath = pathname;
+                } else {
+                    basePath = pathname.replace(/\/[^/]*$/, '') + '/';
+                }
+            }
+            const base = document.createElement('base');
+            base.href = basePath;
+            document.head.insertBefore(base, document.head.firstChild);
+        })();
+    </script>
     <link rel="stylesheet" href="/static/css/style.css">
     <!-- Marked.js for markdown rendering -->
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>

--- a/src/canvas_chat/static/js/app.js
+++ b/src/canvas_chat/static/js/app.js
@@ -509,7 +509,7 @@ class App {
      */
     async loadConfig() {
         try {
-            const response = await fetch('/api/config');
+            const response = await fetch(apiUrl('/api/config'));
             if (response.ok) {
                 const config = await response.json();
                 this.adminMode = config.adminMode || false;
@@ -1844,7 +1844,7 @@ class App {
 
         try {
             // Fetch URL content via backend
-            const response = await fetch('/api/fetch-url', {
+            const response = await fetch(apiUrl('/api/fetch-url'), {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ url })
@@ -1922,7 +1922,7 @@ class App {
 
         try {
             // Fetch PDF content via backend
-            const response = await fetch('/api/fetch-pdf', {
+            const response = await fetch(apiUrl('/api/fetch-pdf'), {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ url })
@@ -1998,7 +1998,7 @@ class App {
             const formData = new FormData();
             formData.append('file', file);
 
-            const response = await fetch('/api/upload-pdf', {
+            const response = await fetch(apiUrl('/api/upload-pdf'), {
                 method: 'POST',
                 body: formData
             });
@@ -3014,7 +3014,7 @@ df.head()
             }
 
             // Stream code generation
-            const response = await fetch('/api/generate-code', {
+            const response = await fetch(apiUrl('/api/generate-code'), {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(requestBody),
@@ -3572,7 +3572,7 @@ df.head()
             let contentData;
             if (hasExa) {
                 // Use Exa's content extraction API
-                const response = await fetch('/api/exa/get-contents', {
+                const response = await fetch(apiUrl('/api/exa/get-contents'), {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
@@ -3594,7 +3594,7 @@ df.head()
                 };
             } else {
                 // Use free Jina/direct fetch fallback
-                const response = await fetch('/api/fetch-url', {
+                const response = await fetch(apiUrl('/api/fetch-url'), {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({ url: url })
@@ -4096,7 +4096,7 @@ df.head()
                 temperature: 0.7
             });
 
-            const response = await fetch('/api/chat', {
+            const response = await fetch(apiUrl('/api/chat'), {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(requestBody),
@@ -4772,7 +4772,7 @@ df.head()
                 content
             });
 
-            const response = await fetch('/api/generate-title', {
+            const response = await fetch(apiUrl('/api/generate-title'), {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(requestBody)
@@ -4833,7 +4833,7 @@ df.head()
                 content: contentForSummary
             });
 
-            const response = await fetch('/api/generate-summary', {
+            const response = await fetch(apiUrl('/api/generate-summary'), {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(requestBody)

--- a/src/canvas_chat/static/js/chat.js
+++ b/src/canvas_chat/static/js/chat.js
@@ -75,7 +75,7 @@ class Chat {
      */
     async fetchModels() {
         try {
-            const response = await fetch('/api/models');
+            const response = await fetch(apiUrl('/api/models'));
             if (response.ok) {
                 this.models = await response.json();
                 return this.models;
@@ -94,7 +94,7 @@ class Chat {
      */
     async fetchProviderModels(provider, apiKey) {
         try {
-            const response = await fetch('/api/provider-models', {
+            const response = await fetch(apiUrl('/api/provider-models'), {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ provider, api_key: apiKey })
@@ -168,7 +168,7 @@ class Chat {
                 requestBody.base_url = baseUrl;
             }
 
-            const response = await fetch('/api/chat', {
+            const response = await fetch(apiUrl('/api/chat'), {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',
@@ -234,7 +234,7 @@ class Chat {
             requestBody.base_url = baseUrl;
         }
 
-        const response = await fetch('/api/chat', {
+        const response = await fetch(apiUrl('/api/chat'), {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -283,7 +283,7 @@ class Chat {
                 requestBody.base_url = baseUrl;
             }
 
-            const response = await fetch('/api/summarize', {
+            const response = await fetch(apiUrl('/api/summarize'), {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/src/canvas_chat/static/js/committee.js
+++ b/src/canvas_chat/static/js/committee.js
@@ -320,7 +320,7 @@ class CommitteeFeature {
         };
 
         try {
-            const response = await fetch('/api/committee', {
+            const response = await fetch(apiUrl('/api/committee'), {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({

--- a/src/canvas_chat/static/js/factcheck.js
+++ b/src/canvas_chat/static/js/factcheck.js
@@ -79,7 +79,7 @@ class FactcheckFeature {
                 console.log('[Factcheck] Refining vague input with context');
                 this.canvas.updateNodeContent(loadingNode.id, '🔄 **Refining query...**', true);
 
-                const refineResponse = await fetch('/api/refine-query', {
+                const refineResponse = await fetch(apiUrl('/api/refine-query'), {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(this.buildLLMRequest({
@@ -436,7 +436,7 @@ class FactcheckFeature {
                 try {
                     let response;
                     if (hasExa) {
-                        response = await fetch('/api/exa/search', {
+                        response = await fetch(apiUrl('/api/exa/search'), {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
                             body: JSON.stringify({
@@ -446,7 +446,7 @@ class FactcheckFeature {
                             })
                         });
                     } else {
-                        response = await fetch('/api/ddg/search', {
+                        response = await fetch(apiUrl('/api/ddg/search'), {
                             method: 'POST',
                             headers: { 'Content-Type': 'application/json' },
                             body: JSON.stringify({

--- a/src/canvas_chat/static/js/matrix.js
+++ b/src/canvas_chat/static/js/matrix.js
@@ -125,7 +125,7 @@ class MatrixFeature {
             context
         });
 
-        const response = await fetch('/api/parse-two-lists', {
+        const response = await fetch(apiUrl('/api/parse-two-lists'), {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(requestBody)
@@ -367,7 +367,7 @@ class MatrixFeature {
             }
 
             // Start streaming fill
-            const response = await fetch('/api/matrix/fill', fetchOptions);
+            const response = await fetch(apiUrl('/api/matrix/fill'), fetchOptions);
 
             if (!response.ok) {
                 throw new Error(`Failed to fill cell: ${response.statusText}`);

--- a/src/canvas_chat/static/js/research.js
+++ b/src/canvas_chat/static/js/research.js
@@ -96,7 +96,7 @@ class ResearchFeature {
             if (context && context.trim()) {
                 this.canvas.updateNodeContent(searchNode.id, `Refining search query...`, true);
 
-                const refineResponse = await fetch('/api/refine-query', {
+                const refineResponse = await fetch(apiUrl('/api/refine-query'), {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(this.buildLLMRequest({
@@ -117,7 +117,7 @@ class ResearchFeature {
             // Call appropriate search API based on provider
             let response;
             if (hasExa) {
-                response = await fetch('/api/exa/search', {
+                response = await fetch(apiUrl('/api/exa/search'), {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
@@ -127,7 +127,7 @@ class ResearchFeature {
                     })
                 });
             } else {
-                response = await fetch('/api/ddg/search', {
+                response = await fetch(apiUrl('/api/ddg/search'), {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
@@ -286,7 +286,7 @@ class ResearchFeature {
             if (context && context.trim()) {
                 this.canvas.updateNodeContent(nodeId, `**Research${providerLabel}:** ${instructions}\n\n*Refining research instructions...*`, true);
 
-                const refineResponse = await fetch('/api/refine-query', {
+                const refineResponse = await fetch(apiUrl('/api/refine-query'), {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(this.buildLLMRequest({
@@ -307,7 +307,7 @@ class ResearchFeature {
             // Call research API (SSE stream): Exa if configured, otherwise DDG fallback
             let response;
             if (hasExa) {
-                response = await fetch('/api/exa/research', {
+                response = await fetch(apiUrl('/api/exa/research'), {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
@@ -318,7 +318,7 @@ class ResearchFeature {
                     signal: abortController.signal
                 });
             } else {
-                response = await fetch('/api/ddg/research', {
+                response = await fetch(apiUrl('/api/ddg/research'), {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(this.buildLLMRequest({


### PR DESCRIPTION
## Summary

Adds support for deploying the app behind a load balancer or reverse proxy with a base path prefix (e.g., `https://some.url/thing/stuff/before/it/`).

## Changes

- **Added base path detection utilities** (`utils.js`):
  - `getBasePath()` - Detects the base path from the current URL
  - `apiUrl(endpoint)` - Helper function that prepends the base path to API endpoints

- **Updated all API fetch calls** to use `apiUrl()`:
  - `chat.js` - 4 calls updated
  - `research.js` - 5 calls updated  
  - `app.js` - 10 calls updated
  - `matrix.js` - 2 calls updated
  - `factcheck.js` - 3 calls updated
  - `committee.js` - 1 call updated

- **Updated HTML** (`index.html`):
  - Added a `<base>` tag that's set dynamically based on the current URL path
  - Ensures static assets (CSS, JS) load correctly with the base path

- **Updated ESLint config** (`.eslintrc.json`):
  - Added `apiUrl` and `getBasePath` to globals

## How It Works

- When deployed at the root (`/`), everything works as before
- When deployed behind a load balancer at `/thing/stuff/before/it/`:
  - The base path is automatically detected from `window.location.pathname`
  - All API calls are prefixed with the base path (e.g., `/thing/stuff/before/it/api/chat`)
  - Static assets are resolved relative to the base path via the `<base>` tag

## Testing

The app should now work correctly when deployed behind a load balancer or reverse proxy with any base path prefix.