### PR TITLE
fix(static)🐛: fix static file paths in index.html for local development

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -930,6 +930,7 @@ packages:
   - pytest>=8.0.0 ; extra == 'dev'
   - httpx>=0.27.0 ; extra == 'dev'
   requires_python: '>=3.11'
+  editable: true
 - pypi: https://files.pythonhosted.org/packages/4b/0c/0654233d7543ac8a50f4785f172430ddc97538ba418eb305d6e529d1a120/cbor2-5.8.0-cp314-cp314-macosx_11_0_arm64.whl
   name: cbor2
   version: 5.8.0

--- a/src/canvas_chat/static/index.html
+++ b/src/canvas_chat/static/index.html
@@ -8,7 +8,7 @@
     <script>
         (function() {
             const pathname = window.location.pathname;
-            let basePath = '';
+            let basePath = '/'; // Default to root for localhost
             if (pathname !== '/' && pathname !== '') {
                 if (pathname.endsWith('/')) {
                     basePath = pathname;
@@ -21,7 +21,7 @@
             document.head.insertBefore(base, document.head.firstChild);
         })();
     </script>
-    <link rel="stylesheet" href="/static/css/style.css">
+    <link rel="stylesheet" href="static/css/style.css">
     <!-- Marked.js for markdown rendering -->
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <!-- KaTeX for math rendering -->
@@ -38,7 +38,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/theme/monokai.css">
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/lib/codemirror.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/codemirror@5.65.16/mode/python/python.js"></script>
-    <script src="/static/js/codemirror-setup.js"></script>
+    <script src="static/js/codemirror-setup.js"></script>
 </head>
 <body>
     <!-- Top Toolbar -->
@@ -784,24 +784,24 @@
     </script>
 
     <!-- Scripts (loaded after Yjs is ready) -->
-    <script src="/static/js/sse.js"></script>
-    <script src="/static/js/search.js"></script>
-    <script src="/static/js/storage.js"></script>
-    <script src="/static/js/layout.js"></script>
-    <script src="/static/js/highlight-utils.js"></script>
-    <script src="/static/js/event-emitter.js"></script>
-    <script src="/static/js/graph-types.js"></script>
-    <script src="/static/js/crdt-graph.js"></script>
-    <script src="/static/js/node-protocols.js"></script>
-    <script src="/static/js/canvas.js"></script>
-    <script src="/static/js/chat.js"></script>
-    <script src="/static/js/utils.js"></script>
-    <script src="/static/js/flashcards.js"></script>
-    <script src="/static/js/committee.js"></script>
-    <script src="/static/js/matrix.js"></script>
-    <script src="/static/js/factcheck.js"></script>
-    <script src="/static/js/research.js"></script>
-    <script src="/static/js/pyodide-runner.js"></script>
-    <script src="/static/js/app.js"></script>
+    <script src="static/js/sse.js"></script>
+    <script src="static/js/search.js"></script>
+    <script src="static/js/storage.js"></script>
+    <script src="static/js/layout.js"></script>
+    <script src="static/js/highlight-utils.js"></script>
+    <script src="static/js/event-emitter.js"></script>
+    <script src="static/js/graph-types.js"></script>
+    <script src="static/js/crdt-graph.js"></script>
+    <script src="static/js/node-protocols.js"></script>
+    <script src="static/js/canvas.js"></script>
+    <script src="static/js/chat.js"></script>
+    <script src="static/js/utils.js"></script>
+    <script src="static/js/flashcards.js"></script>
+    <script src="static/js/committee.js"></script>
+    <script src="static/js/matrix.js"></script>
+    <script src="static/js/factcheck.js"></script>
+    <script src="static/js/research.js"></script>
+    <script src="static/js/pyodide-runner.js"></script>
+    <script src="static/js/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
- Update static file paths in index.html to use relative paths instead of absolute, improving compatibility when running locally.
- Set default basePath to '/' for localhost in the script that injects the base tag.
- Update pixi.lock to mark the main package as editable.