### PR TITLE
Fix: Include PDF node content in code generation context

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -1654,6 +1654,7 @@ packages:
   - pytest>=8.0.0 ; extra == 'dev'
   - httpx>=0.27.0 ; extra == 'dev'
   requires_python: '>=3.11'
+  editable: true
 - pypi: https://files.pythonhosted.org/packages/4b/0c/0654233d7543ac8a50f4785f172430ddc97538ba418eb305d6e529d1a120/cbor2-5.8.0-cp314-cp314-macosx_11_0_arm64.whl
   name: cbor2
   version: 5.8.0

--- a/src/canvas_chat/app.py
+++ b/src/canvas_chat/app.py
@@ -2940,13 +2940,18 @@ async def generate_code(request: GenerateCodeRequest, http_request: Request):
             )
             system_parts.append("\n" + "=" * 60)
 
-        # Add conversation context if available
+        # Add conversation context if available (PDF content, paper text, etc.)
+        # Note: We add this to system prompt to keep it separate from the
+        # code generation flow. This helps the model understand the broader
+        # context without confusing it with code-specific instructions.
         if request.context:
-            system_parts.append("\n\nConversation context:")
-            for msg in request.context[-5:]:  # Last 5 messages for context
+            system_parts.append("\n\nRelevant context from previous nodes:")
+            for msg in (
+                request.context
+            ):  # Include all context messages (don't truncate PDF content)
                 role = msg.role
-                content = msg.content[:200]  # Truncate long messages
-                system_parts.append(f"[{role}]: {content}")
+                content = msg.content
+                system_parts.append(f"\n[{role}]: {content}")
 
         # Add existing code context if modifying
         if request.existing_code:

--- a/src/canvas_chat/static/js/app.js
+++ b/src/canvas_chat/static/js/app.js
@@ -2650,9 +2650,9 @@ df.head()
         // Get ancestor context (conversation history)
         const ancestors = this.graph.getAncestors(nodeId);
         const ancestorContext = ancestors
-            .filter((n) => [NodeType.HUMAN, NodeType.AI, NodeType.NOTE].includes(n.type))
+            .filter((n) => [NodeType.HUMAN, NodeType.AI, NodeType.NOTE, NodeType.PDF].includes(n.type))
             .map((n) => ({
-                role: n.type === NodeType.HUMAN ? 'user' : 'assistant',
+                role: [NodeType.HUMAN, NodeType.PDF].includes(n.type) ? 'user' : 'assistant',
                 content: n.content,
             }));
 

--- a/src/canvas_chat/static/js/crdt-graph.js
+++ b/src/canvas_chat/static/js/crdt-graph.js
@@ -1176,7 +1176,7 @@ class CRDTGraph extends EventEmitter {
         const sorted = Array.from(allAncestors.values()).sort((a, b) => a.created_at - b.created_at);
 
         // Convert to message format for API
-        const userTypes = [NodeType.HUMAN, NodeType.HIGHLIGHT, NodeType.NOTE, NodeType.IMAGE];
+        const userTypes = [NodeType.HUMAN, NodeType.HIGHLIGHT, NodeType.NOTE, NodeType.IMAGE, NodeType.PDF];
         return sorted.map((node) => {
             const msg = {
                 role: userTypes.includes(node.type) ? 'user' : 'assistant',

--- a/tests/test_crdt_graph.js
+++ b/tests/test_crdt_graph.js
@@ -11,7 +11,7 @@ import {
     NodeType,
     TestGraph,
     createTestNode,
-    createTestEdge
+    createTestEdge,
 } from './test_setup.js';
 
 // ============================================================
@@ -94,13 +94,13 @@ test('Graph: getAncestors handles diamond pattern', () => {
     const ancestors = graph.getAncestors('D');
     // The algorithm may return duplicates for A (once through B, once through C)
     // but all A, B, C should be present
-    const ids = ancestors.map(n => n.id);
+    const ids = ancestors.map((n) => n.id);
     assertTrue(ids.includes('A'), 'Should include A');
     assertTrue(ids.includes('B'), 'Should include B');
     assertTrue(ids.includes('C'), 'Should include C');
     // B and C should appear (each once)
-    assertEqual(ids.filter(id => id === 'B').length, 1, 'B should appear once');
-    assertEqual(ids.filter(id => id === 'C').length, 1, 'C should appear once');
+    assertEqual(ids.filter((id) => id === 'B').length, 1, 'B should appear once');
+    assertEqual(ids.filter((id) => id === 'C').length, 1, 'C should appear once');
 });
 
 test('Graph: topologicalSort returns nodes in correct order', () => {
@@ -117,7 +117,7 @@ test('Graph: topologicalSort returns nodes in correct order', () => {
     graph.addEdge(createTestEdge('B', 'C'));
 
     const sorted = graph.topologicalSort();
-    const ids = sorted.map(n => n.id);
+    const ids = sorted.map((n) => n.id);
 
     assertEqual(ids, ['A', 'B', 'C']);
 });
@@ -137,7 +137,7 @@ test('Graph: topologicalSort handles multiple roots', () => {
     graph.addEdge(createTestEdge('B', 'C'));
 
     const sorted = graph.topologicalSort();
-    const ids = sorted.map(n => n.id);
+    const ids = sorted.map((n) => n.id);
 
     // A and B should come before C
     assertTrue(ids.indexOf('A') < ids.indexOf('C'), 'A should come before C');
@@ -210,6 +210,21 @@ test('Graph.resolveContext: sorts by created_at', () => {
     assertEqual(context[1].content, 'Second');
 });
 
+test('Graph.resolveContext: includes PDF nodes as user role', () => {
+    const graph = new TestGraph();
+    const pdfNode = { id: '1', type: NodeType.PDF, content: 'PDF content...', created_at: 1 };
+    const codeNode = { id: '2', type: NodeType.CODE, content: '# code', created_at: 2 };
+    graph.addNode(pdfNode);
+    graph.addNode(codeNode);
+    graph.addEdge(createTestEdge('1', '2'));
+
+    const context = graph.resolveContext(['2']);
+    assertEqual(context.length, 2);
+    assertEqual(context[0].role, 'user', 'PDF node should be mapped to user role');
+    assertEqual(context[0].content, 'PDF content...');
+    assertEqual(context[1].role, 'assistant', 'CODE node should be mapped to assistant role');
+});
+
 // ============================================================
 // Graph.getDescendants() tests
 // ============================================================
@@ -227,8 +242,14 @@ test('Graph.getDescendants returns all descendants in chain', () => {
 
     const descendants = graph.getDescendants('A');
     assertEqual(descendants.length, 2);
-    assertTrue(descendants.some(n => n.id === 'B'), 'Should include B');
-    assertTrue(descendants.some(n => n.id === 'C'), 'Should include C');
+    assertTrue(
+        descendants.some((n) => n.id === 'B'),
+        'Should include B'
+    );
+    assertTrue(
+        descendants.some((n) => n.id === 'C'),
+        'Should include C'
+    );
 });
 
 test('Graph.getDescendants returns multiple children', () => {
@@ -277,7 +298,10 @@ test('Graph.getDescendants handles diamond/merge structure', () => {
     const descendants = graph.getDescendants('A');
     // Should include B, C, D (D only once despite two paths)
     assertEqual(descendants.length, 3);
-    assertTrue(descendants.some(n => n.id === 'D'), 'Should include D');
+    assertTrue(
+        descendants.some((n) => n.id === 'D'),
+        'Should include D'
+    );
 });
 
 // ============================================================
@@ -592,7 +616,7 @@ test('Graph.getVisibleAncestorsThroughHidden returns both visible parents for me
     const result = graph.getVisibleAncestorsThroughHidden(nodeD.id);
     // Both parents B and C are visible
     assertEqual(result.length, 2);
-    const ids = result.map(n => n.id);
+    const ids = result.map((n) => n.id);
     assertTrue(ids.includes(nodeB.id), 'Should include B');
     assertTrue(ids.includes(nodeC.id), 'Should include C');
 });
@@ -625,7 +649,7 @@ test('Graph.getVisibleAncestorsThroughHidden traverses through hidden nodes', ()
     // C is hidden, its parent B is visible (collapsed)
     // E is visible
     assertEqual(result.length, 2);
-    const ids = result.map(n => n.id);
+    const ids = result.map((n) => n.id);
     assertTrue(ids.includes(nodeB.id), 'Should include B (through hidden C)');
     assertTrue(ids.includes(nodeE.id), 'Should include E (direct visible parent)');
 });


### PR DESCRIPTION
## Summary

Fixes an issue where PDF content was not being sent as context when using AI to generate code in code nodes. This resulted in generic code instead of code specific to the paper content.

## Problem

When a user:
1. Uploads or fetches a PDF (creates a PDF node with extracted text)
2. Selects the PDF node and creates a code node as a child
3. Uses "Generate with AI" to ask for code related to the paper

The AI would generate generic code (e.g., basic PDF parsing boilerplate) instead of code that analyzes the specific paper content.

## Root Cause

Two issues prevented PDF content from reaching the LLM:

### 1. Frontend: PDF nodes excluded from ancestor context
- `gatherCodeGenerationContext()` in `app.js` only included `[HUMAN, AI, NOTE]` types
- `resolveContext()` in `crdt-graph.js` only included `[HUMAN, HIGHLIGHT, NOTE, IMAGE]` as user types
- **Fix:** Added `NodeType.PDF` to both filters and updated role mapping

### 2. Backend: Context severely truncated
- `/api/generate-code` endpoint limited context to last 5 messages
- Each message was truncated to 200 characters (!)
- PDF papers typically contain thousands of characters
- **Fix:** Removed both the message limit and character truncation

## Changes

### Frontend (`app.js`)
```javascript
// Before: Only [HUMAN, AI, NOTE]
.filter((n) => [NodeType.HUMAN, NodeType.AI, NodeType.NOTE, NodeType.PDF].includes(n.type))
.map((n) => ({
    role: [NodeType.HUMAN, NodeType.PDF].includes(n.type) ? 'user' : 'assistant',
    content: n.content,
}))
```

### Frontend (`crdt-graph.js`)
```javascript
// Before: Only [HUMAN, HIGHLIGHT, NOTE, IMAGE]
const userTypes = [NodeType.HUMAN, NodeType.HIGHLIGHT, NodeType.NOTE, NodeType.IMAGE, NodeType.PDF];
```

### Backend (`app.py`)
```python
# Before: Limited to 5 messages, truncated to 200 chars
for msg in request.context[-5:]:
    content = msg.content[:200]

# After: All messages, no truncation
for msg in request.context:
    content = msg.content
```

## Testing

- ✅ All existing JavaScript tests pass
- ✅ Added new test in `test_crdt_graph.js` to ensure PDF nodes are included in context with correct role mapping
- ✅ Manual testing: PDF content now properly sent to code generation endpoint

## Impact

Users can now generate code that's specific to their uploaded papers, making the code generation feature much more useful for research workflows.