### PR TITLE
Fix blog post ordering with timestamps

### DIFF
--- a/docs/releases/posts/v0.1.0.md
+++ b/docs/releases/posts/v0.1.0.md
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-31
+date: 2025-12-31 15:18:58
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.1.md
+++ b/docs/releases/posts/v0.1.1.md
@@ -1,5 +1,5 @@
 ---
-date: 2025-12-31
+date: 2025-12-31 23:02:31
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.10.md
+++ b/docs/releases/posts/v0.1.10.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-02
+date: 2026-01-02 13:53:24
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.11.md
+++ b/docs/releases/posts/v0.1.11.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-02
+date: 2026-01-02 14:28:06
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.12.md
+++ b/docs/releases/posts/v0.1.12.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-02
+date: 2026-01-02 17:27:00
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.13.md
+++ b/docs/releases/posts/v0.1.13.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-02
+date: 2026-01-02 19:11:12
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.14.md
+++ b/docs/releases/posts/v0.1.14.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-02
+date: 2026-01-02 19:22:28
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.15.md
+++ b/docs/releases/posts/v0.1.15.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-02
+date: 2026-01-02 19:42:01
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.16.md
+++ b/docs/releases/posts/v0.1.16.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-03
+date: 2026-01-03 01:04:25
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.17.md
+++ b/docs/releases/posts/v0.1.17.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-03
+date: 2026-01-03 02:57:48
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.18.md
+++ b/docs/releases/posts/v0.1.18.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-03
+date: 2026-01-03 04:57:38
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.19.md
+++ b/docs/releases/posts/v0.1.19.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-03
+date: 2026-01-03 15:49:22
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.2.md
+++ b/docs/releases/posts/v0.1.2.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-01
+date: 2026-01-01 04:58:09
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.20.md
+++ b/docs/releases/posts/v0.1.20.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-03
+date: 2026-01-03 18:30:59
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.21.md
+++ b/docs/releases/posts/v0.1.21.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-04
+date: 2026-01-04 18:28:30
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.22.md
+++ b/docs/releases/posts/v0.1.22.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-04
+date: 2026-01-04 19:04:12
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.23.md
+++ b/docs/releases/posts/v0.1.23.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-04
+date: 2026-01-04 19:32:36
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.24.md
+++ b/docs/releases/posts/v0.1.24.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-04
+date: 2026-01-04 22:58:34
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.25.md
+++ b/docs/releases/posts/v0.1.25.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-05
+date: 2026-01-05 03:39:02
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.26.md
+++ b/docs/releases/posts/v0.1.26.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-05
+date: 2026-01-05 04:15:15
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.27.md
+++ b/docs/releases/posts/v0.1.27.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-05
+date: 2026-01-05 23:39:58
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.28.md
+++ b/docs/releases/posts/v0.1.28.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-06
+date: 2026-01-06 01:49:33
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.29.md
+++ b/docs/releases/posts/v0.1.29.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-06
+date: 2026-01-06 03:38:27
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.3.md
+++ b/docs/releases/posts/v0.1.3.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-01
+date: 2026-01-01 11:57:55
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.30.md
+++ b/docs/releases/posts/v0.1.30.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-06
+date: 2026-01-06 18:40:09
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.31.md
+++ b/docs/releases/posts/v0.1.31.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-06
+date: 2026-01-06 18:48:32
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.32.md
+++ b/docs/releases/posts/v0.1.32.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-06
+date: 2026-01-06 23:50:56
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.33.md
+++ b/docs/releases/posts/v0.1.33.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-07
+date: 2026-01-07 23:43:19
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.34.md
+++ b/docs/releases/posts/v0.1.34.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-08
+date: 2026-01-08 02:47:28
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.35.md
+++ b/docs/releases/posts/v0.1.35.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-07
+date: 2026-01-07 22:31:29
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.36.md
+++ b/docs/releases/posts/v0.1.36.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-08
+date: 2026-01-08 06:56:30
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.37.md
+++ b/docs/releases/posts/v0.1.37.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-08
+date: 2026-01-08 22:22:44
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.38.md
+++ b/docs/releases/posts/v0.1.38.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-09
+date: 2026-01-09 04:31:05
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.39.md
+++ b/docs/releases/posts/v0.1.39.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-09
+date: 2026-01-09 13:25:55
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.4.md
+++ b/docs/releases/posts/v0.1.4.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-01
+date: 2026-01-01 13:57:34
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.40.md
+++ b/docs/releases/posts/v0.1.40.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-09
+date: 2026-01-09 14:58:06
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.41.md
+++ b/docs/releases/posts/v0.1.41.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-09
+date: 2026-01-09 18:54:49
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.42.md
+++ b/docs/releases/posts/v0.1.42.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-09
+date: 2026-01-09 19:29:13
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.43.md
+++ b/docs/releases/posts/v0.1.43.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-10
+date: 2026-01-10 00:02:25
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.44.md
+++ b/docs/releases/posts/v0.1.44.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-10
+date: 2026-01-10 11:11:41
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.45.md
+++ b/docs/releases/posts/v0.1.45.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-10
+date: 2026-01-10 13:38:08
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.46.md
+++ b/docs/releases/posts/v0.1.46.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-10
+date: 2026-01-10 14:21:53
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.47.md
+++ b/docs/releases/posts/v0.1.47.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-10
+date: 2026-01-10 15:51:03
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.48.md
+++ b/docs/releases/posts/v0.1.48.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-10
+date: 2026-01-10 21:47:57
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.49.md
+++ b/docs/releases/posts/v0.1.49.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-10
+date: 2026-01-10 22:57:32
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.5.md
+++ b/docs/releases/posts/v0.1.5.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-01
+date: 2026-01-01 15:34:21
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.50.md
+++ b/docs/releases/posts/v0.1.50.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-10
+date: 2026-01-10 23:30:02
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.6.md
+++ b/docs/releases/posts/v0.1.6.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-01
+date: 2026-01-01 19:08:00
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.7.md
+++ b/docs/releases/posts/v0.1.7.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-01
+date: 2026-01-01 21:29:00
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.8.md
+++ b/docs/releases/posts/v0.1.8.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-01
+date: 2026-01-01 23:04:06
 categories:
   - Releases
 ---

--- a/docs/releases/posts/v0.1.9.md
+++ b/docs/releases/posts/v0.1.9.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-01-02
+date: 2026-01-02 01:09:09
 categories:
   - Releases
 ---

--- a/pixi.lock
+++ b/pixi.lock
@@ -1654,6 +1654,7 @@ packages:
   - pytest>=8.0.0 ; extra == 'dev'
   - httpx>=0.27.0 ; extra == 'dev'
   requires_python: '>=3.11'
+  editable: true
 - pypi: https://files.pythonhosted.org/packages/4b/0c/0654233d7543ac8a50f4785f172430ddc97538ba418eb305d6e529d1a120/cbor2-5.8.0-cp314-cp314-macosx_11_0_arm64.whl
   name: cbor2
   version: 5.8.0


### PR DESCRIPTION
## Summary

- Fixed blog post ordering issue where multiple releases on the same day showed in inconsistent order
- Updated `add_frontmatter.py` to extract full timestamps from git tags (including time)
- Modified script to update existing frontmatter instead of skipping files
- All 51 release notes now include timestamps in `YYYY-MM-DD HH:MM:SS` format

## Problem

When multiple releases occurred on the same day (e.g., v0.1.43-47 all on 2026-01-10), the blog posts displayed in reverse/inconsistent order because they all had the same date value without time information.

## Solution

The `add_frontmatter.py` script now:
1. Extracts full timestamps from git tags (not just the date)
2. Updates existing frontmatter instead of skipping files that already have it
3. Includes time in the date field so MkDocs Material's blog plugin can properly sort posts

## Verification

Built the docs and verified that releases now display in correct chronological order:
- v0.1.43: 2026-01-10 00:02:25
- v0.1.44: 2026-01-10 11:11:41
- v0.1.45: 2026-01-10 13:38:08
- v0.1.46: 2026-01-10 14:21:53
- v0.1.47: 2026-01-10 15:51:03