### PR TITLE
feat(ci): add PyPI version check before publishing

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -197,8 +197,45 @@ jobs:
               if: steps.check_release.outputs.already_released == 'false'
               run: uv build --sdist --wheel
 
-            - name: Publish package (trusted publishing)
+            - name: Check if version exists on PyPI
               if: steps.check_release.outputs.already_released == 'false'
+              id: check_pypi
+              shell: bash
+              run: |
+                  OUTPUT=$(uvx python << 'EOF'
+                  import sys
+                  import requests
+
+                  try:
+                      response = requests.get('https://pypi.org/pypi/canvas-chat/json', timeout=10)
+                      response.raise_for_status()
+                      data = response.json()
+                      version = '${{ env.version_number }}'
+
+                      if version in data.get('releases', {}):
+                          print(f'Version {version} already on PyPI - skipping publish')
+                          print('version_exists=true')
+                      else:
+                          print(f'Version {version} not on PyPI - safe to publish')
+                          print('version_exists=false')
+                  except Exception as e:
+                      print(f'Error checking PyPI: {e}')
+                      print('Proceeding with publish attempt (will fail if version exists)')
+                      print('version_exists=false')
+                  EOF
+                  )
+
+                  if echo "$OUTPUT" | grep -q "version_exists=true"; then
+                    echo "version_exists=true" >> $GITHUB_OUTPUT
+                  else
+                    echo "version_exists=false" >> $GITHUB_OUTPUT
+                  fi
+                  echo "PyPI check complete. version_exists=${{ steps.check_pypi.outputs.version_exists }}"
+
+            - name: Publish package (trusted publishing)
+              if: |
+                  steps.check_release.outputs.already_released == 'false' &&
+                  steps.check_pypi.outputs.version_exists != 'true'
               run: uv publish --trusted-publishing always
 
             - name: Push changes with tags


### PR DESCRIPTION
## Summary

Adds a PyPI version check safeguard to the auto-release workflow to prevent "file already exists" errors when a previous workflow run partially completed (e.g., published to PyPI but failed to create the GitHub release).

## Root Cause

The auto-release workflow can fail partway through execution (network issues, rate limits, etc.). If it successfully publishes to PyPI but fails before creating the GitHub release, the next run will attempt to publish the same version again, resulting in a `File already exists` error on PyPI.

This left the repository in an inconsistent state:
- PyPI had the version
- Local pyproject.toml was outdated
- GitHub release didn't exist
- Next workflow run would fail at the publish step

## Solution

Added a new step `Check if version exists on PyPI` that:
1. Runs after building the package
2. Queries PyPI's JSON API for the package
3. Checks if the current version number already exists in the `releases` object
4. Sets a workflow output `version_exists` (true/false)
5. The `Publish package` step now skips when `version_exists=true`

## Changes Breakdown

### Modified Files

- `.github/workflows/auto-release.yaml`: Added PyPI version check step

### Changes Made

1. New workflow step: `Check if version exists on PyPI`
   - Uses `uvx python` to query PyPI API
   - Sets output `version_exists` based on check result
   - Continues workflow even if check fails (let publish step handle errors)

2. Updated `Publish package` step condition:
   - Previously: `steps.check_release.outputs.already_released == 'false'`
   - Now: `steps.check_release.outputs.already_released == 'false' && steps.check_pypi.outputs.version_exists != 'true'`

## Tests

Pre-commit hooks ran successfully:
- `check yaml`: Passed
- `fix end of files`: Passed
- `trim trailing whitespace`: Passed
- `Update pixi.lock`: Passed

## Manual Testing

The safeguard will be tested when the next auto-release workflow runs on main.

## Benefits

- **Resilience**: Workflow can recover from partial failures
- **Clear messaging**: If version exists, skip publish instead of failing
- **Safety net**: Prevents duplicate version errors on PyPI
- **Self-healing**: Can recover from broken release state

## Related

- Fixes the issue encountered in #180 where version 0.1.74 was published to PyPI but workflow failed before creating the release and tag
- Related to git workflow documentation added in AGENTS.md
