### PR TITLE
fix(ci): add --with httpx to uvx command in PyPI version check

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -202,7 +202,7 @@ jobs:
               id: check_pypi
               shell: bash
               run: |
-                  OUTPUT=$(uvx python << 'EOF'
+                  OUTPUT=$(uvx --with httpx python << 'EOF'
                   import sys
                   import httpx
 


### PR DESCRIPTION
## Summary
Fixes the auto-release workflow failure by adding `--with httpx` to the `uvx python` command that checks if a version exists on PyPI.

## Root Cause
The workflow step "Check if version exists on PyPI" uses `uvx python` to run a Python script that imports `httpx`. However, `uvx` runs Python in an isolated environment without dependencies, causing an `ImportError` for the `httpx` module.

## Solution
Changed `uvx python` to `uvx --with httpx python` on line 205 of `.github/workflows/auto-release.yaml`. This ensures the `httpx` package is available in the isolated environment.

## Changes Breakdown
- `.github/workflows/auto-release.yaml`: Added `--with httpx` flag to uvx command in PyPI version check step

## Tests
Manual verification: The change follows the same pattern used for `pre-commit` in line 177, which also uses `uvx` with package flags.
