### PR TITLE
Api key prompt visibility

### DIFF
--- a/src/canvas_chat/static/js/app.js
+++ b/src/canvas_chat/static/js/app.js
@@ -3496,7 +3496,7 @@ class App {
         let emptyState = container.querySelector('.empty-state');
 
         if (this.graph.isEmpty()) {
-            const hasApiKeys = storage.hasAnyLLMApiKey();
+            const hasConfiguredProviders = this.adminMode ? this.adminModels.length > 0 : storage.hasAnyLLMApiKey();
 
             if (!emptyState) {
                 emptyState = document.createElement('div');
@@ -3504,12 +3504,18 @@ class App {
                 container.appendChild(emptyState);
             }
 
-            if (hasApiKeys) {
-                // User has API keys configured - show normal onboarding
+            if (hasConfiguredProviders) {
+                // Providers configured - show normal onboarding
                 emptyState.innerHTML = `
                     <h2>Start a conversation</h2>
                     <p>Type a message below to begin exploring ideas on the canvas.</p>
                     <p><kbd>Cmd/Ctrl+Click</kbd> to multi-select nodes</p>
+                `;
+            } else if (this.adminMode) {
+                // Admin mode with no models configured
+                emptyState.innerHTML = `
+                    <h2>No models configured</h2>
+                    <p>Contact your administrator to enable LLM models.</p>
                 `;
             } else {
                 // No API keys - guide user to settings first


### PR DESCRIPTION
Adjusts Canvas Chat empty state to reflect LLM provider configuration status.

Prevents users from being prompted to configure API keys when LLM providers are already available via admin configuration, and provides a specific message for admins when no models are configured.

---
<a href="https://cursor.com/background-agent?bcId=bc-454a6930-e970-432c-ad40-c2d32889bd41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-454a6930-e970-432c-ad40-c2d32889bd41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

