### PR TITLE
feat: configurable blocked domains for DuckDuckGo search and research

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -130,6 +130,18 @@ plugins:
     # - path: /absolute/path/to/plugin.js
 
 # ============================================================================
+# BLOCKED DOMAINS - DuckDuckGo search / research
+# ============================================================================
+#
+# Optional. Domains listed here are excluded from DuckDuckGo search and
+# research results (e.g. untrusted or low-quality sources).
+# Default when omitted: grokipedia.com
+#
+# blocked_domains:
+#   - grokipedia.com
+#   - spam.example.com
+
+# ============================================================================
 # FIELD REFERENCE
 # ============================================================================
 #
@@ -168,6 +180,12 @@ plugins:
 #   Paths can be absolute or relative to this config file.
 #   JavaScript plugins must be ES modules that import from '/static/js/'
 #   Python plugins must extend plugin base classes (e.g., UrlFetchHandlerPlugin)
+#
+# blocked_domains (optional, array of strings):
+#   Domains to exclude from DuckDuckGo search and research results.
+#   Matching is case-insensitive; subdomains are blocked (e.g. grokipedia.com
+#   blocks www.grokipedia.com). Default when omitted: [grokipedia.com]
+#   Users can add more blocked domains in Settings (stored in browser).
 #
 # ============================================================================
 # ENVIRONMENT VARIABLES

--- a/src/canvas_chat/app.py
+++ b/src/canvas_chat/app.py
@@ -998,6 +998,7 @@ async def get_config():
     return {
         "adminMode": config.admin_mode,
         "models": config.get_frontend_models() if config.admin_mode else [],
+        "blockedDomains": config.blocked_domains,
     }
 
 

--- a/src/canvas_chat/config.py
+++ b/src/canvas_chat/config.py
@@ -213,6 +213,9 @@ class AppConfig:
     models: list[ModelConfig] = field(default_factory=list)
     plugins: list[PluginConfig] = field(default_factory=list)
     admin_mode: bool = False
+    blocked_domains: list[str] = field(
+        default_factory=lambda: ["grokipedia.com"],
+    )
     _config_path: Path | None = None
 
     @classmethod
@@ -279,10 +282,16 @@ class AppConfig:
                             f"Registered Python plugin: {plugin_config.py_path.name}"
                         )
 
+        blocked_domains = data.get("blocked_domains", ["grokipedia.com"])
+        if not isinstance(blocked_domains, list):
+            blocked_domains = ["grokipedia.com"]
+        blocked_domains = [str(d).strip().lower() for d in blocked_domains if d]
+
         config = cls(
             models=models,
             plugins=plugins,
             admin_mode=admin_mode,
+            blocked_domains=blocked_domains,
             _config_path=config_path,
         )
 

--- a/src/canvas_chat/plugins/ddg_endpoints.py
+++ b/src/canvas_chat/plugins/ddg_endpoints.py
@@ -16,6 +16,7 @@ import json
 import logging
 import traceback
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 from pydantic import BaseModel
@@ -32,6 +33,9 @@ class DDGSearchRequest(BaseModel):
 
     query: str
     max_results: int = 10
+    blocked_domains: list[str] | None = (
+        None  # Optional override/merge with server config
+    )
 
 
 class DDGSearchResult(BaseModel):
@@ -59,6 +63,9 @@ class DDGResearchRequest(BaseModel):
     max_sources: int = 40
     max_queries_per_iteration: int = 4
     max_results_per_query: int = 10
+    blocked_domains: list[str] | None = (
+        None  # Optional override/merge with server config
+    )
 
 
 class DDGResearchSource(BaseModel):
@@ -147,6 +154,36 @@ def _max_sources_per_iteration(max_sources: int, max_iterations: int) -> int:
     )
 
 
+def is_domain_blocked(url: str, blocked_domains: list[str]) -> bool:
+    """Check if URL's domain matches any blocked domain pattern.
+
+    Matches exact domain or subdomains (e.g. "grokipedia.com" blocks
+    "www.grokipedia.com").
+
+    Args:
+        url: Full URL to check.
+        blocked_domains: List of domain names to block (e.g. ["grokipedia.com"]).
+
+    Returns:
+        True if the URL's domain is blocked, False otherwise.
+    """
+    if not url or not blocked_domains:
+        return False
+    try:
+        domain = urlparse(url).netloc.lower()
+        if not domain:
+            return False
+        for blocked in blocked_domains:
+            blocked_lower = blocked.strip().lower()
+            if not blocked_lower:
+                continue
+            if domain == blocked_lower or domain.endswith("." + blocked_lower):
+                return True
+        return False
+    except Exception:
+        return False
+
+
 # =============================================================================
 # Endpoint registration
 # =============================================================================
@@ -172,6 +209,17 @@ def register_endpoints(app: Any) -> None:
         try:
             from ddgs import DDGS
 
+            from canvas_chat.app import get_admin_config
+
+            config = get_admin_config()
+            server_blocked = config.blocked_domains or []
+            client_blocked = request.blocked_domains or []
+            effective_blocked = list(
+                dict.fromkeys(
+                    [d.strip().lower() for d in server_blocked + client_blocked if d]
+                )
+            )
+
             with DDGS() as ddgs:
                 results = list(
                     ddgs.text(request.query, max_results=request.max_results)
@@ -179,10 +227,14 @@ def register_endpoints(app: Any) -> None:
 
             formatted_results = []
             for result in results:
+                url = result.get("href", "")
+                if is_domain_blocked(url, effective_blocked):
+                    logger.debug("Filtered blocked domain: %s", url)
+                    continue
                 formatted_results.append(
                     DDGSearchResult(
                         title=result.get("title", "Untitled"),
-                        url=result.get("href", ""),
+                        url=url,
                         snippet=result.get("body", ""),
                     )
                 )
@@ -237,11 +289,24 @@ def register_endpoints(app: Any) -> None:
                 _llm_text,
                 fetch_url_directly,
                 fetch_url_via_jina,
+                get_admin_config,
             )
 
             try:
                 from ddgs import DDGS
 
+                config = get_admin_config()
+                server_blocked = config.blocked_domains or []
+                client_blocked = request.blocked_domains or []
+                effective_blocked = list(
+                    dict.fromkeys(
+                        [
+                            d.strip().lower()
+                            for d in server_blocked + client_blocked
+                            if d
+                        ]
+                    )
+                )
                 instructions = request.instructions.strip()
                 context = (request.context or "").strip()
 
@@ -353,6 +418,12 @@ def register_endpoints(app: Any) -> None:
                                     if not url:
                                         continue
                                     if url in url_to_result or url in seen_urls:
+                                        continue
+                                    if is_domain_blocked(url, effective_blocked):
+                                        logger.debug(
+                                            "Filtered blocked domain in research: %s",
+                                            url,
+                                        )
                                         continue
 
                                     title = (r.get("title") or "").lower()

--- a/src/canvas_chat/static/index.html
+++ b/src/canvas_chat/static/index.html
@@ -270,6 +270,24 @@
                         </div>
                     </div>
 
+                    <div class="settings-section">
+                        <h3>Blocked domains (web search)</h3>
+                        <p class="settings-note">
+                            Domains listed here are excluded from DuckDuckGo search and research results.
+                            Server default: <code id="blocked-domains-server-default">grokipedia.com</code>.
+                            Add more below, one domain per line.
+                        </p>
+                        <div class="api-key-group">
+                            <label for="blocked-domains">Additional blocked domains</label>
+                            <textarea
+                                id="blocked-domains"
+                                class="modal-text-input"
+                                rows="3"
+                                placeholder="spam.example.com&#10;untrusted-site.org"
+                            ></textarea>
+                        </div>
+                    </div>
+
                     <!-- Plugin settings sections will be injected here -->
                     <div id="plugin-settings-container"></div>
 

--- a/src/canvas_chat/static/js/app.js
+++ b/src/canvas_chat/static/js/app.js
@@ -92,6 +92,7 @@ class App {
         // Admin mode state (set by loadConfig)
         this.adminMode = false;
         this.adminModels = []; // Models configured by admin (only in admin mode)
+        this.serverBlockedDomains = []; // Blocked domains from config (merged with user list for DDG)
 
         // Feature flags (set by fetchFeatureFlags)
         this.copilotEnabled = true; // Default to enabled, updated after fetch
@@ -208,6 +209,7 @@ class App {
                 const config = await response.json();
                 this.adminMode = config.adminMode || false;
                 this.adminModels = config.models || [];
+                this.serverBlockedDomains = config.blockedDomains || [];
 
                 if (this.adminMode) {
                     console.log('%c[App] Admin mode enabled', 'color: #FF9800; font-weight: bold');
@@ -221,6 +223,7 @@ class App {
             console.warn('[App] Failed to load config, using normal mode:', error);
             this.adminMode = false;
             this.adminModels = [];
+            this.serverBlockedDomains = [];
         }
     }
 
@@ -4119,6 +4122,13 @@ class App {
         // Save flashcard strictness
         const strictness = document.getElementById('flashcard-strictness').value;
         storage.setFlashcardStrictness(strictness);
+
+        // Save blocked domains (web search)
+        const blockedDomainsText = document.getElementById('blocked-domains').value.trim();
+        const blockedDomains = blockedDomainsText
+            ? blockedDomainsText.split(/\n/).map((d) => d.trim()).filter(Boolean)
+            : [];
+        storage.saveBlockedDomains(blockedDomains);
 
         // Reload models to reflect newly configured API keys
         this.loadModels();

--- a/src/canvas_chat/static/js/modal-manager.js
+++ b/src/canvas_chat/static/js/modal-manager.js
@@ -395,6 +395,17 @@ class ModalManager {
 
         this.updateCopilotStatus();
 
+        // Load blocked domains (user additions only; server default shown in label)
+        const blockedDomains = storage.getBlockedDomains();
+        const blockedDomainsEl = document.getElementById('blocked-domains');
+        if (blockedDomainsEl) {
+            blockedDomainsEl.value = blockedDomains.join('\n');
+        }
+        const serverDefaultEl = document.getElementById('blocked-domains-server-default');
+        if (serverDefaultEl && this.app.serverBlockedDomains?.length) {
+            serverDefaultEl.textContent = this.app.serverBlockedDomains.join(', ');
+        }
+
         // Load base URL
         document.getElementById('base-url').value = storage.getBaseUrl() || '';
 

--- a/src/canvas_chat/static/js/plugins/research.js
+++ b/src/canvas_chat/static/js/plugins/research.js
@@ -5,11 +5,11 @@
  * Extends FeaturePlugin to integrate with the plugin architecture.
  */
 
-import { NodeType, EdgeType, createNode, createEdge } from '../graph-types.js';
-import { storage } from '../storage.js';
-import { readSSEStream, normalizeText } from '../sse.js';
-import { apiUrl } from '../utils.js';
 import { FeaturePlugin } from '../feature-plugin.js';
+import { EdgeType, NodeType, createEdge, createNode } from '../graph-types.js';
+import { normalizeText, readSSEStream } from '../sse.js';
+import { storage } from '../storage.js';
+import { apiUrl } from '../utils.js';
 
 /**
  * ResearchFeature - Handles search and research commands with Exa/DuckDuckGo.
@@ -33,6 +33,17 @@ class ResearchFeature extends FeaturePlugin {
      */
     async onLoad() {
         console.log('[ResearchFeature] Loaded');
+    }
+
+    /**
+     * Build effective blocked-domains list: server default (from config) + user additions (from Settings).
+     * Used when calling DuckDuckGo search and research so both config and UI blocklist apply.
+     * @returns {string[]}
+     */
+    getEffectiveBlockedDomains() {
+        const server = this._app?.serverBlockedDomains || [];
+        const user = storage.getBlockedDomains();
+        return [...new Set([...server, ...user])];
     }
 
     /**
@@ -132,6 +143,7 @@ class ResearchFeature extends FeaturePlugin {
                     body: JSON.stringify({
                         query: effectiveQuery,
                         max_results: 10,
+                        blocked_domains: this.getEffectiveBlockedDomains(),
                     }),
                 });
             }
@@ -354,14 +366,15 @@ class ResearchFeature extends FeaturePlugin {
                 response = await fetch(apiUrl('/api/ddg/research'), {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify(
-                        this.buildLLMRequest({
+                    body: JSON.stringify({
+                        ...this.buildLLMRequest({
                             instructions: effectiveInstructions,
                             context: selectedContext || null,
                             max_iterations: 4,
                             max_sources: 40,
-                        })
-                    ),
+                        }),
+                        blocked_domains: this.getEffectiveBlockedDomains(),
+                    }),
                     signal: abortController.signal,
                 });
             }

--- a/src/canvas_chat/static/js/storage.js
+++ b/src/canvas_chat/static/js/storage.js
@@ -76,6 +76,7 @@ const DB_NAME = 'canvas-chat';
 const DB_VERSION = 1;
 const SESSIONS_STORE = 'sessions';
 const COPILOT_AUTH_KEY = 'canvas-chat-copilot-auth';
+const BLOCKED_DOMAINS_KEY = 'canvas-chat-blocked-domains';
 
 /**
  *
@@ -512,6 +513,31 @@ class Storage {
     hasExaApiKey() {
         const key = this.getExaApiKey();
         return key && key.trim().length > 0;
+    }
+
+    /**
+     * Get user-configured blocked domains for web search (DuckDuckGo).
+     * Merged with server default (from /api/config) when calling DDG endpoints.
+     * @returns {string[]} - Array of domain names (e.g. ['spam.example.com'])
+     */
+    getBlockedDomains() {
+        const raw = localStorage.getItem(BLOCKED_DOMAINS_KEY);
+        if (!raw) return [];
+        try {
+            const arr = JSON.parse(raw);
+            return Array.isArray(arr) ? arr.filter((d) => typeof d === 'string' && d.trim()) : [];
+        } catch {
+            return [];
+        }
+    }
+
+    /**
+     * Save user-configured blocked domains for web search.
+     * @param {string[]} domains - Array of domain names
+     */
+    saveBlockedDomains(domains) {
+        const list = Array.isArray(domains) ? domains.map((d) => String(d).trim()).filter(Boolean) : [];
+        localStorage.setItem(BLOCKED_DOMAINS_KEY, JSON.stringify(list));
     }
 
     /**

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -135,6 +135,41 @@ def test_admin_config_load_empty_models_list(tmp_path):
 # --- AppConfig.disabled tests ---
 
 
+def test_admin_config_load_blocked_domains_default(tmp_path):
+    """Test blocked_domains defaults to grokipedia.com when not in YAML."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("""
+models:
+  - id: "openai/gpt-4o"
+    name: "GPT-4o"
+    apiKeyEnvVar: "OPENAI_API_KEY"
+""")
+    config = AppConfig.load(config_file, admin_mode=False)
+    assert config.blocked_domains == ["grokipedia.com"]
+
+
+def test_admin_config_load_blocked_domains_custom(tmp_path):
+    """Test blocked_domains loaded from YAML when provided."""
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text("""
+models:
+  - id: "openai/gpt-4o"
+    name: "GPT-4o"
+    apiKeyEnvVar: "OPENAI_API_KEY"
+blocked_domains:
+  - grokipedia.com
+  - spam.example.com
+""")
+    config = AppConfig.load(config_file, admin_mode=False)
+    assert config.blocked_domains == ["grokipedia.com", "spam.example.com"]
+
+
+def test_admin_config_empty_has_default_blocked_domains():
+    """Test AppConfig.empty() has default blocked_domains."""
+    config = AppConfig.empty()
+    assert "grokipedia.com" in config.blocked_domains
+
+
 def test_admin_config_disabled():
     """Test creating a disabled admin config."""
     config = AppConfig.empty()

--- a/tests/test_ddg_endpoints.py
+++ b/tests/test_ddg_endpoints.py
@@ -1,6 +1,11 @@
-"""Tests for DDG endpoints plugin (per-iteration cap and related logic)."""
+"""Tests for DDG endpoints (per-iteration cap, domain filtering, and related logic)."""
 
-from canvas_chat.plugins.ddg_endpoints import _max_sources_per_iteration
+from unittest.mock import patch
+
+from canvas_chat.plugins.ddg_endpoints import (
+    _max_sources_per_iteration,
+    is_domain_blocked,
+)
 
 
 class TestMaxSourcesPerIteration:
@@ -36,3 +41,108 @@ class TestMaxSourcesPerIteration:
         """When max_sources is divisible by max_iterations, result is exact."""
         assert _max_sources_per_iteration(60, 4) == 15
         assert _max_sources_per_iteration(12, 3) == 5  # 12/3=4, but min is 5
+
+
+class TestIsDomainBlocked:
+    """Unit tests for is_domain_blocked.
+
+    Ensures blocked domain filtering correctly matches exact domains and
+    subdomains so untrusted sources (e.g. Grokipedia) can be excluded.
+    """
+
+    def test_exact_domain_blocked(self):
+        """Exact domain match is blocked."""
+        assert is_domain_blocked("https://grokipedia.com/page", ["grokipedia.com"])
+        assert is_domain_blocked("https://grokipedia.com", ["grokipedia.com"])
+
+    def test_subdomain_blocked(self):
+        """Subdomains of blocked domain are blocked."""
+        assert is_domain_blocked(
+            "https://www.grokipedia.com/article", ["grokipedia.com"]
+        )
+        assert is_domain_blocked("https://sub.grokipedia.com/path", ["grokipedia.com"])
+
+    def test_domain_not_blocked(self):
+        """Other domains are not blocked."""
+        assert not is_domain_blocked("https://example.com/page", ["grokipedia.com"])
+        assert not is_domain_blocked(
+            "https://wikipedia.org/wiki/Test", ["grokipedia.com"]
+        )
+
+    def test_case_insensitive(self):
+        """Domain matching is case-insensitive."""
+        assert is_domain_blocked("https://GROKIPEDIA.COM/page", ["grokipedia.com"])
+        assert is_domain_blocked("https://www.Grokipedia.COM/", ["grokipedia.com"])
+        assert is_domain_blocked("https://grokipedia.com/", ["GROKIPEDIA.COM"])
+
+    def test_empty_url_or_blocklist(self):
+        """Empty URL or empty blocklist returns False."""
+        assert not is_domain_blocked("", ["grokipedia.com"])
+        assert not is_domain_blocked("https://grokipedia.com", [])
+        assert not is_domain_blocked("", [])
+
+    def test_multiple_blocked_domains(self):
+        """Any domain in the blocklist matches."""
+        blocklist = ["grokipedia.com", "spam.example.com"]
+        assert is_domain_blocked("https://grokipedia.com/p", blocklist)
+        assert is_domain_blocked("https://spam.example.com/p", blocklist)
+        assert not is_domain_blocked("https://trusted.example.com/p", blocklist)
+
+    def test_invalid_url_returns_false(self):
+        """Invalid or malformed URL does not raise; returns False."""
+        assert not is_domain_blocked("not-a-url", ["grokipedia.com"])
+
+
+class TestDdgSearchEndpointFiltersBlockedDomains:
+    """Integration tests: /api/ddg/search filters blocked domains."""
+
+    def test_blocked_domains_excluded_from_search_results(self):
+        """Results from blocked domains are not returned by /api/ddg/search."""
+        from fastapi.testclient import TestClient
+
+        from canvas_chat.app import app
+        from canvas_chat.config import AppConfig
+
+        mock_results = [
+            {
+                "title": "Good Source",
+                "href": "https://example.com/article",
+                "body": "Snippet",
+            },
+            {
+                "title": "Grokipedia",
+                "href": "https://www.grokipedia.com/page",
+                "body": "Snippet",
+            },
+            {
+                "title": "Another Good",
+                "href": "https://reliable.org/post",
+                "body": "Snippet",
+            },
+        ]
+
+        with (
+            patch("ddgs.DDGS") as mock_ddgs_class,
+            patch("canvas_chat.app.get_admin_config") as mock_config,
+        ):
+            mock_ddgs = mock_ddgs_class.return_value.__enter__.return_value
+            mock_ddgs.text.return_value = mock_results
+            mock_config.return_value = AppConfig.empty()
+            # AppConfig.empty() uses default blocked_domains = ["grokipedia.com"]
+            assert "grokipedia.com" in mock_config.return_value.blocked_domains
+
+            client = TestClient(app)
+            response = client.post(
+                "/api/ddg/search",
+                json={"query": "test query", "max_results": 10},
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["provider"] == "duckduckgo"
+        urls = [r["url"] for r in data["results"]]
+        assert "https://www.grokipedia.com/page" not in urls
+        assert "https://example.com/article" in urls
+        assert "https://reliable.org/post" in urls
+        assert len(data["results"]) == 2
+        assert data["num_results"] == 2


### PR DESCRIPTION
## Summary

Add a configurable domain blocklist so DuckDuckGo search and research results can exclude untrusted sources (e.g. Grokipedia). The blocklist is configurable via **config file** and **Settings UI**, and is applied to both `/api/ddg/search` and `/api/ddg/research`.

## Root cause / motivation

DuckDuckGo sometimes returns results from low-trust domains (e.g. Grokipedia). The app had no way to filter these. Users requested the ability to avoid such sources.

## Solution

- **Backend**: Config field `blocked_domains` (default: `["grokipedia.com"]`). Both DDG endpoints filter results by domain; request bodies can send additional `blocked_domains` that are merged with the server list.
- **Config**: `blocked_domains` in `config.yaml`; documented in `config.example.yaml`.
- **API**: `/api/config` returns `blockedDomains`. `DDGSearchRequest` and `DDGResearchRequest` accept optional `blocked_domains`.
- **UI**: Settings → "Blocked domains (web search)" shows server default and a textarea for additional domains (one per line), stored in localStorage.
- **Research plugin**: Builds effective list = server + user, sends it with DDG search and research requests.

## Changes breakdown

- **config.py**: `blocked_domains` on `AppConfig`, loaded from YAML with default `["grokipedia.com"]`.
- **ddg_endpoints.py**: `is_domain_blocked()` helper; merge server + request `blocked_domains`; filter in `/api/ddg/search` and `/api/ddg/research`.
- **app.py**: `/api/config` includes `blockedDomains`.
- **storage.js**: `getBlockedDomains()` / `saveBlockedDomains()` (localStorage).
- **app.js**: `serverBlockedDomains` from config; save blocked domains from Settings.
- **index.html**: Settings section "Blocked domains (web search)" with textarea.
- **modal-manager.js**: Load blocked domains and server default when opening Settings.
- **research.js**: `getEffectiveBlockedDomains()`; send `blocked_domains` with DDG search and research requests.
- **config.example.yaml**: Document `blocked_domains` and UI note.
- **Tests**: `is_domain_blocked` unit tests; config load tests for `blocked_domains`; integration test that `/api/ddg/search` filters blocked domains.

## Tests

- `pixi run pytest tests/test_ddg_endpoints.py tests/test_config.py tests/test_models.py` — 101 passed.

## Manual testing

1. Run app; use `/search` or `/research` without Exa key so DDG is used.
2. Confirm Grokipedia (or any URL on the blocklist) does not appear in results.
3. Settings → add a domain under "Additional blocked domains", save, run search again and confirm it is filtered.
4. With a config file that sets `blocked_domains: [grokipedia.com, spam.example.com]`, confirm server default is shown in Settings and both are applied.
