### PR TITLE
feat(cypress): slash command menu E2E tests + ESM config fix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -730,6 +730,7 @@ pixi run npx cypress run --browser electron --headless --spec cypress/e2e/matrix
 - `cypress/e2e/matrix_copy.cy.js` - Matrix copy-to-clipboard tests
 - `cypress/e2e/note_node.cy.js` - Note node tests
 - `cypress/e2e/settings_modal.cy.js` - Settings modal tests
+- `cypress/e2e/slash_command_menu.cy.js` - Slash command menu (open, filter, select) tests
 - `cypress/e2e/keyboard_interactions.cy.js` - Keyboard shortcut tests
 - `cypress/e2e/canvas_interactions.cy.js` - Canvas pan/zoom/select tests
 - `cypress/e2e/node_selection.cy.js` - Node selection behavior tests

--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,6 +1,6 @@
-const { defineConfig } = require('cypress');
+import { defineConfig } from 'cypress';
 
-module.exports = defineConfig({
+export default defineConfig({
     e2e: {
         baseUrl: 'http://127.0.0.1:7865',
         defaultCommandTimeout: 30000, // Increased from default 4000ms for AI tests

--- a/cypress/e2e/slash_command_menu.cy.js
+++ b/cypress/e2e/slash_command_menu.cy.js
@@ -1,0 +1,50 @@
+describe('Slash command menu', () => {
+    beforeEach(() => {
+        cy.clearLocalStorage();
+        cy.clearIndexedDB();
+        cy.visit('/');
+        cy.wait(1000); // App and feature registry init so /note etc. are available
+    });
+
+    it('opens and shows commands when typing /', () => {
+        cy.get('#chat-input').focus().type('/');
+
+        cy.get('.slash-command-menu').should('be.visible');
+        cy.get('.slash-command-menu .slash-command-item').should('have.length.at.least', 1);
+        cy.get('.slash-command-menu .slash-command-name').contains('/note').should('be.visible');
+        cy.get('.slash-command-menu .slash-command-name').contains('/matrix').should('be.visible');
+    });
+
+    it('filters commands when typing more (e.g. /no)', () => {
+        cy.get('#chat-input').focus().type('/no');
+
+        cy.get('.slash-command-menu').should('be.visible');
+        cy.get('.slash-command-menu .slash-command-name').contains('/note').should('be.visible');
+        // All visible command names should start with /no
+        cy.get('.slash-command-menu .slash-command-name').each(($el) => {
+            expect($el.text().toLowerCase().startsWith('/no')).to.be.true;
+        });
+    });
+
+    it('selects command with Enter, fills input, and send creates note node', () => {
+        cy.get('#chat-input').focus().type('/no');
+        cy.get('.slash-command-menu').should('be.visible');
+        // Cypress .type() doesn't support {tab}; trigger Tab keydown so menu selectCommand runs
+        cy.get('#chat-input').trigger('keydown', { key: 'Tab', keyCode: 9, which: 9 });
+
+        cy.get('#chat-input').should('have.value', '/note ');
+        cy.get('.slash-command-menu').should('not.be.visible');
+
+        cy.get('#chat-input').type('test content{enter}');
+        cy.get('.node').should('exist').and('be.visible').and('contain', 'test content');
+    });
+
+    it('Esc dismisses menu and leaves input unchanged', () => {
+        cy.get('#chat-input').focus().type('/');
+        cy.get('.slash-command-menu').should('be.visible');
+
+        cy.get('#chat-input').type('{esc}');
+        cy.get('.slash-command-menu').should('not.be.visible');
+        cy.get('#chat-input').should('have.value', '/');
+    });
+});


### PR DESCRIPTION
## Summary

Add Cypress E2E tests for the slash command autocomplete menu and fix Cypress config so it loads under the project's ESM setup.

## Changes

- **New:** `cypress/e2e/slash_command_menu.cy.js` – four specs:
  - Menu opens and shows commands when typing `/`
  - Menu filters when typing more (e.g. `/no`)
  - Selects command (Tab via keydown trigger), fills input, send creates note node
  - Esc dismisses menu and leaves input unchanged
- **Fix:** `cypress.config.js` – use ESM `import`/`export default` instead of `require`/`module.exports` so Cypress loads when `package.json` has `"type": "module"`.
- **Docs:** `AGENTS.md` – add `slash_command_menu.cy.js` to the E2E test list in the Testing section.

## Testing

- `pixi run npx cypress run --browser electron --headless --spec cypress/e2e/slash_command_menu.cy.js` – all four specs pass.
