### PR TITLE
feat(matrix): web search grounding, sources drawer, single /matrix command

### DIFF
--- a/cypress/e2e/matrix_web_search.cy.js
+++ b/cypress/e2e/matrix_web_search.cy.js
@@ -1,0 +1,93 @@
+/**
+ * E2E: Matrix web search (ground evaluations with web search).
+ * Single highest-priority test: create matrix with "Ground with web search" checked,
+ * fill one cell (mocked search + fill), assert Sources section appears.
+ *
+ * All LLM-backed API calls in this flow are mocked (no real Ollama/OpenAI/Exa):
+ * - /api/parse-two-lists (LLM parses rows/columns)
+ * - /api/refine-query (LLM refines search query)
+ * - /api/generate-summary (LLM summarizes node for zoom; runs after matrix create)
+ * - /api/matrix/fill (LLM generates cell content; mocked as SSE)
+ * - /api/ddg/search (non-LLM; mocked for deterministic results)
+ */
+describe('Matrix Web Search', () => {
+    beforeEach(() => {
+        cy.clearLocalStorage();
+        cy.clearIndexedDB();
+        cy.visit('/');
+        cy.wait(2000);
+
+        // LLM: parse rows/columns from context
+        cy.intercept('POST', '/api/parse-two-lists', {
+            statusCode: 200,
+            body: {
+                rows: ['Python', 'JavaScript'],
+                columns: ['Performance', 'Ease of Learning'],
+            },
+        }).as('parseTwoLists');
+
+        // LLM: refine search query (web grounding)
+        cy.intercept('POST', '/api/refine-query', {
+            statusCode: 200,
+            body: { refined_query: 'programming languages performance ease of learning' },
+        }).as('refineQuery');
+
+        // LLM: generate node summary (runs after matrix create)
+        cy.intercept('POST', '/api/generate-summary', {
+            statusCode: 200,
+            body: { summary: 'Matrix evaluation' },
+        }).as('generateSummary');
+
+        // Non-LLM: web search (DDG)
+        cy.intercept('POST', '/api/ddg/search', {
+            statusCode: 200,
+            body: {
+                results: [
+                    {
+                        title: 'Programming Languages Comparison',
+                        url: 'https://example.com/lang-comparison',
+                        snippet: 'Comparison of performance and ease of learning.',
+                    },
+                ],
+            },
+        }).as('webSearch');
+
+        // LLM: fill matrix cell (mocked as SSE)
+        cy.intercept('POST', '/api/matrix/fill', (req) => {
+            const content = `Grounded evaluation for ${req.body.row_item} vs ${req.body.col_item}.`;
+            const response = `event: message\ndata: ${content}\n\nevent: done\ndata: \n\n`;
+            req.reply({
+                statusCode: 200,
+                headers: { 'Content-Type': 'text/event-stream' },
+                body: response,
+            });
+        }).as('matrixFill');
+    });
+
+    it('shows Sources section after filling a cell when Ground with web search is checked', () => {
+        cy.get('#chat-input').type('/matrix Compare languages by performance and ease');
+        cy.get('#send-btn').click();
+        cy.wait('@parseTwoLists');
+        cy.get('#matrix-main-modal', { timeout: 10000 }).should('be.visible');
+
+        cy.get('#matrix-ground-with-web').check();
+
+        cy.get('#matrix-create-btn').click();
+        cy.get('#matrix-main-modal').should('not.be.visible');
+        cy.get('.node.matrix', { timeout: 10000 }).should('be.visible');
+
+        cy.get('.matrix-cell[data-row="0"][data-col="0"]').click();
+        cy.wait('@refineQuery', { timeout: 5000 });
+        cy.wait('@webSearch', { timeout: 5000 });
+        cy.wait('@matrixFill', { timeout: 5000 });
+
+        cy.get('.matrix-cell[data-row="0"][data-col="0"]').should('have.class', 'filled');
+        // Sources appear in the output panel (drawer); expand it to see content
+        cy.get('.output-panel-wrapper .code-output-toggle', { timeout: 5000 }).click();
+        cy.get('.output-panel-wrapper .matrix-sources-drawer', { timeout: 5000 }).should('be.visible');
+        cy.get('.output-panel-wrapper .matrix-sources-drawer-header').should('contain', 'Sources (1)');
+        cy.get('.output-panel-wrapper .matrix-source-link')
+            .should('have.attr', 'href', 'https://example.com/lang-comparison')
+            .and('contain', 'Programming Languages Comparison');
+    });
+});

--- a/src/canvas_chat/static/css/matrix.css
+++ b/src/canvas_chat/static/css/matrix.css
@@ -294,6 +294,34 @@
     color: white;
 }
 
+/* Matrix web grounding sources (drawer / output panel) */
+.matrix-sources-drawer {
+    padding: 8px 12px;
+    font-size: 12px;
+}
+
+.matrix-sources-drawer-header {
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 8px;
+}
+
+.matrix-sources-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.matrix-sources-list .matrix-source-link {
+    display: block;
+    color: var(--accent);
+    text-decoration: none;
+}
+
+.matrix-sources-list .matrix-source-link:hover {
+    text-decoration: underline;
+}
+
 /* Cell Node */
 .node.cell {
     background: var(--bg-primary);

--- a/src/canvas_chat/static/js/graph-types.js
+++ b/src/canvas_chat/static/js/graph-types.js
@@ -201,6 +201,8 @@
  * @property {Position} [position] - Initial position
  * @property {number} [width] - Custom width
  * @property {number} [height] - Custom height
+ * @property {boolean} [groundWithWeb] - Whether to ground cell evaluations with web search
+ * @property {Array<{title: string, url: string, snippet?: string}>} [webSearchResults] - Cached web search results for citations
  */
 
 // =============================================================================

--- a/src/canvas_chat/static/js/plugins/matrix.js
+++ b/src/canvas_chat/static/js/plugins/matrix.js
@@ -23,6 +23,12 @@ import { NodeRegistry } from '../node-registry.js';
 import { CancellableEvent } from '../plugin-events.js';
 import { streamSSEContent } from '../sse.js';
 import { apiUrl, buildMessagesForApi, escapeHtmlText } from '../utils.js';
+import {
+    appendWebContextToMessages,
+    deriveSearchQuery,
+    runWebSearch,
+} from '../web-grounding.js';
+import { formatSourcesSection } from './committee.js';
 
 // =============================================================================
 // Matrix Node Protocol
@@ -82,6 +88,37 @@ class MatrixNode extends BaseNode {
     }
 
     /**
+     * Whether this matrix has web-grounded sources to show in the output panel (drawer).
+     * @returns {boolean}
+     */
+    hasOutput() {
+        return !!(this.node.webSearchResults && this.node.webSearchResults.length > 0);
+    }
+
+    /**
+     * Render the Sources drawer content (same pattern as code node output panel).
+     * @param {Canvas} canvas
+     * @returns {string} HTML for the panel body
+     */
+    renderOutputPanel(canvas) {
+        const results = this.node.webSearchResults;
+        if (!results || results.length === 0) return '';
+
+        const links = results
+            .map(
+                (r, i) =>
+                    `<a href="${canvas.escapeHtml(r.url)}" target="_blank" rel="noopener noreferrer" class="matrix-source-link">${i + 1}. ${canvas.escapeHtml(r.title)}</a>`
+            )
+            .join('');
+
+        return `
+            <div class="matrix-sources-drawer">
+                <div class="matrix-sources-drawer-header">Sources (${results.length})</div>
+                <div class="matrix-sources-list">${links}</div>
+            </div>`;
+    }
+
+    /**
      * Get summary text for semantic zoom (shown when zoomed out)
      * @param {Canvas} _canvas
      * @returns {string}
@@ -105,7 +142,7 @@ class MatrixNode extends BaseNode {
      * @returns {string} HTML for the content portion only
      */
     renderContent(canvas) {
-        const { context, rowItems, colItems, cells, indexColWidth } = this.node;
+        const { context, rowItems, colItems, cells, indexColWidth, webSearchResults } = this.node;
 
         // Build table HTML with optional custom index column width
         const styleAttr = indexColWidth ? ` style="--index-col-width: ${indexColWidth}"` : '';
@@ -155,6 +192,7 @@ class MatrixNode extends BaseNode {
         }
         tableHtml += '</tbody></table>';
 
+        // Sources are shown in the output panel (drawer), not inline
         // Matrix-specific content: context bar at top, table, and internal actions at bottom
         return `
             <div class="matrix-context">
@@ -220,6 +258,10 @@ class MatrixNode extends BaseNode {
                 text += ` ${content} |`;
             }
             text += '\n';
+        }
+
+        if (this.node.webSearchResults?.length > 0) {
+            text += formatSourcesSection(this.node.webSearchResults);
         }
 
         return text;
@@ -631,6 +673,14 @@ class MatrixFeature extends FeaturePlugin {
                             ⚠️ Maximum 10 items per axis. Some items have been truncated.
                         </div>
 
+                        <div class="matrix-options-group">
+                            <label class="committee-checkbox-label">
+                                <input type="checkbox" id="matrix-ground-with-web" />
+                                <span class="checkbox-text">Ground evaluations with web search</span>
+                                <span class="checkbox-hint">Run a web search from the matrix context and use results to inform each cell evaluation.</span>
+                            </label>
+                        </div>
+
                         <div class="modal-actions">
                             <button id="matrix-cancel-btn" class="secondary-btn">Cancel</button>
                             <button id="matrix-create-btn" class="primary-btn">Create Matrix</button>
@@ -672,6 +722,14 @@ class MatrixFeature extends FeaturePlugin {
                                 <ul class="axis-items" id="edit-col-items"></ul>
                                 <button class="axis-add-btn" id="edit-add-col-btn">+ Add column</button>
                             </div>
+                        </div>
+
+                        <div class="matrix-options-group">
+                            <label class="committee-checkbox-label">
+                                <input type="checkbox" id="edit-matrix-ground-with-web" />
+                                <span class="checkbox-text">Ground evaluations with web search</span>
+                                <span class="checkbox-hint">Use web search results to inform cell evaluations when filling.</span>
+                            </label>
                         </div>
 
                         <div class="modal-actions">
@@ -921,8 +979,8 @@ class MatrixFeature extends FeaturePlugin {
         return [
             {
                 command: '/matrix',
-                description: 'Create a matrix for cross-product evaluation',
-                placeholder: 'Enter matrix context (e.g., "Compare programming languages by performance")',
+                description: 'Build a comparison table: pick rows and columns, then fill cells with AI',
+                placeholder: 'e.g. Compare languages by performance and ease of learning',
             },
         ];
     }
@@ -1232,8 +1290,16 @@ class MatrixFeature extends FeaturePlugin {
             };
         }
 
+        // Read "Ground with web search" from create modal
+        const createModal = this.modalManager.getPluginModal('matrix', 'create');
+        const groundWithWebCheckbox = createModal?.querySelector('#matrix-ground-with-web');
+        const groundWithWeb = groundWithWebCheckbox ? groundWithWebCheckbox.checked : false;
+
         // Create matrix node
-        const matrixNode = createMatrixNode(context, contextNodeIds, rowItems, colItems, { position });
+        const matrixNode = createMatrixNode(context, contextNodeIds, rowItems, colItems, {
+            position,
+            groundWithWeb,
+        });
 
         this.graph.addNode(matrixNode);
         this.canvas.panToNodeAnimated(matrixNode.id);
@@ -1345,19 +1411,57 @@ class MatrixFeature extends FeaturePlugin {
             });
             this.emit('matrix:cell:prompt', promptEvent);
 
+            // Optionally add web search context for grounding (same pattern as committee)
+            let messagesForRequest = promptEvent.data.messages;
+            const nodeForWeb = this.graph.getNode(nodeId);
+            if (nodeForWeb?.groundWithWeb) {
+                let searchResults = nodeForWeb.webSearchResults;
+                if (!searchResults || searchResults.length === 0) {
+                    try {
+                        const contextString = (nodeForWeb.contextNodeIds || [])
+                            .map((id) => {
+                                const n = this.graph.getNode(id);
+                                return n && n.content ? n.content : '';
+                            })
+                            .filter(Boolean)
+                            .join('\n\n');
+                        const model = this.modelPicker?.value ?? this.getModelPicker?.()?.value;
+                        const query = await deriveSearchQuery(
+                            nodeForWeb.context || '',
+                            contextString,
+                            this.buildLLMRequest.bind(this),
+                            model
+                        );
+                        searchResults = await runWebSearch(query);
+                        const currentNode = this.graph.getNode(nodeId);
+                        this.graph.updateNode(nodeId, {
+                            webSearchResults: searchResults,
+                            outputExpanded: false,
+                            outputPanelHeight: currentNode.outputPanelHeight ?? 200,
+                        });
+                    } catch (err) {
+                        console.warn('[MatrixFeature] Web grounding failed for cell fill:', err);
+                        searchResults = [];
+                    }
+                }
+                if (searchResults.length > 0) {
+                    messagesForRequest = appendWebContextToMessages(promptEvent.data.messages, searchResults);
+                }
+            }
+
             // Build request body, using custom prompt if provided by a plugin
             let requestBody;
             if (promptEvent.data.customPrompt) {
                 requestBody = this.buildLLMRequest({
                     custom_prompt: promptEvent.data.customPrompt,
-                    messages: promptEvent.data.messages,
+                    messages: messagesForRequest,
                 });
             } else {
                 requestBody = this.buildLLMRequest({
                     row_item: rowItem,
                     col_item: colItem,
                     context: context,
-                    messages: promptEvent.data.messages,
+                    messages: messagesForRequest,
                 });
             }
 
@@ -1435,6 +1539,9 @@ class MatrixFeature extends FeaturePlugin {
             });
 
             this.saveSession();
+
+            // Re-render matrix node so Sources section appears when webSearchResults was set
+            this.canvas.renderNode(this.graph.getNode(nodeId));
 
             // Extension hook: matrix:after:fill - notify plugins that cell fill completed
             this.emit('matrix:after:fill', {
@@ -1590,6 +1697,41 @@ class MatrixFeature extends FeaturePlugin {
             return;
         }
 
+        // If groundWithWeb and no cached results, run web search once and store on node
+        if (matrixNode.groundWithWeb) {
+            const existingResults = matrixNode.webSearchResults;
+            if (!existingResults || existingResults.length === 0) {
+                try {
+                    const contextString = (matrixNode.contextNodeIds || [])
+                        .map((id) => {
+                            const n = this.graph.getNode(id);
+                            return n && n.content ? n.content : '';
+                        })
+                        .filter(Boolean)
+                        .join('\n\n');
+                    const model = this.modelPicker?.value ?? this.getModelPicker?.()?.value;
+                    const query = await deriveSearchQuery(
+                        matrixNode.context || '',
+                        contextString,
+                        this.buildLLMRequest.bind(this),
+                        model
+                    );
+                    const searchResults = await runWebSearch(query);
+                    this.graph.updateNode(nodeId, {
+                        webSearchResults: searchResults,
+                        outputExpanded: false,
+                        outputPanelHeight: matrixNode.outputPanelHeight ?? 200,
+                    });
+                    if (searchResults.length > 0 && this.showToast) {
+                        this.showToast('Web search complete. Filling cells with grounded evaluations.');
+                    }
+                } catch (err) {
+                    console.warn('[MatrixFeature] Web grounding failed, proceeding without:', err);
+                    if (this.showToast) this.showToast('Web search failed. Proceeding without web context.');
+                }
+            }
+        }
+
         // Fill all cells in parallel - each cell handles its own tracking/cleanup
         const fillPromises = emptyCells.map(({ row, col }) => {
             return this.handleMatrixCellFill(nodeId, row, col).catch((err) => {
@@ -1651,6 +1793,11 @@ class MatrixFeature extends FeaturePlugin {
         editModal.querySelector('#edit-row-count').textContent = `${this._editMatrixData.rowItems.length} items`;
         editModal.querySelector('#edit-col-count').textContent = `${this._editMatrixData.colItems.length} items`;
 
+        const groundWithWebCheckbox = editModal.querySelector('#edit-matrix-ground-with-web');
+        if (groundWithWebCheckbox) {
+            groundWithWebCheckbox.checked = Boolean(matrixNode.groundWithWeb);
+        }
+
         this.modalManager.showPluginModal('matrix', 'edit');
     }
 
@@ -1707,11 +1854,16 @@ class MatrixFeature extends FeaturePlugin {
             }
         }
 
+        const editModal = this.modalManager.getPluginModal('matrix', 'edit');
+        const groundWithWebCheckbox = editModal?.querySelector('#edit-matrix-ground-with-web');
+        const groundWithWeb = groundWithWebCheckbox ? groundWithWebCheckbox.checked : false;
+
         // Update the matrix node
         this.graph.updateNode(nodeId, {
             rowItems,
             colItems,
             cells: newCells,
+            groundWithWeb,
         });
 
         // Re-render the node

--- a/src/canvas_chat/static/js/slash-command-menu.js
+++ b/src/canvas_chat/static/js/slash-command-menu.js
@@ -22,7 +22,7 @@ export function setFeatureRegistry(registry) {
 const BUILTIN_SLASH_COMMANDS = [
     { command: '/search', description: 'Search the web', placeholder: 'query' },
     { command: '/research', description: 'Deep research', placeholder: 'topic' },
-    { command: '/matrix', description: 'Create a comparison matrix', placeholder: 'context for matrix' },
+    // /matrix is provided by MatrixFeature plugin
     { command: '/committee', description: 'Consult multiple LLMs and synthesize', placeholder: 'question' },
     {
         command: '/factcheck',


### PR DESCRIPTION
## Summary

Adds optional web search grounding to the matrix feature (like committee), shows Sources in a slide-out drawer (like the code node output panel), consolidates the `/matrix` slash command to a single entry with a clearer description, and adds an E2E test.

## Root cause / motivation

- Matrix evaluations were not grounded with web search; users had no way to use current web info when filling cells.
- Sources were shown inline in the matrix node, taking space and competing with Edit/Fill All/Clear All.
- The slash command menu showed two `/matrix` entries (built-in + plugin) with vague descriptions.

## Solution

1. **Web search lifecycle**
   - Checkbox "Ground evaluations with web search" in Create Matrix and Edit Matrix modals; stored as `groundWithWeb` on the node.
   - When filling cells (single or Fill All), if `groundWithWeb`: run `deriveSearchQuery` + `runWebSearch` once, cache `webSearchResults` on the node, and pass `appendWebContextToMessages(messages, searchResults)` into the matrix fill request. No backend changes.

2. **Sources as drawer**
   - Matrix node implements `hasOutput()` and `renderOutputPanel(canvas)` when `webSearchResults.length > 0`. Sources are shown in the same output-panel (drawer) pattern as the code node: collapsed by default, user expands with ▼ to see links. Inline Sources block removed from main content.

3. **Single /matrix command**
   - Removed `/matrix` from `BUILTIN_SLASH_COMMANDS` in slash-command-menu.js so only the plugin’s command appears. Updated plugin description to: "Build a comparison table: pick rows and columns, then fill cells with AI" and a clearer placeholder.

4. **E2E**
   - New spec `matrix_web_search.cy.js`: mocks parse-two-lists, refine-query, generate-summary, ddg/search, matrix/fill; creates matrix with "Ground with web search" checked; fills one cell; expands drawer; asserts Sources (1) and link.

## Changes breakdown

- `src/canvas_chat/static/js/plugins/matrix.js`: web-grounding imports; Create/Edit modal checkboxes; `handleMatrixFillAll` / `handleMatrixCellFill` run search and augment messages; `MatrixNode.hasOutput()` / `renderOutputPanel()`; remove inline Sources from `renderContent`; re-render node after fill so drawer appears; `formatForClipboard` appends sources; set `outputExpanded: false` and `outputPanelHeight` when storing webSearchResults.
- `src/canvas_chat/static/js/graph-types.js`: `CreateMatrixOptions` extended with `groundWithWeb`, `webSearchResults`.
- `src/canvas_chat/static/js/slash-command-menu.js`: remove `/matrix` from built-in list (comment that plugin provides it).
- `src/canvas_chat/static/css/matrix.css`: styles for Sources drawer (matrix-sources-drawer, drawer header, list, links).
- `cypress/e2e/matrix_web_search.cy.js`: new E2E spec with all LLM/search mocks.

## Tests

- Matrix-related Cypress: `matrix_web_search.cy.js`, `matrix.cy.js`, `matrix_undo_redo.cy.js` — all 6 tests passing.
- Full Cypress run: 21/22 specs passing; single failure in `code_node.cy.js` (timeout on `.output-panel-wrapper[data-output-panel="true"]`), unrelated to this PR.
- JS unit tests: not modified; existing matrix/plugin tests remain valid.

## Manual testing

- Create matrix with "Ground evaluations with web search" checked; Fill one cell or Fill All; confirm Sources drawer appears under the matrix, expand to see links; copy matrix and confirm "Sources used (web grounding)" in pasted markdown.
- Edit matrix and toggle the web search checkbox; create matrix without the checkbox and confirm no drawer.
- Type `/ma` and confirm a single `/matrix` suggestion with the new description.
