### PR TITLE
CI: Switch to native Ollama for cache hits (fix tar permission errors)

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -51,23 +51,10 @@ jobs:
                   name: cypress-screenshots
                   path: cypress/screenshots
 
-    # Job 2: AI E2E Tests (with Ollama, slower)
+    # Job 2: AI E2E Tests (with native Ollama, slower)
     cypress-ai:
         name: AI E2E Tests (Ollama)
         runs-on: ubuntu-latest
-
-        services:
-            ollama:
-                image: ollama/ollama:latest
-                ports:
-                    - 11434:11434
-                options: >-
-                    --name ollama-service
-                    --volume /home/runner/.ollama:/root/.ollama
-                    --health-cmd "ollama list || exit 1"
-                    --health-interval 10s
-                    --health-timeout 5s
-                    --health-retries 5
 
         steps:
             - name: Checkout
@@ -85,64 +72,35 @@ jobs:
             - name: Install dependencies
               run: npm ci
 
+            - name: Cache Ollama model weights
+              id: cache-ollama-model
+              uses: actions/cache@v5
+              with:
+                  path: ~/.ollama
+                  key: ${{ runner.os }}-ollama-gemma3n-e4b
+                  restore-keys: |
+                      ${{ runner.os }}-ollama-gemma3n-e4b
+                      ${{ runner.os }}-ollama-gemma3n-
+
+            - name: Install Ollama
+              run: |
+                  curl -fsSL https://ollama.com/install.sh | sh
+                  sleep 5
+
             - name: Wait for Ollama to be healthy
               run: |
                   timeout 300 bash -c 'until curl -s http://localhost:11434/api/tags > /dev/null; do sleep 2; done'
                   echo "Ollama service is ready"
 
-            - name: Ensure Ollama cache directory exists
-              run: |
-                  # Ensure the directory exists and has correct permissions
-                  mkdir -p /home/runner/.ollama/models
-                  echo "Cache directory created/verified: /home/runner/.ollama/models"
-
-            - name: Cache Ollama model weights
-              id: cache-ollama-model
-              uses: actions/cache@v5
-              with:
-                  # Cache only the models subdirectory to avoid permission issues with other .ollama files
-                  # Models are stored in /root/.ollama/models inside the container
-                  # which maps to /home/runner/.ollama/models on the host via volume mount
-                  path: /home/runner/.ollama/models
-                  key: ollama-gemma3n-e4b
-                  restore-keys: |
-                      ollama-gemma3n-e4b
-                      ollama-gemma3n-
-
             - name: Check if model exists and pull if needed
               run: |
-                  # Check if model is already available in Ollama
                   MODEL_EXISTS=$(curl -s http://localhost:11434/api/tags | grep -o '"name":"gemma3n:e4b"' || echo "")
-
-                  if [ -z "$MODEL_EXISTS" ]; then
-                      if [ "${{ steps.cache-ollama-model.outputs.cache-hit }}" == "true" ]; then
-                          echo "Cache hit: Model files restored from cache"
-                          echo "Models directory size before pull: $(du -sh /home/runner/.ollama/models 2>/dev/null | cut -f1 || echo 'N/A')"
-                      else
-                          echo "Cache miss: Model not in cache (this is expected on first run or after cache expiry)"
-                      fi
-                      # Pull model (will use cached files if available, otherwise downloads)
-                      curl -sSf -X POST http://localhost:11434/api/pull -d '{"name":"gemma3n:e4b"}'
-                      echo "Model pull completed"
-
-                      # Wait for files to be written to disk
-                      sleep 3
-
-                      # Verify model is now available
-                      MODEL_EXISTS_AFTER=$(curl -s http://localhost:11434/api/tags | grep -o '"name":"gemma3n:e4b"' || echo "")
-                      if [ -z "$MODEL_EXISTS_AFTER" ]; then
-                          echo "Warning: Model pull completed but model not found in Ollama"
-                      else
-                          echo "Model verified in Ollama"
-                      fi
-
-                      # Show cache directory info for debugging (files written by container are visible on host)
-                      if [ -d "/home/runner/.ollama/models" ]; then
-                          echo "Models directory size after pull: $(du -sh /home/runner/.ollama/models | cut -f1)"
-                          echo "Cache will be saved automatically at end of job"
-                      fi
+                  if [ -n "$MODEL_EXISTS" ]; then
+                      echo "Model already available (cache hit), skipping pull"
                   else
-                      echo "Model already exists in Ollama, skipping pull"
+                      echo "Pulling gemma3n:e4b..."
+                      ollama pull gemma3n:e4b
+                      echo "Model pull completed"
                   fi
 
             - name: Run Cypress (AI tests only)

--- a/docs/how-to/run-ai-e2e-tests.md
+++ b/docs/how-to/run-ai-e2e-tests.md
@@ -129,19 +129,19 @@ The `.github/workflows/cypress-tests.yml` file has been updated with two paralle
     - Excludes AI tests with `excludeSpecPattern="**/*ai*.cy.js"`
     - Fast feedback for UI/interaction changes
 
-2. **cypress-ai**: Runs AI tests with Ollama service
-    - Uses Docker service for Ollama on port 11434
-    - Pulls `gemma3n:e4b` model on first run (cached in subsequent runs)
-    - Cache key: `ollama-gemma3n-e4b`
+2. **cypress-ai**: Runs AI tests with native Ollama
+    - Installs Ollama on the runner via official install script (no Docker)
+    - Caches `~/.ollama` so restores are runner-owned (avoids tar permission errors)
+    - Pulls `gemma3n:e4b` on cache miss; on hit, skips pull for faster runs
     - Runs only AI tests with `specPattern="cypress/e2e/**/*ai*.cy.js"`
 
 ### Model Caching
 
 Ollama model weights are cached in GitHub Actions to avoid repeated downloads (~7.5GB per run):
 
-- Cache path: `~/.ollama/models`
-- Cache key: `ollama-gemma3n-e4b`
-- Restore keys: `ollama-gemma3n-` (allows model updates)
+- Cache path: `~/.ollama` (native install; all files runner-owned)
+- Cache key: `${{ runner.os }}-ollama-gemma3n-e4b`
+- Restore keys: `${{ runner.os }}-ollama-gemma3n-` (allows model updates)
 - Cache expires: 7 days after last use (GitHub Actions default)
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

Switches the `cypress-ai` job from Docker Ollama to **native Ollama** on the runner so the cache restore succeeds (runner-owned `~/.ollama`) and we get real cache hits instead of tar permission errors.

Closes #225

## Root cause

- Ollama ran in Docker (root). Cache was saved with root-owned files under the mounted volume.
- Restore ran as the runner user; extracting root-owned files from the cache caused tar permission errors.
- Cache never effectively helped, so we always pulled the model and CI stayed slow.

## Solution

- Remove the `services: ollama:` Docker block from `cypress-ai`.
- Install Ollama on the runner via `curl -fsSL https://ollama.com/install.sh | sh`.
- Cache `~/.ollama` (key: `${{ runner.os }}-ollama-gemma3n-e4b`) so all files are runner-owned; restore then succeeds.
- Wait for Ollama (curl loop on `/api/tags`), then check for `gemma3n:e4b` and run `ollama pull gemma3n:e4b` only when missing (log "Model already available (cache hit)" when skipping).

## Changes breakdown

- **`.github/workflows/cypress-tests.yml`**: Removed Docker Ollama service; added cache step (path `~/.ollama`), install-Ollama step, existing wait step, and model check/pull using `ollama pull`.
- **`docs/how-to/run-ai-e2e-tests.md`**: Updated CI and model-caching sections to describe native Ollama and the new cache path/key.

## Verification

- On cache miss: job installs Ollama, pulls model, saves cache.
- On cache hit: restore succeeds (no tar permission errors), model present, pull skipped, faster run.
- Model name `gemma3n:e4b` unchanged; matches `ai_chat.cy.js` and `matrix.cy.js`.
