### PR TITLE
ci: Run Ollama as runner user so ~/.ollama cache is used

### DIFF
--- a/.github/workflows/cypress-tests.yml
+++ b/.github/workflows/cypress-tests.yml
@@ -85,6 +85,9 @@ jobs:
             - name: Install Ollama
               run: |
                   curl -fsSL https://ollama.com/install.sh | sh
+                  # Stop systemd service so we run Ollama as runner user and use ~/.ollama (cache path)
+                  sudo systemctl stop ollama || true
+                  nohup ollama serve > /tmp/ollama-serve.log 2>&1 &
                   sleep 5
 
             - name: Wait for Ollama to be healthy


### PR DESCRIPTION
## Summary

Fixes the native-Ollama CI cache so model weights are actually saved and restored. The install script starts Ollama as a systemd service (using `/var/lib/ollama` or `/root/.ollama`), but we cache `~/.ollama` — so the server never used the cache and we always pulled. This PR stops the systemd service and runs `ollama serve` as the runner user so it uses `~/.ollama` and cache hits work.

## Root cause

- After #227 we install Ollama via the official script, which starts the **systemd** `ollama` service.
- That service runs as the `ollama` user (or root) and stores models in `/var/lib/ollama` (or `/root/.ollama`), not in the runner’s `~/.ollama`.
- We cache and restore `~/.ollama`, so the server never reads from it; `ollama pull` writes to the service’s dir; and we save an empty `~/.ollama` at job end → every run is a cache miss and we always download ~7.5 GB.

## Solution

After installing Ollama:

1. Stop the systemd service: `sudo systemctl stop ollama || true`
2. Start Ollama as the runner user: `nohup ollama serve &` so it uses `$HOME/.ollama` (= `~/.ollama`)

Then the same process that serves the API uses the cached directory: restore populates `~/.ollama`, the server sees existing blobs (cache hit → skip pull), and on miss the pull writes to `~/.ollama` so the job’s cache save stores the model for the next run.

## Changes

- **`.github/workflows/cypress-tests.yml`** (cypress-ai job): In “Install Ollama”, add stop systemd + `nohup ollama serve &` after the install script.

## Verification

- Push and run CI: on a cache miss the job should pull once and save cache; on the next run, cache restore should succeed and logs should show “Model already available (cache hit), skipping pull” and a faster run.
