### PR TITLE
fix: remove duplicate escapeHtml method on App class

### DIFF
--- a/src/canvas_chat/static/js/app.js
+++ b/src/canvas_chat/static/js/app.js
@@ -4448,15 +4448,6 @@ class App {
         this.renderTagSlots();
     }
 
-    /**
-     *
-     * @param {string} text
-     * @returns {string}
-     */
-    escapeHtml(text) {
-        return escapeHtmlText(text);
-    }
-
     // --- Search Methods ---
 
     /**


### PR DESCRIPTION
## Summary
Remove the duplicate `escapeHtml` method on the App class. The same method was defined twice (around lines 2068 and 4456); the second definition overwrote the first. One definition is kept; the duplicate is removed.

## Root cause
`escapeHtml(text) { return escapeHtmlText(text); }` was added in two places on the App class during earlier changes. Only one definition is needed.

## Solution
Delete the second definition and its JSDoc block (previously before "// --- Search Methods ---"). The first definition (near other App helpers) remains; behavior is unchanged.

## Changes
- `src/canvas_chat/static/js/app.js`: Removed duplicate `escapeHtml` method and JSDoc (9 lines).

## Tests
- `pixi run test-js`: 75 tests passed.
