### PR TITLE
feat: matrix grounded pipeline, cell spinners, URL fetch fix, and tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -750,6 +750,8 @@ pixi run npx cypress run --browser electron --headless --spec cypress/e2e/matrix
 - `cypress/e2e/ai_chat.cy.js` - AI chat interaction tests
 - `cypress/e2e/matrix.cy.js` - Matrix creation and interaction tests
 - `cypress/e2e/matrix_undo_redo.cy.js` - Matrix undo/redo tests
+- `cypress/e2e/matrix_row_column_click.cy.js` - Matrix row/column header click (slice modal) tests
+- `cypress/e2e/matrix_fill_all_spinners.cy.js` - Matrix Fill All cell spinners (mocked, fast)
 - `cypress/e2e/matrix_copy.cy.js` - Matrix copy-to-clipboard tests
 - `cypress/e2e/note_node.cy.js` - Note node tests
 - `cypress/e2e/settings_modal.cy.js` - Settings modal tests

--- a/cypress/e2e/matrix_fill_all_spinners.cy.js
+++ b/cypress/e2e/matrix_fill_all_spinners.cy.js
@@ -1,0 +1,66 @@
+/**
+ * Matrix Fill All: cell spinners appear immediately and disappear when filled.
+ * Uses mocked APIs only (no real LLM) for fast runs.
+ */
+describe('Matrix Fill All spinners', () => {
+    beforeEach(() => {
+        cy.clearLocalStorage();
+        cy.clearIndexedDB();
+        cy.visit('/');
+        cy.wait(2000);
+
+        cy.intercept('POST', '/api/parse-two-lists', {
+            statusCode: 200,
+            body: {
+                rows: ['A', 'B'],
+                columns: ['X', 'Y'],
+            },
+        }).as('parseTwoLists');
+
+        // Reply with SSE after a short delay so we can assert spinners first
+        cy.intercept('POST', '/api/matrix/fill', (req) => {
+            const content = `${req.body.row_item} vs ${req.body.col_item}: done.`;
+            const response = `event: message\ndata: ${content}\n\nevent: done\ndata: \n\n`;
+            req.reply({
+                delay: 600,
+                statusCode: 200,
+                headers: { 'Content-Type': 'text/event-stream' },
+                body: response,
+            });
+        }).as('matrixFill');
+    });
+
+    it('shows spinners in all empty cells when Fill All is clicked', () => {
+        cy.get('#chat-input').type('/matrix Compare');
+        cy.get('#send-btn').click();
+        cy.wait('@parseTwoLists');
+        cy.get('#matrix-main-modal', { timeout: 10000 }).should('be.visible');
+        cy.get('#matrix-create-btn').click();
+        cy.get('.node.matrix', { timeout: 10000 }).should('be.visible');
+
+        // All 4 cells should be empty
+        cy.get('.node.matrix .matrix-cell.empty').should('have.length', 4);
+
+        // Click Fill All
+        cy.get('.node.matrix .matrix-fill-all-btn').click();
+
+        // Spinners should appear immediately in all empty cells
+        cy.get('.node.matrix .matrix-cell.filling', { timeout: 3000 }).should(
+            'have.length',
+            4
+        );
+
+        // Wait for all 4 fill requests (they run in parallel)
+        cy.wait('@matrixFill', { timeout: 5000 });
+        cy.wait('@matrixFill', { timeout: 5000 });
+        cy.wait('@matrixFill', { timeout: 5000 });
+        cy.wait('@matrixFill', { timeout: 5000 });
+
+        // All cells should be filled (spinners gone)
+        cy.get('.node.matrix .matrix-cell.filled', { timeout: 8000 }).should(
+            'have.length',
+            4
+        );
+        cy.get('.node.matrix .matrix-cell.filling').should('have.length', 0);
+    });
+});

--- a/cypress/e2e/matrix_row_column_click.cy.js
+++ b/cypress/e2e/matrix_row_column_click.cy.js
@@ -1,0 +1,79 @@
+describe('Matrix row and column header click', () => {
+    beforeEach(() => {
+        cy.clearLocalStorage();
+        cy.clearIndexedDB();
+        cy.visit('/');
+        cy.wait(2000); // Wait for plugins to load
+
+        // Mock parse-two-lists API to return deterministic 2x3 matrix
+        cy.intercept('POST', '/api/parse-two-lists', {
+            statusCode: 200,
+            body: {
+                rows: ['Python', 'JavaScript'],
+                columns: ['Ease of use', 'Ecosystem', 'Safety'],
+            },
+        }).as('parseTwoLists');
+
+        // Mock matrix/fill so we can fill one cell for non-empty slice content
+        cy.intercept('POST', '/api/matrix/fill', (req) => {
+            const key = `${req.body.row_item}-${req.body.col_item}`;
+            const content = key === 'Python-Ease of use' ? 'Great for beginners.' : 'Filled.';
+            const response = `event: message\ndata: ${content}\n\nevent: done\ndata: \n\n`;
+            req.reply({
+                statusCode: 200,
+                headers: { 'Content-Type': 'text/event-stream' },
+                body: response,
+            });
+        }).as('matrixFillStream');
+    });
+
+    it('clicking row header opens slice modal with row details', () => {
+        cy.get('#chat-input').type('/matrix Compare languages');
+        cy.get('#send-btn').click();
+        cy.wait('@parseTwoLists');
+        cy.get('#matrix-main-modal', { timeout: 10000 }).should('be.visible');
+        cy.get('#matrix-create-btn').click();
+        cy.get('.node.matrix', { timeout: 10000 }).should('be.visible');
+
+        // Fill cell (0,0) so row slice has content to assert
+        cy.get('.node.matrix .matrix-cell[data-row="0"][data-col="0"]').click();
+        cy.wait('@matrixFillStream', { timeout: 5000 });
+        cy.get('.node.matrix .matrix-cell[data-row="0"][data-col="0"]').should('have.class', 'filled');
+
+        // Click first row header (Python)
+        cy.get('.node.matrix .row-header[data-row="0"]').click();
+
+        // Slice modal should be visible with Row Details
+        cy.get('#matrix-slice-modal', { timeout: 5000 }).should('be.visible');
+        cy.get('#slice-title').should('have.text', 'Row Details');
+        cy.get('#slice-label').should('contain', 'Row');
+        cy.get('#slice-item').should('have.text', 'Python');
+        cy.get('#slice-content').should('contain', 'Ease of use');
+        cy.get('#slice-content').should('contain', 'Great for beginners');
+    });
+
+    it('clicking column header opens slice modal with column details', () => {
+        cy.get('#chat-input').type('/matrix Compare languages');
+        cy.get('#send-btn').click();
+        cy.wait('@parseTwoLists');
+        cy.get('#matrix-main-modal', { timeout: 10000 }).should('be.visible');
+        cy.get('#matrix-create-btn').click();
+        cy.get('.node.matrix', { timeout: 10000 }).should('be.visible');
+
+        // Fill cell (0,0) so column slice has at least one non-empty cell
+        cy.get('.node.matrix .matrix-cell[data-row="0"][data-col="0"]').click();
+        cy.wait('@matrixFillStream', { timeout: 5000 });
+        cy.get('.node.matrix .matrix-cell[data-row="0"][data-col="0"]').should('have.class', 'filled');
+
+        // Click first column header (Ease of use)
+        cy.get('.node.matrix .col-header[data-col="0"]').click();
+
+        // Slice modal should be visible with Column Details
+        cy.get('#matrix-slice-modal', { timeout: 5000 }).should('be.visible');
+        cy.get('#slice-title').should('have.text', 'Column Details');
+        cy.get('#slice-label').should('contain', 'Column');
+        cy.get('#slice-item').should('have.text', 'Ease of use');
+        cy.get('#slice-content').should('contain', 'Python');
+        cy.get('#slice-content').should('contain', 'Great for beginners');
+    });
+});

--- a/docs/releases/posts/v0.1.99.md
+++ b/docs/releases/posts/v0.1.99.md
@@ -1,0 +1,21 @@
+---
+date: 2026-02-22 14:12:54
+categories:
+  - Releases
+---
+
+# Version v0.1.99
+
+This release improves model ID validation by supporting the OpenRouter model ID format, refactors test helpers for consistency, and cleans up unused test utilities.
+
+## New Features
+
+- Add support for OpenRouter model ID format with three segments (openrouter/provider/model-name) and update UI hints and validation messages accordingly (e13684) (Eric Ma)
+
+## Bug Fixes
+
+- Refactor test helpers to use a single source of truth for model ID patterns, improving maintainability (fc9ec6) (Eric Ma)
+
+## Deprecations
+
+- Remove obsolete test helper `test-expire-auth.js` to streamline the codebase (7138a2) (Eric Ma)

--- a/pixi.lock
+++ b/pixi.lock
@@ -2145,8 +2145,8 @@ packages:
   requires_python: '>=3.9'
 - pypi: ./
   name: canvas-chat
-  version: 0.1.98
-  sha256: 6fb30c9ae428167d74027cedc44930e43d3dc5d120509d6e370e4bdbb33fa100
+  version: 0.1.99
+  sha256: 0ed1c2e4123f0b05120801028a8762ece3b74f7164c318f5dea8aa26da7d5604
   requires_dist:
   - fastapi>=0.115.0
   - uvicorn>=0.32.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-chat"
-version = "0.1.98"
+version = "0.1.99"
 description = "A visual, non-linear chat interface where conversations are nodes on an infinite canvas"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/canvas_chat/plugins/git_repo_handler.py
+++ b/src/canvas_chat/plugins/git_repo_handler.py
@@ -785,13 +785,14 @@ class GitRepoHandler(UrlFetchHandlerPlugin):
         return await self.fetch_selected_files(url, default_files)
 
 
-# Register git repository handler
+# Register git repository handler.
+# Only known Git hosting domains and git@ SSH URLs trigger clone; all other URLs
+# (e.g. blog posts, docs) fall through to normal web fetch and are not cloned.
 UrlFetchRegistry.register(
     id="git-repo",
     url_patterns=[
         r"^https?://(github|gitlab|bitbucket|gitea|codeberg)\.(com|org)/[\w\-\.]+/[\w\-\.]+(?:\.git)?/?$",
         r"^git@[\w\-\.]+:[\w\-\.]+/[\w\-\.]+(?:\.git)?$",
-        r"^https?://[\w\-\.]+/([\w\-\.]+/)+[\w\-\.]+(?:\.git)?/?$",
     ],
     handler=GitRepoHandler,
     priority=PRIORITY["BUILTIN"],

--- a/src/canvas_chat/static/css/matrix.css
+++ b/src/canvas_chat/static/css/matrix.css
@@ -269,6 +269,34 @@
     animation: spin 0.8s linear infinite;
 }
 
+/* Cell filling state: spinner + label from click until content arrives */
+.matrix-cell.filling {
+    cursor: wait;
+}
+
+.matrix-cell-filling {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    min-height: 100%;
+    padding: 8px;
+    color: var(--text-muted);
+    font-size: 11px;
+}
+
+.matrix-cell-spinner {
+    width: 20px;
+    height: 20px;
+    border-width: 2px;
+    flex-shrink: 0;
+}
+
+.matrix-cell-filling-text {
+    white-space: nowrap;
+}
+
 .matrix-actions {
     display: flex;
     gap: 4px;
@@ -298,6 +326,58 @@
 .matrix-sources-drawer {
     padding: 8px 12px;
     font-size: 12px;
+}
+
+.matrix-sources-drawer-title {
+    margin-bottom: 10px;
+    padding-bottom: 6px;
+    border-bottom: 1px solid var(--edge-color-light);
+}
+
+.matrix-sources-section {
+    margin-bottom: 12px;
+}
+
+.matrix-sources-section:last-child {
+    margin-bottom: 0;
+}
+
+.matrix-sources-section-header {
+    font-weight: 600;
+    color: var(--text-primary);
+    margin-bottom: 2px;
+}
+
+.matrix-sources-drawer-hint {
+    font-size: 11px;
+    color: var(--text-muted);
+    margin-bottom: 6px;
+}
+
+/* Progress state while fetching/summarizing (spinner + message) */
+.matrix-sources-drawer.matrix-web-progress {
+    display: flex;
+    align-items: center;
+    min-height: 48px;
+}
+
+.matrix-web-progress-line {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--text-primary);
+}
+
+.matrix-web-progress-spinner {
+    width: 20px;
+    height: 20px;
+    border-width: 2px;
+    flex-shrink: 0;
+}
+
+.matrix-web-progress-count {
+    font-weight: 600;
+    color: var(--accent);
 }
 
 .matrix-sources-drawer-header {

--- a/src/canvas_chat/static/js/crdt-graph.js
+++ b/src/canvas_chat/static/js/crdt-graph.js
@@ -562,16 +562,17 @@ class CRDTGraph extends EventEmitter {
                 const yTags = new Y.Array();
                 yTags.push(value);
                 yNode.set('tags', yTags);
-            } else if (key === 'cells' && value) {
-                // Matrix cells - store as Y.Map
-                const yCells = new Y.Map();
-                for (const [cellKey, cellValue] of Object.entries(value)) {
-                    const yCell = new Y.Map();
-                    yCell.set('content', cellValue.content);
-                    yCell.set('filled', cellValue.filled || false);
-                    yCells.set(cellKey, yCell);
-                }
-                yNode.set('cells', yCells);
+                } else if (key === 'cells' && value) {
+                    // Matrix cells - store as Y.Map
+                    const yCells = new Y.Map();
+                    for (const [cellKey, cellValue] of Object.entries(value)) {
+                        const yCell = new Y.Map();
+                        yCell.set('content', cellValue.content);
+                        yCell.set('filled', cellValue.filled || false);
+                        yCell.set('filling', cellValue.filling || false);
+                        yCells.set(cellKey, yCell);
+                    }
+                    yNode.set('cells', yCells);
             } else if (key === 'metadata' && value && typeof value === 'object') {
                 // Metadata object - store as Y.Map to preserve nested properties
                 const yMetadata = new Y.Map();
@@ -957,6 +958,7 @@ class CRDTGraph extends EventEmitter {
                         }
                         yCell.set('content', cellValue.content);
                         yCell.set('filled', cellValue.filled || false);
+                        yCell.set('filling', cellValue.filling || false);
                     }
                 } else if (key === 'metadata' && value && typeof value === 'object') {
                     // Metadata object - store as Y.Map to preserve nested properties
@@ -1409,6 +1411,35 @@ class CRDTGraph extends EventEmitter {
     // =========================================================================
 
     /**
+     * Build synthetic context string for a matrix node (context, labels, cells, source metadata).
+     * Cell contents already contain synthesized information from the grounded pipeline,
+     * so we only include source metadata (title/URL) rather than full fetched content.
+     * @param {Object} node - Matrix node
+     * @returns {string}
+     */
+    getMatrixContextString(node) {
+        const parts = [];
+        if (node.context) parts.push(node.context);
+        const rowItems = node.rowItems || [];
+        const colItems = node.colItems || [];
+        if (rowItems.length) parts.push(`Rows: ${rowItems.join(', ')}`);
+        if (colItems.length) parts.push(`Columns: ${colItems.join(', ')}`);
+        const cells = node.cells || {};
+        const cellEntries = Object.entries(cells)
+            .filter(([, c]) => c && c.content)
+            .map(([key, c]) => `${key}: ${c.content}`);
+        if (cellEntries.length) parts.push('Cells:\n' + cellEntries.join('\n'));
+        const results = node.webSearchResults || [];
+        if (results.length > 0) {
+            const sourceLines = results.map(
+                (r, i) => `[${i + 1}] ${r.title || ''} (${r.url || ''})`
+            );
+            parts.push('Web sources:\n' + sourceLines.join('\n'));
+        }
+        return parts.join('\n\n').trim() || '';
+    }
+
+    /**
      * Resolve context for one or more nodes
      * Returns messages in chronological order, deduplicated
      * @param {string[]} nodeIds
@@ -1445,9 +1476,11 @@ class CRDTGraph extends EventEmitter {
             NodeType.GIT_REPO,
         ];
         return sorted.map((node) => {
+            const content =
+                node.type === NodeType.MATRIX ? this.getMatrixContextString(node) : node.content;
             const msg = {
                 role: userTypes.includes(node.type) ? 'user' : 'assistant',
-                content: node.content,
+                content: content || '',
                 nodeId: node.id,
             };
             if (node.imageData) {

--- a/src/canvas_chat/static/js/plugins/matrix.js
+++ b/src/canvas_chat/static/js/plugins/matrix.js
@@ -26,6 +26,7 @@ import { apiUrl, buildMessagesForApi, escapeHtmlText } from '../utils.js';
 import {
     appendWebContextToMessages,
     deriveSearchQuery,
+    enrichSearchResultsWithContent,
     runWebSearch,
 } from '../web-grounding.js';
 import { formatSourcesSection } from './committee.js';
@@ -88,33 +89,76 @@ class MatrixNode extends BaseNode {
     }
 
     /**
-     * Whether this matrix has web-grounded sources to show in the output panel (drawer).
+     * Whether this matrix has output to show: web processing in progress or sources list.
      * @returns {boolean}
      */
     hasOutput() {
-        return !!(this.node.webSearchResults && this.node.webSearchResults.length > 0);
+        const hasProgress = this.node.webProcessingProgress != null;
+        const hasSources = !!(this.node.webSearchResults && this.node.webSearchResults.length > 0);
+        return hasProgress || hasSources;
     }
 
     /**
      * Render the Sources drawer content (same pattern as code node output panel).
+     * Shows progress (spinner + message) when web processing is running, otherwise sources list.
      * @param {Canvas} canvas
      * @returns {string} HTML for the panel body
      */
     renderOutputPanel(canvas) {
+        const progress = this.node.webProcessingProgress;
+        if (progress && progress.message) {
+            const msg = canvas.escapeHtml(progress.message);
+            const nOfM =
+                progress.total != null && progress.current != null
+                    ? ` <span class="matrix-web-progress-count">${progress.current} of ${progress.total}</span>`
+                    : '';
+            return `
+            <div class="matrix-sources-drawer matrix-web-progress">
+                <div class="matrix-web-progress-line">
+                    <span class="loading-spinner matrix-web-progress-spinner"></span>
+                    <span>${msg}${nOfM}</span>
+                </div>
+            </div>`;
+        }
+
         const results = this.node.webSearchResults;
         if (!results || results.length === 0) return '';
 
-        const links = results
-            .map(
-                (r, i) =>
-                    `<a href="${canvas.escapeHtml(r.url)}" target="_blank" rel="noopener noreferrer" class="matrix-source-link">${i + 1}. ${canvas.escapeHtml(r.title)}</a>`
-            )
-            .join('');
+        const summarized = results.filter((r) => r.content?.trim());
+        const snippetOnly = results.filter((r) => !r.content?.trim());
+        const total = results.length;
+        const summarizedCount = summarized.length;
+
+        const linkHtml = (list, startIndex) =>
+            list
+                .map(
+                    (r, i) =>
+                        `<a href="${canvas.escapeHtml(r.url)}" target="_blank" rel="noopener noreferrer" class="matrix-source-link">${startIndex + i + 1}. ${canvas.escapeHtml(r.title)}</a>`
+                )
+                .join('');
+
+        let body = '';
+        if (summarized.length > 0) {
+            body += `
+                <div class="matrix-sources-section">
+                    <div class="matrix-sources-drawer-header matrix-sources-section-header">Summarized (${summarized.length})</div>
+                    <div class="matrix-sources-drawer-hint">Full page fetched and used for cell evaluations.</div>
+                    <div class="matrix-sources-list">${linkHtml(summarized, 0)}</div>
+                </div>`;
+        }
+        if (snippetOnly.length > 0) {
+            body += `
+                <div class="matrix-sources-section">
+                    <div class="matrix-sources-drawer-header matrix-sources-section-header">Snippet only (${snippetOnly.length})</div>
+                    <div class="matrix-sources-drawer-hint">Could not fetch full page; only search snippet available.</div>
+                    <div class="matrix-sources-list">${linkHtml(snippetOnly, summarized.length)}</div>
+                </div>`;
+        }
 
         return `
             <div class="matrix-sources-drawer">
-                <div class="matrix-sources-drawer-header">Sources (${results.length})</div>
-                <div class="matrix-sources-list">${links}</div>
+                <div class="matrix-sources-drawer-header matrix-sources-drawer-title">Sources (${total} total${summarizedCount > 0 ? `, ${summarizedCount} summarized` : ''})</div>
+                ${body}
             </div>`;
     }
 
@@ -175,8 +219,16 @@ class MatrixNode extends BaseNode {
                 const cellKey = `${r}-${c}`;
                 const cell = cells[cellKey];
                 const isFilled = cell && cell.filled && cell.content;
+                const isFilling = cell && cell.filling && !(cell.content && cell.content.length > 0);
 
-                if (isFilled) {
+                if (isFilling) {
+                    tableHtml += `<td class="matrix-cell filling" data-row="${r}" data-col="${c}" title="Filling cell...">
+                        <div class="matrix-cell-filling">
+                            <span class="loading-spinner matrix-cell-spinner"></span>
+                            <span class="matrix-cell-filling-text">Filling...</span>
+                        </div>
+                    </td>`;
+                } else if (isFilled) {
                     tableHtml += `<td class="matrix-cell filled" data-row="${r}" data-col="${c}" title="Click to view details">
                         <div class="matrix-cell-content">${canvas.escapeHtml(cell.content)}</div>
                     </td>`;
@@ -1324,6 +1376,206 @@ class MatrixFeature extends FeaturePlugin {
         this.updateEmptyState();
     }
 
+    // --- Web Search Helpers ---
+
+    /**
+     * Update or clear web processing progress in the matrix node's output panel (drawer).
+     * Opens the drawer on first progress; subsequent calls only update panel content.
+     * @param {string} nodeId - Matrix node ID
+     * @param {{ message: string, current?: number, total?: number } | null} progress - Progress state, or null to clear
+     * @param {boolean} [openDrawer] - If true, set outputExpanded true and full render (for first show)
+     */
+    _updateWebProgress(nodeId, progress, openDrawer = false) {
+        const payload = { webProcessingProgress: progress };
+        if (openDrawer && progress) {
+            const node = this.graph.getNode(nodeId);
+            payload.outputExpanded = true;
+            payload.outputPanelHeight = node?.outputPanelHeight ?? 200;
+            this.graph.updateNode(nodeId, payload);
+            this.canvas.renderNode(this.graph.getNode(nodeId));
+            return;
+        }
+        this.graph.updateNode(nodeId, payload);
+        const updatedNode = this.graph.getNode(nodeId);
+        const panelWrapper = this.canvas.outputPanels?.get(nodeId);
+        if (panelWrapper) {
+            this.canvas.updateOutputPanelContent(nodeId, updatedNode);
+        }
+    }
+
+    /**
+     * Ensure web search results (enriched with full page content) are cached on a matrix node.
+     * If results already exist, returns them. Otherwise runs search, enriches, and stores.
+     * @param {string} nodeId - Matrix node ID
+     * @returns {Promise<Array<{title: string, url: string, snippet: string, content?: string}>>} Search results (possibly empty)
+     */
+    async _ensureWebSearchResults(nodeId) {
+        const node = this.graph.getNode(nodeId);
+        if (!node) return [];
+        const existing = node.webSearchResults;
+        if (existing && existing.length > 0) return existing;
+
+        this._updateWebProgress(
+            nodeId,
+            { message: 'Fetching web sources...' },
+            true
+        );
+        try {
+            const contextString = (node.contextNodeIds || [])
+                .map((id) => {
+                    const n = this.graph.getNode(id);
+                    return n && n.content ? n.content : '';
+                })
+                .filter(Boolean)
+                .join('\n\n');
+            const model = this.modelPicker?.value ?? this.getModelPicker?.()?.value;
+            const query = await deriveSearchQuery(
+                node.context || '',
+                contextString,
+                this.buildLLMRequest.bind(this),
+                model
+            );
+            let searchResults = await runWebSearch(query);
+            searchResults = await enrichSearchResultsWithContent(searchResults);
+            const currentNode = this.graph.getNode(nodeId);
+            this.graph.updateNode(nodeId, {
+                webSearchResults: searchResults,
+                webProcessingProgress: null,
+                outputExpanded: true,
+                outputPanelHeight: currentNode.outputPanelHeight ?? 200,
+            });
+            this._updateWebProgress(nodeId, null);
+            return searchResults;
+        } catch (err) {
+            this.graph.updateNode(nodeId, { webProcessingProgress: null });
+            this._updateWebProgress(nodeId, null);
+            throw err;
+        }
+    }
+
+    // --- Grounded Cell Fill Pipeline ---
+
+    /**
+     * Make a non-streaming LLM call via /api/chat and return the collected text.
+     * @param {Array<{role: string, content: string}>} messages - Chat messages
+     * @param {AbortSignal} [abortSignal] - Optional abort signal
+     * @returns {Promise<string>} Full response text
+     */
+    async _makeLLMCall(messages, abortSignal) {
+        const requestBody = this.buildLLMRequest({ messages });
+        const fetchOptions = {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(requestBody),
+        };
+        if (abortSignal) fetchOptions.signal = abortSignal;
+        const response = await fetch(apiUrl('/api/chat'), fetchOptions);
+        if (!response.ok) throw new Error(`LLM call failed: ${response.statusText}`);
+        let result = '';
+        await streamSSEContent(response, {
+            onContent: (_chunk, fullContent) => {
+                result = fullContent;
+            },
+            onDone: () => {},
+            onError: (err) => {
+                throw new Error(err);
+            },
+        });
+        return result;
+    }
+
+    /**
+     * Run the grounded cell-fill pipeline: generate a cell-specific summarization
+     * prompt, summarize each web source in parallel, and return the summaries
+     * formatted as context for the final synthesis call.
+     *
+     * @param {string} matrixContext - Overarching matrix context (e.g. "backend development")
+     * @param {string} rowItem - Row item (e.g. "Python")
+     * @param {string} colItem - Column item (e.g. "safety")
+     * @param {Array<{title: string, url: string, content?: string}>} webResults - Enriched search results
+     * @param {AbortSignal} [abortSignal] - Optional abort signal
+     * @param {(opts: { message: string, current?: number, total?: number }) => void} [onProgress] - Progress callback for drawer UI
+     * @returns {Promise<string>} Formatted summaries to use as grounding context
+     */
+    async _runGroundedPipeline(matrixContext, rowItem, colItem, webResults, abortSignal, onProgress) {
+        const sourcesWithContent = webResults.filter((r) => r.content?.trim());
+        if (sourcesWithContent.length === 0) return '';
+
+        const total = sourcesWithContent.length;
+        if (onProgress) onProgress({ message: 'Generating cell prompt...' });
+
+        // Step 1: Generate a cell-specific summarization prompt via LLM
+        const promptGenMessages = [
+            {
+                role: 'system',
+                content:
+                    'You are a prompt engineer. Output ONLY the summarization prompt, nothing else. ' +
+                    'The prompt should instruct an AI to extract information relevant to a specific evaluation criterion from a web page.',
+            },
+            {
+                role: 'user',
+                content:
+                    `Generate a concise summarization prompt for the following evaluation:\n` +
+                    `Overall comparison: ${matrixContext}\n` +
+                    `Item being evaluated: ${rowItem}\n` +
+                    `Criterion: ${colItem}\n\n` +
+                    `The prompt will be given to an AI along with a web page's content. ` +
+                    `It should guide the AI to extract and summarize ONLY the parts relevant to evaluating "${rowItem}" on "${colItem}" in the context of "${matrixContext}".`,
+            },
+        ];
+        const summarizationPrompt = await this._makeLLMCall(promptGenMessages, abortSignal);
+
+        if (onProgress) onProgress({ message: 'Summarizing sources...', current: 0, total });
+
+        // Step 2: Summarize each source in parallel, pairing each result with its source
+        let completed = 0;
+        const summaryPromises = sourcesWithContent.map((r) => {
+            const msgs = [
+                { role: 'system', content: summarizationPrompt },
+                {
+                    role: 'user',
+                    content: `Source: ${r.title}\nURL: ${r.url}\n\n${r.content}`,
+                },
+            ];
+            return this._makeLLMCall(msgs, abortSignal)
+                .then((summary) => {
+                    completed += 1;
+                    if (onProgress) {
+                        onProgress({
+                            message: 'Summarizing sources...',
+                            current: completed,
+                            total,
+                        });
+                    }
+                    return { summary, source: r };
+                })
+                .catch((err) => {
+                    if (err.name === 'AbortError') throw err;
+                    completed += 1;
+                    if (onProgress) {
+                        onProgress({
+                            message: 'Summarizing sources...',
+                            current: completed,
+                            total,
+                        });
+                    }
+                    console.warn(`[MatrixFeature] Failed to summarize source ${r.url}:`, err);
+                    return null;
+                });
+        });
+        const results = (await Promise.all(summaryPromises)).filter(Boolean);
+        if (results.length === 0) return '';
+
+        // Format summaries for the final synthesis step
+        const lines = ['Web-grounded source summaries:', ''];
+        results.forEach(({ summary, source }, i) => {
+            lines.push(`[${i + 1}] ${source.title} (${source.url})`);
+            lines.push(summary);
+            lines.push('');
+        });
+        return lines.join('\n').trim();
+    }
+
     // --- Matrix Cell Handlers ---
 
     /**
@@ -1397,6 +1649,12 @@ class MatrixFeature extends FeaturePlugin {
             this.canvas.showStopButton(nodeId);
         }
 
+        // Show spinner in this cell immediately (covers pipeline + streaming until first content)
+        const currentCells = matrixNode.cells || {};
+        const cellsWithFilling = { ...currentCells, [cellKey]: { content: '', filled: false, filling: true } };
+        this.graph.updateNode(nodeId, { cells: cellsWithFilling });
+        this.canvas.renderNode(this.graph.getNode(nodeId));
+
         try {
             // Extension hook: matrix:cell:prompt - allow plugins to customize the prompt/request
             const promptEvent = new CancellableEvent('matrix:cell:prompt', {
@@ -1411,41 +1669,55 @@ class MatrixFeature extends FeaturePlugin {
             });
             this.emit('matrix:cell:prompt', promptEvent);
 
-            // Optionally add web search context for grounding (same pattern as committee)
+            // Optionally add web search context via grounded pipeline (map-reduce summarization)
             let messagesForRequest = promptEvent.data.messages;
             const nodeForWeb = this.graph.getNode(nodeId);
             if (nodeForWeb?.groundWithWeb) {
-                let searchResults = nodeForWeb.webSearchResults;
-                if (!searchResults || searchResults.length === 0) {
-                    try {
-                        const contextString = (nodeForWeb.contextNodeIds || [])
-                            .map((id) => {
-                                const n = this.graph.getNode(id);
-                                return n && n.content ? n.content : '';
-                            })
-                            .filter(Boolean)
-                            .join('\n\n');
-                        const model = this.modelPicker?.value ?? this.getModelPicker?.()?.value;
-                        const query = await deriveSearchQuery(
-                            nodeForWeb.context || '',
-                            contextString,
-                            this.buildLLMRequest.bind(this),
-                            model
-                        );
-                        searchResults = await runWebSearch(query);
-                        const currentNode = this.graph.getNode(nodeId);
-                        this.graph.updateNode(nodeId, {
-                            webSearchResults: searchResults,
-                            outputExpanded: false,
-                            outputPanelHeight: currentNode.outputPanelHeight ?? 200,
-                        });
-                    } catch (err) {
-                        console.warn('[MatrixFeature] Web grounding failed for cell fill:', err);
-                        searchResults = [];
-                    }
+                let searchResults = [];
+                try {
+                    searchResults = await this._ensureWebSearchResults(nodeId);
+                } catch (err) {
+                    console.warn('[MatrixFeature] Web grounding failed for cell fill:', err);
                 }
                 if (searchResults.length > 0) {
-                    messagesForRequest = appendWebContextToMessages(promptEvent.data.messages, searchResults);
+                    const hasContent = searchResults.some((r) => r.content?.trim());
+                    if (hasContent) {
+                        let progressDrawerOpened = false;
+                        const onProgress = (opts) => {
+                            this._updateWebProgress(nodeId, opts, !progressDrawerOpened);
+                            if (!progressDrawerOpened) progressDrawerOpened = true;
+                        };
+                        try {
+                            const groundedContext = await this._runGroundedPipeline(
+                                context,
+                                rowItem,
+                                colItem,
+                                searchResults,
+                                abortController?.signal,
+                                onProgress
+                            );
+                            if (groundedContext) {
+                                messagesForRequest = [
+                                    ...promptEvent.data.messages,
+                                    { role: 'user', content: groundedContext },
+                                ];
+                            }
+                        } catch (err) {
+                            if (err.name === 'AbortError') throw err;
+                            console.warn('[MatrixFeature] Grounded pipeline failed, using snippets:', err);
+                            messagesForRequest = appendWebContextToMessages(
+                                promptEvent.data.messages,
+                                searchResults
+                            );
+                        } finally {
+                            this._updateWebProgress(nodeId, null);
+                        }
+                    } else {
+                        messagesForRequest = appendWebContextToMessages(
+                            promptEvent.data.messages,
+                            searchResults
+                        );
+                    }
                 }
             }
 
@@ -1524,7 +1796,7 @@ class MatrixFeature extends FeaturePlugin {
             const currentNode = this.graph.getNode(nodeId);
             const currentCells = currentNode?.cells || {};
             const oldCell = currentCells[cellKey] ? { ...currentCells[cellKey] } : { content: null, filled: false };
-            const newCell = { content: cellContent, filled: true };
+            const newCell = { content: cellContent, filled: true, filling: false };
             const updatedCells = { ...currentCells, [cellKey]: newCell };
             this.graph.updateNode(nodeId, { cells: updatedCells });
 
@@ -1557,10 +1829,23 @@ class MatrixFeature extends FeaturePlugin {
             // Don't log abort errors as failures
             if (err.name === 'AbortError') {
                 console.log(`Cell fill aborted: (${row}, ${col})`);
+                // Clear filling state so cell shows + again
+                const currentNode = this.graph.getNode(nodeId);
+                const currentCells = currentNode?.cells || {};
+                const cleared = { ...currentCells, [cellKey]: { content: null, filled: false, filling: false } };
+                this.graph.updateNode(nodeId, { cells: cleared });
+                this.canvas.renderNode(this.graph.getNode(nodeId));
                 return;
             }
             console.error('Failed to fill matrix cell:', err);
             alert(`Failed to fill cell: ${err.message}`);
+
+            // Clear filling state so cell shows + again
+            const currentNode = this.graph.getNode(nodeId);
+            const currentCells = currentNode?.cells || {};
+            const cleared = { ...currentCells, [cellKey]: { content: null, filled: false, filling: false } };
+            this.graph.updateNode(nodeId, { cells: cleared });
+            this.canvas.renderNode(this.graph.getNode(nodeId));
 
             // Extension hook: matrix:after:fill with error
             this.emit('matrix:after:fill', {
@@ -1632,7 +1917,8 @@ class MatrixFeature extends FeaturePlugin {
 
         const wrapped = wrapNode(matrixNode);
         const cellKey = `${action.row}-${action.col}`;
-        const updatedCells = { ...matrixNode.cells, [cellKey]: { ...action.oldCell } };
+        const restored = { ...action.oldCell, filling: false };
+        const updatedCells = { ...matrixNode.cells, [cellKey]: restored };
 
         // Update graph
         this.graph.updateNode(action.nodeId, { cells: updatedCells });
@@ -1697,38 +1983,26 @@ class MatrixFeature extends FeaturePlugin {
             return;
         }
 
-        // If groundWithWeb and no cached results, run web search once and store on node
+        // Show spinners in all empty cells immediately so user sees activity
+        const currentCells = matrixNode.cells || {};
+        const cellsWithFilling = { ...currentCells };
+        for (const { row, col } of emptyCells) {
+            const cellKey = `${row}-${col}`;
+            cellsWithFilling[cellKey] = { content: '', filled: false, filling: true };
+        }
+        this.graph.updateNode(nodeId, { cells: cellsWithFilling });
+        this.canvas.renderNode(this.graph.getNode(nodeId));
+
+        // If groundWithWeb, ensure search results are cached before filling cells
         if (matrixNode.groundWithWeb) {
-            const existingResults = matrixNode.webSearchResults;
-            if (!existingResults || existingResults.length === 0) {
-                try {
-                    const contextString = (matrixNode.contextNodeIds || [])
-                        .map((id) => {
-                            const n = this.graph.getNode(id);
-                            return n && n.content ? n.content : '';
-                        })
-                        .filter(Boolean)
-                        .join('\n\n');
-                    const model = this.modelPicker?.value ?? this.getModelPicker?.()?.value;
-                    const query = await deriveSearchQuery(
-                        matrixNode.context || '',
-                        contextString,
-                        this.buildLLMRequest.bind(this),
-                        model
-                    );
-                    const searchResults = await runWebSearch(query);
-                    this.graph.updateNode(nodeId, {
-                        webSearchResults: searchResults,
-                        outputExpanded: false,
-                        outputPanelHeight: matrixNode.outputPanelHeight ?? 200,
-                    });
-                    if (searchResults.length > 0 && this.showToast) {
-                        this.showToast('Web search complete. Filling cells with grounded evaluations.');
-                    }
-                } catch (err) {
-                    console.warn('[MatrixFeature] Web grounding failed, proceeding without:', err);
-                    if (this.showToast) this.showToast('Web search failed. Proceeding without web context.');
+            try {
+                const searchResults = await this._ensureWebSearchResults(nodeId);
+                if (searchResults.length > 0 && this.showToast) {
+                    this.showToast('Web search complete. Filling cells with grounded evaluations.');
                 }
+            } catch (err) {
+                console.warn('[MatrixFeature] Web grounding failed, proceeding without:', err);
+                if (this.showToast) this.showToast('Web search failed. Proceeding without web context.');
             }
         }
 
@@ -2007,12 +2281,13 @@ class MatrixFeature extends FeaturePlugin {
             cellContents: cellContents,
         };
 
-        // Populate and show modal
-        document.getElementById('slice-title').textContent = 'Column Details';
-        document.getElementById('slice-label').textContent = 'Column:';
-        document.getElementById('slice-item').textContent = colItem;
-        document.getElementById('slice-content').textContent = displayContent.trim();
-        document.getElementById('slice-modal').style.display = 'flex';
+        // Populate and show modal (same pattern as handleMatrixRowExtract)
+        const sliceModal = this.modalManager.getPluginModal('matrix', 'slice');
+        sliceModal.querySelector('#slice-title').textContent = 'Column Details';
+        sliceModal.querySelector('#slice-label').textContent = 'Column:';
+        sliceModal.querySelector('#slice-item').textContent = colItem;
+        sliceModal.querySelector('#slice-content').textContent = displayContent.trim();
+        this.modalManager.showPluginModal('matrix', 'slice');
     }
 
     /**

--- a/src/canvas_chat/static/js/web-grounding.js
+++ b/src/canvas_chat/static/js/web-grounding.js
@@ -92,8 +92,55 @@ export async function runWebSearch(query) {
 }
 
 /**
+ * Fetch full page content for a single URL via /api/fetch-url.
+ * @param {string} url - URL to fetch
+ * @returns {Promise<{title: string, content: string} | null>} Title and content, or null on failure
+ */
+export async function fetchUrlContent(url) {
+    try {
+        const response = await fetch(apiUrl('/api/fetch-url'), {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ url }),
+        });
+        if (!response.ok) return null;
+        const data = await response.json();
+        const content = data.content && typeof data.content === 'string' ? data.content.trim() : '';
+        if (!content) return null;
+        return {
+            title: data.title || '',
+            content,
+        };
+    } catch (err) {
+        console.warn('[web-grounding] fetchUrlContent failed for', url, err);
+        return null;
+    }
+}
+
+/**
+ * Enrich web search results with fetched page content (full text) for each URL.
+ * Fetches content in sequence to avoid overloading the server. On per-URL failure, keeps snippet only.
+ * @param {Array<{title: string, url: string, snippet: string}>} searchResults - Results from runWebSearch
+ * @returns {Promise<Array<{title: string, url: string, snippet: string, content?: string}>>} Same results with content added when fetch succeeds
+ */
+export async function enrichSearchResultsWithContent(searchResults) {
+    if (!searchResults || searchResults.length === 0) return searchResults;
+    const enriched = [];
+    for (const r of searchResults) {
+        const fetched = await fetchUrlContent(r.url);
+        if (fetched) {
+            enriched.push({ ...r, content: fetched.content });
+        } else {
+            enriched.push({ ...r });
+        }
+    }
+    return enriched;
+}
+
+/**
  * Append a single user message containing formatted web search results to the messages array.
- * Does not mutate the input array.
+ * Uses title/URL/snippet only. Full page content is handled by feature-specific pipelines
+ * (e.g. matrix grounded pipeline) to avoid clogging the context window.
  * @param {Array<{role: string, content: string}>} messages - Conversation messages
  * @param {Array<{title: string, url: string, snippet: string}>} searchResults - Web search results
  * @returns {Array<{role: string, content: string}>} New array with one additional user message
@@ -106,7 +153,9 @@ export function appendWebContextToMessages(messages, searchResults) {
         searchResults.forEach((r, i) => {
             lines.push(`[${i + 1}] ${r.title}`);
             lines.push(r.url);
-            if (r.snippet) lines.push(r.snippet);
+            if (r.snippet) {
+                lines.push(r.snippet);
+            }
             lines.push('');
         });
     }

--- a/tests/test_url_fetch_registry.py
+++ b/tests/test_url_fetch_registry.py
@@ -1,0 +1,35 @@
+"""Tests for URL fetch handler registry.
+
+Ensures URL patterns only match intended URLs (e.g. blog URLs are not treated as git).
+"""
+
+# Import so git handler registers its URL patterns
+from canvas_chat.plugins import git_repo_handler  # noqa: F401
+from canvas_chat.url_fetch_registry import UrlFetchRegistry
+
+
+class TestUrlFetchRegistryGitPatterns:
+    """Git handler must not match non-git URLs (e.g. blog posts)."""
+
+    def test_blog_like_url_does_not_match_git_handler(self):
+        """Blog/post URLs must not be treated as git repos (no clone)."""
+        url = "https://poovarasu.dev/news/python-fastapi-django-weekly-news-summary-31-03-2025-to-06-04-2025/"
+        handler = UrlFetchRegistry.find_handler(url)
+        assert handler is None, (
+            "Blog-like URL must not match git handler; "
+            "otherwise /api/fetch-url would clone instead of web fetch"
+        )
+
+    def test_github_url_matches_git_handler(self):
+        """Known git host URLs should still match for clone."""
+        url = "https://github.com/user/repo"
+        handler = UrlFetchRegistry.find_handler(url)
+        assert handler is not None
+        assert handler.get("id") == "git-repo"
+
+    def test_gitlab_url_matches_git_handler(self):
+        """GitLab URLs should match git handler."""
+        url = "https://gitlab.com/group/project"
+        handler = UrlFetchRegistry.find_handler(url)
+        assert handler is not None
+        assert handler.get("id") == "git-repo"

--- a/uv.lock
+++ b/uv.lock
@@ -335,7 +335,7 @@ wheels = [
 
 [[package]]
 name = "canvas-chat"
-version = "0.1.98"
+version = "0.1.99"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

Matrix web grounding improvements (summarize-then-synthesize pipeline, cell spinners, progress/sources drawer), URL fetch fix so blog-like URLs are not cloned as git repos, and new fast tests (Cypress + Python).

## Changes

### Matrix
- **Grounded cell-fill pipeline**: Instead of dumping full page content into one LLM call, we now (1) generate a cell-specific summarization prompt, (2) summarize each web source in parallel with that prompt, (3) pass the N summaries to the final synthesis call. Reduces context clogging.
- **Per-cell and Fill All spinners**: Cells show a spinner (`.filling`) from the moment you click + or Fill All until content arrives. `filling` is persisted in the CRDT (fix: it was not stored before, so spinners never appeared after re-render).
- **Sources drawer**: Two sections—**Summarized (N)** (full page fetched and used) and **Snippet only (M)** (fetch failed)—with header "Sources (total, N summarized)". Clarifies why N ≠ total.
- **Web progress in drawer**: Progress messages: "Fetching web sources...", "Generating cell prompt...", "Summarizing sources... N of M". Drawer opens automatically during fetch/pipeline.
- **Shared helper**: `_ensureWebSearchResults(nodeId)` deduplicates fetch+enrich logic used by single-cell fill and Fill All.
- **Pipeline fix**: Summary/source pairing in `_runGroundedPipeline` fixed so failed summaries do not misalign with sources.

### URL fetch
- **Git handler**: Removed the third URL pattern that matched any host with two path segments. Blog URLs (e.g. `https://poovarasu.dev/news/article-name/`) were incorrectly matched and triggered git clone. Now only known Git hosts (GitHub, GitLab, Bitbucket, Gitea, Codeberg) and `git@` SSH URLs trigger clone; all others use normal web fetch.

### Web grounding
- **appendWebContextToMessages**: Uses title/URL/snippet only. Full page content is handled by the matrix pipeline only.
- **enrichSearchResultsWithContent**: Still used by the matrix pipeline to fetch full content before per-source summarization.

### Tests
- **Cypress** (mocked, fast):
  - `matrix_fill_all_spinners.cy.js`: Fill All shows spinners in all cells, then all become filled.
  - `matrix_row_column_click.cy.js`: Row and column header clicks open slice modal with correct title/content.
- **Python**: `tests/test_url_fetch_registry.py` — blog-like URL does not match git handler; GitHub/GitLab URLs still match.

### Docs
- **AGENTS.md**: Added `matrix_fill_all_spinners.cy.js` to E2E test list.

## Manual testing

- Matrix: Create matrix with "ground with web" on, run Fill All or single cell; confirm drawer shows progress then sources (Summarized / Snippet only).
- URL fetch: `/fetch https://poovarasu.dev/news/...` (or similar blog URL) should return web content, not clone.

## Tests

- `pixi run test` — 132 passed (includes 3 new in test_url_fetch_registry.py).
- `pixi run test-js` — 75 passed.
- `pixi run npx cypress run --browser electron --headless --spec cypress/e2e/matrix_fill_all_spinners.cy.js` — 1 passing.
- `pixi run npx cypress run --browser electron --headless --spec cypress/e2e/matrix_row_column_click.cy.js` — 2 passing.
