### PR TITLE
fix(cypress): wait for empty-state overlay in canvas_interactions

### DIFF
--- a/cypress/e2e/canvas_interactions.cy.js
+++ b/cypress/e2e/canvas_interactions.cy.js
@@ -8,6 +8,8 @@ describe('Canvas Pan and Zoom', () => {
     it('pans canvas by dragging', () => {
         // Create a node away from center
         cy.get('#chat-input').type('/note Pan me{enter}');
+        // Wait for empty-state overlay to disappear so canvas is not covered
+        cy.get('.empty-state').should('not.exist');
 
         // Get canvas container
         cy.get('#canvas').as('canvas');
@@ -28,6 +30,8 @@ describe('Canvas Pan and Zoom', () => {
     it('zooms canvas with mouse wheel', () => {
         // Create a node
         cy.get('#chat-input').type('/note Zoom me{enter}');
+        // Wait for empty-state overlay to disappear so canvas is not covered
+        cy.get('.empty-state').should('not.exist');
 
         // Get initial transform
         cy.get('#canvas').invoke('attr', 'transform').as('initialTransform');


### PR DESCRIPTION
## Summary

Fixes the flaky Cypress test in `canvas_interactions.cy.js` (specifically "zooms canvas with mouse wheel") that was failing in CI with:

```
CypressError: Timed out retrying after 30000ms: `cy.trigger()` failed because this element:
`<svg id="canvas" ...>` is being covered by another element: `<h2>Welcome...</h2>`
```

## Root cause

On a fresh load (cleared storage, no API key), the app shows the "Welcome to Canvas Chat" empty-state overlay. When the test creates a note node, the overlay is removed asynchronously. In CI (and sometimes locally) the zoom test triggered the wheel on `#canvas` before the overlay was gone, so Cypress correctly reported the canvas as covered.

## Solution

Wait for the `.empty-state` overlay to be removed before interacting with the canvas in both tests:
- After typing `/note Pan me{enter}` or `/note Zoom me{enter}`, assert `cy.get('.empty-state').should('not.exist')` so we only pan/zoom once the canvas is uncovered.

## Changes

- `cypress/e2e/canvas_interactions.cy.js`: Add wait for `.empty-state` to not exist in "pans canvas by dragging" and "zooms canvas with mouse wheel".

## Tests

- Ran locally: `pixi run npx cypress run --browser chrome --headless --spec cypress/e2e/canvas_interactions.cy.js` — 2 passing.
