### PR TITLE
docs: add EARS specs for chat/model loading, add code annotations

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -724,6 +724,30 @@ Always use in-app modals for user interactions that require confirmation or inpu
 
 **CRITICAL:** Always run unit tests after making code changes to ensure nothing is broken.
 
+### EARS Specification Management
+
+**When renumbering EARS specs, you MUST sync with the codebase:**
+
+1. **Check for @spec annotations:** Before renumbering, search the codebase for `@spec` annotations that reference the specs being changed:
+
+    ```bash
+    rg '@spec' src/canvas_chat/static/js/
+    ```
+
+2. **Update all code references:** If specs are renumbered, update all `@spec` annotations in source files to match the new IDs.
+
+3. **Update spec Location fields:** Verify that the `**Location**:` field in each spec points to the correct file and function. Run grep commands to verify the function exists:
+
+    ```bash
+    rg 'functionName' src/canvas_chat/static/js/
+    ```
+
+4. **Keep IDs sequential:** EARS spec IDs should be sequential within each spec file (e.g., CHAT-REQ-001, CHAT-REQ-002, ...). Avoid gaps or non-sequential numbers.
+
+5. **Document new specs:** When adding new specs, assign the next available sequential ID and add a proper `**Location**:` field pointing to the implementing code.
+
+**Why this matters:** Spec IDs are the source of truth for traceability. Code annotations link implementation to requirements. If they drift, you lose the ability to trace changes back to requirements.
+
 ```bash
 pixi run test      # Python tests
 pixi run test-js   # JavaScript tests

--- a/docs/high-level-design.md
+++ b/docs/high-level-design.md
@@ -1,0 +1,314 @@
+# High-Level Design: Canvas-Chat
+
+**Project:** Canvas-Chat
+**Issue:** N/A (comprehensive HLD for entire application)
+**Status:** Draft
+**Created:** 2026-03-16
+**Updated:** 2026-03-17 (added build pipeline, Modal deployment, pip distribution)
+
+## 1. What Is This Project?
+
+Canvas-Chat is a **chat with LLMs application** that visualizes conversation history as a graph canvas. Instead of a linear chat interface (like ChatGPT or Claude), messages appear as nodes on an infinite 2D canvas, connected by edges that show conversation flow.
+
+**The core metaphor**: Think of it as a whiteboard where every message you send and receive gets written as a sticky note. You can reply to any message, branch conversations, highlight important text, and explore your chat history spatially.
+
+## 2. Core Concept: Chat-First, Visual Second
+
+The primary interaction is **chatting with LLMs**. The visual canvas is how that chat is presented, not the primary abstraction.
+
+- **You chat with LLMs** - Type prompts, get responses, iterate
+- **Chat history becomes visual** - Each message is a node on the canvas
+- **Edges show reply relationships** - When you reply to a message, an edge connects them
+- **Branching is natural** - Select any text in any message and branch a new conversation from it
+
+## 3. Why This Design?
+
+### 3.1 Non-Linear LLM Workflows
+
+Traditional chat interfaces are linear. You send a message, get a response, send another. But LLM interactions often need to:
+
+- **Branch** - Try multiple approaches from one response
+- **Reference** - Pull in content from earlier in the conversation
+- **Extract** - Highlight and save important snippets
+- **Iterate** - Go back and refine earlier responses
+
+A visual canvas naturally supports all of these. You're not locked into a single conversation thread.
+
+### 3.2 Visual Chat History
+
+When conversations get long (hundreds of messages), a linear list becomes hard to navigate. The canvas lets you:
+
+- See the structure of your conversation at a glance
+- Zoom out to see high-level flow
+- Zoom in to read details
+- Drag related conversations closer together
+
+### 3.3 Rich LLM Features
+
+The app isn't just chat - it's a toolkit for working with LLMs:
+
+- **Code execution** - Run Python directly in the conversation
+- **Research** - Deep research on topics with web search
+- **Committee** - Ask multiple LLMs and see their different perspectives
+- **Fact-checking** - Verify claims against web sources
+- **Flashcards** - Generate spaced-repetition cards from content
+- **Matrix evaluation** - Compare options across multiple criteria
+- **Instant AI Response** - Auto-trigger AI response as you type
+
+All of these are plugins that extend the core chat experience.
+
+## 4. Key Design Principles
+
+### 4.1 Local-First
+
+All data stays in the browser. No server-side storage of user conversations.
+
+- **Sessions** stored in browser IndexedDB
+- **Settings** stored in localStorage
+- **Portable** - Export sessions as files
+
+### 4.2 Bring Your Own Keys
+
+Users provide their own API keys. The server never sees them.
+
+- Keys stored in browser localStorage
+- Sent directly to LLM providers (or through a proxy)
+- Admin mode available for server-side keys (enterprise)
+
+### 4.3 Plugin-Extensible
+
+The app grows through a three-level plugin system:
+
+1. **Node types** - Custom visual representations (matrix, code, PDF)
+2. **Features** - Complex workflows with slash commands (research, committee)
+3. **Extensions** - Hook into existing features (logging, validation)
+
+### 4.4 Streaming-First
+
+All LLM responses stream in real-time.
+
+- See responses token-by-token as they're generated
+- Stop generation mid-stream
+- Continue stopped generations
+
+### 4.5 Explicit Viewport Focus
+
+The canvas doesn't auto-pan when you add nodes (except when explicitly replying). This prevents disorienting jumps when bulk operations happen.
+
+### 4.6 Instant AI Response (Copilot Mode)
+
+When API keys are configured, users can enable an "Instant AI Response" mode (similar to GitHub Copilot). In this mode:
+
+- As the user types in the chat input, an AI suggestion appears in real-time
+- The suggestion shows as a ghost/pending AI node on the canvas
+- User presses Tab to accept the suggestion, or continues typing to ignore it
+- This provides a "Fluid conversation" experience where AI assistance feels immediate
+
+This is an opt-in feature, off by default. Users who prefer explicit send can continue using the traditional flow.
+
+## 5. Architecture at a Glance
+
+### 5.1 Frontend: Three Main Parts
+
+### The Chat Input
+
+- Text area at the bottom
+- Model selector in toolbar
+- Send button
+
+### The Canvas
+
+- Infinite 2D space
+- Nodes placed automatically (new messages below current)
+- Pan and zoom to navigate
+- Semantic zoom shows more/less detail at different scales
+
+### The Graph
+
+- Tracks all nodes and their positions
+- Edges connect messages (reply relationships)
+- Persists to IndexedDB
+
+### 5.2 Backend: LLM Proxy
+
+The FastAPI backend primarily proxies requests to LLM providers:
+
+- **Chat endpoint** - Streams LLM responses
+- **Search/Research** - Web search integration (Exa)
+- **File processing** - PDF, PowerPoint, images
+- **Multi-LLM committee** - Query multiple models, synthesize responses
+
+No user data is stored. It's a thin orchestration layer.
+
+### 5.3 Data Flow
+
+```text
+[Chat Input] → [App] → [LLM via Backend] → [Stream back]
+                                              ↓
+                              [Create Node] → [Canvas renders]
+                                              ↓
+                              [Add to Graph] → [IndexedDB persists]
+```
+
+## 6. Node Types
+
+Messages are the core node type, but the system supports many others:
+
+| Category      | Purpose                                          |
+| ------------- | ------------------------------------------------ |
+| **Messages**  | Human messages, AI responses                     |
+| **Reference** | Links to URLs, highlighted text from other nodes |
+| **Data**      | Matrices for evaluation, tables from CSV/Excel   |
+| **Documents** | PDFs, PowerPoint, YouTube transcripts            |
+| **Code**      | Executable Python with output panels             |
+| **Multi-LLM** | Committee opinions, synthesis                    |
+
+## 7. Edge Types
+
+Edges represent relationships between nodes:
+
+| Type          | Meaning                                 |
+| ------------- | --------------------------------------- |
+| **Reply**     | Direct response to a message            |
+| **Branch**    | Conversation forked from text selection |
+| **Reference** | Content linked from another node        |
+| **Highlight** | Excerpt extracted from source           |
+
+## 8. Design Decisions
+
+### 8.1 Current Architecture: Vanilla JavaScript + Custom SVG Canvas
+
+The application currently uses vanilla JavaScript with a custom SVG canvas (`canvas.js`, ~4,700 lines).
+
+**What exists today**:
+
+- `index.html` contains all UI: toolbar, chat input, 9+ modal templates, canvas container, search overlay
+- `app.js` (~4,700 lines) orchestrates all DOM manipulation via `getElementById`
+- Custom SVG canvas renders nodes and edges
+- Vanilla JS ES modules for plugins (feature plugins, node protocols)
+
+### 8.2 Planned: Svelte + Svelte Flow Migration (issue #247)
+
+**Planned migration** from vanilla JavaScript + custom SVG canvas to Svelte + Svelte Flow.
+
+- **Why**: Safari is completely broken with SVG foreignObject; Svelte Flow uses HTML/CSS. Svelte Flow provides MiniMap, better touch, and saves ~4,700 lines of custom canvas code.
+- **After migration**: `index.html` becomes a minimal `<div id="app">` shell. Svelte owns the entire page.
+- **Trade-off**: Adds a build step (Vite); introduces framework dependency; existing vanilla JS plugins need adapter pattern.
+
+### 8.3 CRDT for Data Model
+
+Using Yjs (Conflict-free Replicated Data Type) for the graph.
+
+- **Why**: Enables future multiplayer, handles conflicts gracefully
+- **Trade-off**: More complex than simple JSON storage
+
+### 8.4 LiteLLM for LLM Abstraction
+
+Using LiteLLM as the backend proxy.
+
+- **Why**: Single API works with OpenAI, Anthropic, Google, and many others
+- **Trade-off**: Another dependency to maintain
+
+### 8.5 Vite Build Pipeline
+
+**Current**: Static JS/CSS served directly by FastAPI's StaticFiles.
+
+**After Svelte migration**: Svelte source is compiled by Vite into static JS/CSS bundles.
+
+- **Why**: Svelte requires compilation; Vite provides fast HMR for development and optimized builds for production.
+- **Trade-off**: Adds Node.js as a build dependency; CI must run build before deploy.
+
+## 9. Build, Deploy, and Distribution
+
+### 9.1 Build Pipeline
+
+The frontend has a compile step. Svelte source files are not directly served — they must be built first.
+
+```text
+Svelte source (.svelte) → Vite build → Static JS/CSS → FastAPI StaticFiles → Browser
+```
+
+**Build output location**: `src/canvas_chat/static/svelte-dist/`
+
+- Built assets live inside the Python package so that FastAPI's `StaticFiles(directory=STATIC_DIR)` serves them at `/static/svelte-dist/`.
+- `index.html` references the built bundle(s).
+
+**Build runs in CI**, not on user machines. Users who `pip install canvas-chat` get pre-built assets in the wheel — no Node.js required.
+
+### 9.2 Deployment to Modal
+
+Canvas-Chat deploys to Modal as a serverless ASGI app via `modal_app.py`.
+
+**How it works**:
+
+1. `modal_app.py` defines a Docker-like image with Python + system deps (LibreOffice, fonts)
+2. `.add_local_dir("src/canvas_chat")` copies the entire Python package (including built Svelte assets) into the Modal image
+3. The FastAPI app serves HTML at `/` and static assets at `/static/`
+4. LLM proxy endpoints handle chat, search, committee, etc.
+
+**CI/CD**: GitHub Actions builds Svelte assets (if needed), then runs `modal deploy modal_app.py` on push to `main`. Test deployments run on PRs.
+
+**Key constraint**: The Svelte build must complete before Modal deployment. CI runs `npm run build` (or equivalent) before `modal deploy`, and the built output is part of `src/canvas_chat/static/` which gets copied into the Modal image.
+
+### 9.3 Distribution via pip
+
+Canvas-Chat is distributed as a Python package via pip.
+
+**How it works**:
+
+1. `pyproject.toml` defines the package with hatchling as the build backend
+2. `hatchling` packages `src/canvas_chat/` (including `static/svelte-dist/` with built assets)
+3. Users install with `pip install canvas-chat`
+4. Users run with `canvas-chat launch` (typer CLI entry point)
+5. FastAPI serves the built Svelte app at `http://localhost:7865`
+
+**Key constraint**: The pip wheel must include pre-built Svelte assets. Users should NOT need Node.js. The build happens in CI (or locally by maintainers before release), and the output is committed or included in the wheel.
+
+**Current package structure (target)**:
+
+```text
+canvas-chat-0.x.x/
+└── canvas_chat/
+    ├── app.py              # FastAPI backend
+    ├── __main__.py         # CLI entry point (canvas-chat launch)
+    ├── config.py           # Configuration
+    ├── plugins/            # Python backend plugins
+    └── static/
+        ├── index.html      # HTML shell (references built bundle)
+        ├── css/            # Stylesheets
+        └── svelte-dist/    # Built Svelte bundle (JS/CSS)
+            ├── assets/
+            └── index.js
+```
+
+### 9.4 Development Workflow
+
+**Local development** uses Vite dev server for fast HMR on the Svelte frontend, alongside FastAPI for the backend:
+
+1. `pixi run dev` starts FastAPI (backend API + serves static files)
+2. `npm run dev` (Vite) starts Svelte dev server with HMR at `http://localhost:5173`
+3. Vite proxies API requests to FastAPI
+4. Changes to `.svelte` files hot-reload instantly
+
+**Production** uses only FastAPI serving pre-built static assets. No Vite dev server.
+
+## 10. What's Out of Scope
+
+- **Real-time multiplayer** - WebRTC signaling exists but is optional
+- **Server-side storage** - All data local
+- **TypeScript** - Plain JavaScript with JSDoc for documentation (Svelte components use Svelte 5 runes)
+- **Node.js as runtime dependency** - Build only; users never need Node.js
+
+## 11. Risks
+
+| Risk                 | Impact | Mitigation                                   |
+| -------------------- | ------ | -------------------------------------------- |
+| Safari compatibility | High   | Issue #247: migrate to Svelte Flow           |
+| Canvas performance   | Medium | Semantic zoom, visibility culling            |
+| Plugin conflicts     | Medium | Priority system, event cancellation          |
+| Build complexity     | Medium | Vite build in CI only; users get pre-built   |
+| Modal image size     | Low    | Built assets are small (tree-shaken by Vite) |
+
+## 12. Summary
+
+Canvas-Chat is a chat app that visualizes your LLM conversations as a graph. The key insight is that LLM workflows are non-linear - you branch, iterate, reference, and extract. A visual canvas naturally supports this, while still being fundamentally about chatting with LLMs.

--- a/docs/llds/app-orchestrator.md
+++ b/docs/llds/app-orchestrator.md
@@ -1,0 +1,84 @@
+# Chat Input and App Orchestrator
+
+**Created**: 2026-03-16
+**Status**: Design Phase
+
+## Context and Design Philosophy
+
+The App class is the central orchestrator for Canvas-Chat. It handles the primary user interaction: chatting with LLMs. The chat input is the entry point for all AI interactions - messages typed here flow through to the LLM, and responses become nodes on the canvas.
+
+## Primary Flow: Chat to Node
+
+### User Sends Message
+
+1. User types in chat input and presses Enter (or clicks Send)
+2. App creates a `human` node with the message content
+3. App sends message to LLM via chat module
+4. LLM response streams back token-by-token
+5. App creates an `ai` node that updates as response streams
+6. Canvas renders both nodes; edge connects them (reply relationship)
+
+### Branching from Selection
+
+When user selects text in any node:
+
+- A tooltip appears with "Reply" option
+- Selecting it focuses chat input with context
+- The resulting AI response branches from that node (edge type: `branch`)
+
+## Event Routing
+
+The App sits between several subsystems and routes events:
+
+```text
+Canvas Events (nodeSelect, nodeMove, etc.)
+    ↓
+App.handleXxx() methods
+    ↓
+Graph updates (CRDTGraph)
+    ↓
+Canvas re-renders
+```
+
+Similarly for Graph events and Feature plugin events.
+
+## Key Methods
+
+| Method              | Purpose                                         |
+| ------------------- | ----------------------------------------------- |
+| `handleSend()`      | Process chat input, create nodes, call LLM      |
+| `addUserNode(node)` | Add node to graph and canvas, focus viewport    |
+| `streamWithAbort()` | Handle streaming LLM response with stop support |
+
+## Session Management
+
+- **Load**: On startup, check last session in localStorage, load from IndexedDB
+- **Create**: New session gets UUID, empty graph
+- **Save**: Debounced auto-save (500ms) after any graph change
+
+## Dependencies
+
+The App coordinates these modules:
+
+- `Canvas` - Rendering
+- `CRDTGraph` - Data model
+- `Chat` - LLM API calls
+- `Storage` - Persistence
+- `FeatureRegistry` - Plugin system
+- `ModalManager` - UI dialogs
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. ✅ Chat input always at bottom - keeps interaction model consistent with familiar chat apps
+
+### Deferred
+
+1. How to handle very long conversations? Pagination? Archival?
+2. Should there be multiple chat threads in one session?
+
+## References
+
+- HLD: `/docs/high-level-design.md`
+- Implementation: `src/canvas_chat/static/js/app.js`

--- a/docs/llds/backend-llm-proxy.md
+++ b/docs/llds/backend-llm-proxy.md
@@ -1,0 +1,127 @@
+# Backend: LLM Proxy and Services
+
+**Created**: 2026-03-16
+**Status**: Design Phase
+
+## Context and Design Philosophy
+
+The FastAPI backend provides two things:
+
+1. **LLM proxy** - Routes requests to various LLM providers
+2. **Services** - Web search, research, file processing
+
+It does NOT store user data. All conversation data stays in the browser.
+
+## LLM Proxy
+
+### Architecture
+
+```text
+Frontend → Backend → LiteLLM → Provider APIs
+```
+
+LiteLLM provides a unified API across providers:
+
+| Provider  | Example Model                  |
+| --------- | ------------------------------ |
+| OpenAI    | `openai/gpt-4o`                |
+| Anthropic | `anthropic/claude-sonnet-4-5`  |
+| Google    | `google/gemini-1.5-pro`        |
+| Groq      | `groq/llama-3.1-70b-versatile` |
+| GitHub    | `github/gpt-4o`                |
+
+### Chat Endpoint
+
+```text
+POST /api/chat
+```
+
+Request:
+
+```json
+{
+    "messages": [{ "role": "user", "content": "Hello" }],
+    "model": "openai/gpt-4o",
+    "api_key": "sk-...",
+    "temperature": 0.3
+}
+```
+
+Response: Server-Sent Events (SSE) streaming
+
+### Why Proxy?
+
+- **CORS**: Avoids CORS issues with direct provider calls
+- **Key management**: API keys stored in browser, not exposed to providers directly
+- **Unified interface**: Single endpoint works with any LiteLLM-supported model
+
+## Services
+
+### Web Search (Exa)
+
+```text
+POST /api/exa/search
+POST /api/exa/research
+```
+
+Search the web, get content from URLs. Used by:
+
+- `/search` command
+- Research feature
+- Factcheck feature
+
+### File Processing
+
+```text
+POST /api/upload-file
+```
+
+Routes to Python handlers based on file type:
+
+- **PDF**: Extract text, create node
+- **PowerPoint**: Extract slides, create node
+- **CSV/Excel**: Parse data, create node with `csvData`
+
+### Multi-LLM Committee
+
+```text
+POST /api/committee
+```
+
+Query multiple models in parallel, stream their responses, synthesize with another LLM call.
+
+## Admin Mode
+
+For enterprise deployments:
+
+```yaml
+# config.yaml
+admin_mode: true
+models:
+    - id: openai/gpt-4o
+      api_key_env_var: OPENAI_API_KEY
+```
+
+In admin mode:
+
+- API keys come from server environment
+- Frontend doesn't show API key settings
+- Keys never exposed to client
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. ✅ LiteLLM - reduces provider-specific code
+2. ✅ SSE streaming - real-time token delivery
+3. ✅ No user data storage - privacy, simplicity
+
+### Deferred
+
+1. Rate limiting per user?
+2. Usage analytics?
+
+## References
+
+- HLD: `/docs/high-level-design.md`
+- Implementation: `src/canvas_chat/app.py`

--- a/docs/llds/build-deployment.md
+++ b/docs/llds/build-deployment.md
@@ -1,0 +1,464 @@
+# Build, Deploy, and Distribution
+
+**Created**: 2026-03-17
+**Status**: Design Phase
+
+## Context and Design Philosophy
+
+Canvas-Chat is both a Python package (installed via `pip`) and a serverless deployment (Modal). The frontend migration to Svelte introduces a build step that must integrate cleanly with both distribution channels. The guiding principle: **users never need Node.js**. Build artifacts are pre-built and included in the wheel and Modal image.
+
+## Build Pipeline
+
+### Source Structure
+
+```text
+src/canvas_chat/
+├── static/
+│   ├── index.html              # Minimal shell (<div id="app"> + CDN scripts)
+│   ├── css/                    # Global styles (shared baseline)
+│   ├── js/                     # Vanilla JS modules (ESM, consumed by Svelte via import)
+│   └── svelte/                 # Svelte source
+│       ├── App.svelte           # Root: toolbar + canvas + chat input
+│       ├── CanvasFlow.svelte    # Svelte Flow canvas wrapper
+│       ├── components/
+│       │   ├── Toolbar.svelte       # Model picker, action buttons
+│       │   ├── ChatInput.svelte     # Message textarea + send
+│       │   ├── TagDrawer.svelte     # Tag management sidebar
+│       │   ├── nodes/              # 25+ node type components
+│       │   ├── modals/             # 9 modal components
+│       │   │   ├── SettingsModal.svelte
+│       │   │   ├── HelpModal.svelte
+│       │   │   ├── SessionsModal.svelte
+│       │   │   ├── EditContentModal.svelte
+│       │   │   ├── EditTitleModal.svelte
+│       │   │   ├── CodeEditorModal.svelte
+│       │   │   ├── CopilotAuthModal.svelte
+│       │   │   ├── SearchOverlay.svelte
+│       │   │   └── FlashcardToast.svelte
+│       │   └── SlashCommandMenu.svelte
+│       ├── stores/             # Svelte stores (graph, chat state)
+│       └── imports/
+│           └── plugins.js      # Side-effect imports for plugin registration
+├── app.py                      # FastAPI backend
+├── plugins/                    # Python backend plugins
+└── __main__.py                 # CLI entry point
+```
+
+### Build Configuration
+
+**`vite.config.js`** at project root:
+
+```javascript
+export default {
+    root: 'src/canvas_chat/static/svelte',
+    build: {
+        outDir: '../svelte-dist',
+        emptyOutDir: true,
+        base: './',
+    },
+    server: {
+        proxy: {
+            '/api': 'http://localhost:7865',
+            '/static/js': 'http://localhost:7865',
+            '/static/css': 'http://localhost:7865',
+        },
+    },
+};
+```
+
+### HTML Ownership: Full Page Takeover (Post-Migration)
+
+**Target (after Svelte migration)**: Svelte owns the entire page. `index.html` becomes a minimal shell. All current HTML (toolbar, chat input, 9 modal templates, canvas container, search overlay) moves into Svelte components.
+
+**Current state**: The application uses vanilla JavaScript with all HTML in `index.html`. The Svelte migration is planned but not yet implemented.
+
+**Target `index.html`** (post-migration):
+
+```html
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Canvas Chat</title>
+        <!-- Base path for load balancer support (kept from current) -->
+        <script>
+            /* ... existing base path logic ... */
+        </script>
+        <!-- CDN dependencies (marked.js, KaTeX, etc.) — kept for now -->
+        <!-- Global CSS -->
+        <link rel="stylesheet" href="static/css/style.css" />
+    </head>
+    <body>
+        <div id="app"></div>
+        <script type="module" src="static/svelte-dist/assets/index-[hash].js"></script>
+    </body>
+</html>
+```
+
+**Why full takeover, not canvas-only mount**:
+
+The `app.js` class is the real bottleneck (~4,700 lines, 99 `getElementById` calls), not `canvas.js`. A canvas-only mount leaves the App class intact — you swap one canvas for another without fixing the architecture. Full takeover lets you decompose the App class naturally into Svelte components as you migrate each section.
+
+**Progressive migration within full takeover**:
+
+The architectural decision is "Svelte owns the page", but execution is phased:
+
+| Phase | What moves to Svelte           | App class impact                               |
+| ----- | ------------------------------ | ---------------------------------------------- |
+| 1-2   | Blank canvas + graph store     | None yet                                       |
+| 3     | Canvas rendering (Svelte Flow) | Canvas calls move to Svelte                    |
+| 4-5   | Node components                | Node rendering moves to Svelte                 |
+| 6     | Feature plugin nodes           | Plugin nodes move to Svelte                    |
+| 7a    | Chat input + toolbar           | App.send/message methods decomposed            |
+| 7b    | Modals (9 total)               | modal-manager.js replaced by Svelte components |
+| 7c    | Search overlay + keybindings   | Search/keyboard logic moves to Svelte          |
+| 8     | Remove old App class           | Entire `app.js` deleted                        |
+
+During transition, the old `app.js` coexists with Svelte. Svelte components call into existing ESM modules (`chat.js`, `storage.js`) directly. As each section moves to Svelte, the corresponding `getElementById` calls in `app.js` are removed.
+
+### Build Output (Post-Migration)
+
+After Svelte migration, Vite compiles `.svelte` source into optimized JS/CSS bundles:
+
+**Current state** (vanilla JS, no Svelte):
+
+```text
+src/canvas_chat/static/
+├── index.html                 # All HTML (toolbar, modals, canvas container)
+├── css/                      # Stylesheets
+└── js/                       # Vanilla JS modules (app.js, canvas.js, etc.)
+```
+
+**Target state** (after Svelte migration):
+
+```text
+src/canvas_chat/static/
+├── svelte-dist/               # BUILD OUTPUT (committed or built in CI)
+│   ├── assets/
+│   │   ├── index-[hash].js    # Main bundle
+│   │   └── index-[hash].css    # Scoped styles
+│   └── index.js                # Entry point
+├── index.html                  # Minimal shell with <div id="app">
+├── css/                        # Global CSS (non-Svelte)
+└── js/                         # Vanilla JS modules (consumed via ESM import)
+```
+
+**Key**: `index.html` uses a script tag pointing to the built bundle. During development, the Vite dev server handles this. In production, FastAPI serves the built files.
+
+### Build Commands
+
+**Current** (vanilla JS, no Svelte):
+
+```bash
+pixi run dev    # FastAPI backend + serves static files at :7865
+```
+
+**After Svelte migration**:
+
+```bash
+# Development (Vite dev server with HMR)
+npm run dev                    # Svelte dev server at :5173, proxies API to :7865
+pixi run dev                   # FastAPI backend at :7865
+
+# Production build
+npm run build                  # Builds to src/canvas_chat/static/svelte-dist/
+```
+
+### Built Assets in Version Control
+
+**Decision**: Built assets (`svelte-dist/`) are included in the git repository.
+
+**Why**:
+
+- Modal deployment uses `.add_local_dir("src/canvas_chat")` — it copies files from the local checkout, so built assets must be present
+- pip wheel includes files from `src/canvas_chat/` — built assets must be present at package time
+- Avoids requiring Node.js in the CI pipeline for Modal deploys (build runs separately)
+
+**Enforcement**: Pre-commit hook or CI check verifies `svelte-dist/` is up-to-date with the Svelte source.
+
+## Deployment to Modal
+
+### How Modal Deployment Works
+
+`modal_app.py` creates a Modal image and serves the FastAPI app:
+
+1. **Image setup**: Debian slim + Python 3.11 + system packages (LibreOffice, fonts)
+2. **Package copy**: `.add_local_dir("src/canvas_chat", remote_path="/app/canvas_chat")` copies the entire Python package (including `static/svelte-dist/`)
+3. **Runtime**: FastAPI mounts `StaticFiles` at `/static` and serves the HTML shell + built bundles
+
+### CI/CD Pipeline
+
+GitHub Actions workflow (`.github/workflows/modal-deploy.yaml`):
+
+```text
+1. Checkout repository
+2. (Optional) npm install && npm run build — if svelte-dist/ is not committed
+3. modal deploy modal_app.py -e test   (PRs)
+   modal deploy modal_app.py           (push to main)
+4. Health check: GET /health
+```
+
+**Trigger paths** (must include build output if committed):
+
+```yaml
+paths:
+    - 'src/**' # Python + static files (including svelte-dist/)
+    - 'modal_app.py'
+    - 'pyproject.toml'
+```
+
+### Static File Serving
+
+FastAPI serves static files at mount point `/static`:
+
+```python
+STATIC_DIR = Path(__file__).parent / "static"
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+```
+
+The HTML shell (`index.html`) at the root route references:
+
+- `/static/svelte-dist/assets/index-[hash].js` — built Svelte bundle
+- `/static/css/style.css` — global styles
+- `/static/js/*.js` — vanilla JS modules (loaded by the Svelte app)
+
+### Base Path Handling
+
+Modal may deploy behind a load balancer with a non-root path (e.g., `/my-app/`). The existing base path script in `index.html` handles this by dynamically setting `<base href>`. The Vite build must use relative paths (no leading `/` in asset URLs) to work with arbitrary base paths.
+
+```javascript
+// vite.config.js
+build: {
+  base: './',  // Relative paths for load balancer support
+}
+```
+
+## Distribution via pip
+
+### Package Configuration
+
+`pyproject.toml`:
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/canvas_chat"]
+# hatchling includes all files in the package by default
+```
+
+The wheel includes everything under `src/canvas_chat/`:
+
+- Python source (app.py, plugins/, config.py, etc.)
+- Static files (index.html, css/, js/)
+- Built Svelte assets (svelte-dist/)
+
+### CLI Entry Point
+
+```toml
+[project.scripts]
+canvas-chat = "canvas_chat.__main__:app"
+```
+
+Users run:
+
+```bash
+pip install canvas-chat
+canvas-chat launch          # Starts FastAPI at http://localhost:7865
+canvas-chat launch --port 8080
+canvas-chat launch --admin-mode --config config.yaml
+```
+
+The `launch` command starts uvicorn with the FastAPI app, which serves the pre-built Svelte frontend.
+
+### What Users Don't Need
+
+- Node.js — not a runtime dependency
+- npm — not needed
+- Build tools — Svelte is pre-compiled
+
+### What Users Do Need
+
+- Python >= 3.11
+- Dependencies listed in `pyproject.toml` (fastapi, litellm, etc.)
+
+## Development Workflow
+
+### Local Development (two processes)
+
+**Terminal 1 — Backend**:
+
+```bash
+pixi run dev     # FastAPI at :7865 (API + serves static in production mode)
+```
+
+**Terminal 2 — Frontend**:
+
+```bash
+npm run dev       # Vite at :5173 with HMR, proxies /api to :7865
+```
+
+Open `http://localhost:5173` for development (Vite serves Svelte with HMR).
+Open `http://localhost:7865` for production-mode testing (FastAPI serves built assets).
+
+### Vite Proxy Configuration
+
+During development, Vite proxies backend requests to FastAPI:
+
+- `/api/*` → `http://localhost:7865/api/*` (API endpoints)
+- `/static/js/*` → `http://localhost:7865/static/js/*` (vanilla JS modules)
+- `/static/css/*` → `http://localhost:7865/static/css/*` (global CSS)
+
+This lets the Svelte dev server handle `.svelte` files while delegating API calls to FastAPI.
+
+### Single Command for Contributors
+
+For convenience, a single pixi task can start both:
+
+```toml
+[tool.pixi.tasks]
+dev = "python -m uvicorn canvas_chat.app:app --reload --port 7865"
+dev-all = "concurrently 'pixi run dev' 'npm run dev'"
+```
+
+## ESM Module Strategy
+
+### Current State: Already ESM
+
+The codebase is already ES modules. `app.js` is loaded as `<script type="module">` and uses `import`/`export` throughout. All core modules use ESM exports:
+
+```javascript
+// crdt-graph.js
+export { CRDTGraph };
+
+// storage.js
+export { storage };
+
+// feature-registry.js
+export { FeatureRegistry };
+```
+
+Several modules also expose to `window` as a compatibility bridge:
+
+```javascript
+// node-registry.js — ESM export + global fallback
+export { NodeRegistry };
+if (typeof window !== 'undefined') {
+    window.NodeRegistry = NodeRegistry;
+}
+```
+
+Yjs is loaded via an import map (esm.sh CDN) in `index.html`, imported as an ES module, and exposed to `window`.
+
+### Chosen Path: Direct ESM Imports (Option A)
+
+The Svelte app imports existing ESM modules directly. No global scope bridge, no adapter for module loading.
+
+```svelte
+<!-- CanvasFlow.svelte -->
+<script>
+import { CRDTGraph } from '../js/crdt-graph.js';
+import { storage } from '../js/storage.js';
+import { chat } from '../js/chat.js';
+</script>
+```
+
+**Why this works**: The modules are already ESM. Vite resolves `import` statements natively. No code transformation needed — Vite just bundles the ESM graph.
+
+**Why not globals (Option B)**: Global scope creates fragile coupling, prevents tree-shaking, and makes testing harder. Direct imports are the standard Svelte/Vite pattern.
+
+### Migration Path
+
+**Phase 1 — Direct import, keep window globals**:
+
+- Svelte app imports modules via `import { X } from '../js/x.js'`
+- Existing `window.X = X` assignments remain untouched
+- Plugins continue to work via globals during transition
+- Zero risk of breakage
+
+**Phase 2 — Remove window globals progressively**:
+
+- As each module is consumed by Svelte, remove the `window.X = X` fallback
+- Start with modules that are only used internally (no plugin access): `crdt-graph.js`, `storage.js`, `sse.js`, `layout.js`
+- Defer modules with heavy plugin usage: `node-registry.js`, `node-protocols.js`, `streaming-manager.js`
+
+**Phase 3 — Convert to Svelte stores (optional, future)**:
+
+- Wrap `CRDTGraph` in a Svelte writable store for reactivity
+- Wrap `storage` in a Svelte store for reactive settings
+- This is optional — plain imports work fine for non-reactive data
+
+### Yjs Import Strategy
+
+Yjs is currently loaded via import map from esm.sh CDN. For the Svelte migration:
+
+**Short term**: Keep the import map in `index.html`. The Svelte app imports Yjs via bare specifier (`import * as Y from 'yjs'`), which Vite resolves using the import map. `y-indexeddb` is also imported via import map to ensure a single Yjs instance.
+
+**Long term**: Move Yjs to npm dependency (`npm install yjs y-indexeddb`). Vite bundles it natively, no CDN needed. This reduces external dependencies and improves offline behavior. This should happen after the initial migration stabilizes.
+
+### Modules by Migration Difficulty
+
+| Difficulty | Module                                                                              | Why                                              |
+| ---------- | ----------------------------------------------------------------------------------- | ------------------------------------------------ |
+| Easy       | `crdt-graph.js`, `storage.js`, `sse.js`, `layout.js`, `utils.js`, `model-utils.js`  | No DOM dependency, pure logic, no plugin access  |
+| Medium     | `chat.js`, `search.js`, `web-grounding.js`, `scroll-utils.js`                       | Some DOM usage, but well-encapsulated            |
+| Hard       | `node-registry.js`, `node-protocols.js`, `feature-registry.js`, `feature-plugin.js` | Plugin system — plugins reference globals        |
+| Hard       | `modal-manager.js`, `slash-command-menu.js`                                         | Heavy DOM manipulation, inline HTML templates    |
+| No change  | `pyodide-runner.js`                                                                 | Loaded via non-module `<script>`, self-contained |
+
+### Plugin System Note
+
+Plugins are imported as side-effect modules in `app.js`:
+
+```javascript
+import './plugins/code.js'; // Registers CodeFeature + CodeNode
+import './plugins/committee.js'; // Registers CommitteeFeature + OpinionNode, etc.
+```
+
+Each plugin file calls `FeatureRegistry.register()` on import. The Svelte app must replicate this import chain to trigger plugin registration. This can be done by:
+
+1. Creating a single entry point `svelte/imports/plugins.js` that re-exports all plugins as side-effect imports
+2. The main Svelte `App.svelte` imports this entry point
+3. Plugins register themselves into the `FeatureRegistry` singleton (same as current behavior)
+
+## EARS vs LLD Boundary
+
+Architecture decisions and migration strategy live in this LLD, NOT in EARS specs. EARS specs describe observable, testable behavior. The following decisions are documented here only:
+
+- **Full page takeover** (Svelte owns entire page) — not a spec because "rendered by Svelte" is not observable from outside. The testable consequence is that `index.html` is a minimal shell (covered by DEP-REQ-001/003).
+- **Phased migration order** (canvas → chat → modals) — not a spec because phasing is a plan, not behavior. Each phase has its own testable specs.
+- **Window globals during transition** — not a spec because it's temporary scaffolding. Removed after migration complete.
+- **CI build step before Modal deploy** — not a spec because it's pipeline config. The testable consequence is that the deployed app serves the Svelte bundle (covered by DEP-REQ-001).
+- **Plugin registration via side-effect imports** — implementation detail, not independently testable.
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. Built assets committed to git — required for Modal `.add_local_dir()` and pip wheel packaging
+2. Users don't need Node.js — build runs in CI/maintainer machines only
+3. Vite relative paths — `base: './'` for load balancer compatibility
+4. ESM module strategy — Option A: Svelte imports existing ESM modules directly (modules are already ESM, no adapter needed)
+5. Window globals — Keep during transition, remove progressively as each module is consumed by Svelte
+6. Plugin registration — Side-effect import chain replicated in Svelte app entry point
+7. HTML ownership — Full page takeover: Svelte owns toolbar, canvas, chat input, modals, search. index.html becomes minimal `<div id="app">` shell. Progressive execution: canvas first, then chat/toolbar, then modals, then remove App class.
+
+### Deferred
+
+1. Should the build be enforced via pre-commit hook or CI-only? → Start with CI check, add pre-commit hook later
+2. Convert modules to Svelte stores? → Optional future work; plain imports work for initial migration
+3. CDN vs bundled dependencies? (marked.js, KaTeX, Pyodide) → Keep as CDN for now; evaluate bundling later
+4. Yjs as npm dependency? → Move from CDN import map to npm after initial migration stabilizes
+
+## References
+
+- HLD: `/docs/high-level-design.md` (Section 9: Build, Deploy, and Distribution)
+- Canvas Rendering LLD: `/docs/llds/canvas-rendering.md`
+- Plugin System LLD: `/docs/llds/plugin-system.md`
+- App Orchestrator LLD: `/docs/llds/app-orchestrator.md`
+- Modal deployment: `modal_app.py`
+- CI workflow: `.github/workflows/modal-deploy.yaml`
+- Package config: `pyproject.toml`

--- a/docs/llds/canvas-rendering.md
+++ b/docs/llds/canvas-rendering.md
@@ -1,0 +1,370 @@
+# Canvas: Visual Chat History
+
+**Created**: 2026-03-16
+**Updated**: 2026-03-17 (migrated to Svelte Flow)
+**Status**: Design Phase
+
+## Context and Design Philosophy
+
+The Canvas renders the visual representation of chat history. Each message (human or AI) appears as a node on an infinite 2D space. The canvas handles pan, zoom, and interaction - letting users explore their conversation spatially.
+
+**Migration (issue #247)**: The canvas is migrating from a custom SVG implementation (`canvas.js`, ~4,700 lines) to Svelte Flow (`@xyflow/svelte`). See `/docs/llds/build-deployment.md` for the build pipeline that compiles Svelte source into static assets.
+
+## Rendering Strategy
+
+### Svelte Flow (Target — issue #247)
+
+Nodes are rendered as Svelte components. Svelte Flow uses HTML/CSS transforms instead of SVG foreignObject:
+
+```svelte
+<!-- CanvasFlow.svelte -->
+<SvelteFlow :nodes :edges :onNodesChange :onEdgesChange>
+  <HumanNode type="human" />
+  <AiNode type="ai" />
+  <NoteNode type="note" />
+  <!-- 25+ custom node types -->
+  <MiniMap />
+  <Controls />
+</SvelteFlow>
+```
+
+**Why Svelte Flow**: HTML/CSS rendering (no Safari foreignObject issues), built-in MiniMap/Controls, active maintenance, saves ~4,700 lines of custom code.
+
+**Trade-off**: Adds build step (Vite), framework dependency, adapter pattern for vanilla JS plugins.
+
+### Node Structure
+
+Each node has:
+
+- **Header**: Type icon, model name, delete button, stop/continue (AI nodes)
+- **Content**: Rendered markdown/code/images
+- **Actions**: Copy, edit, branch buttons
+- **Resize handle**: Drag to resize (complex nodes)
+
+### Edge Rendering
+
+Edges are Bezier curves connecting nodes. Svelte Flow handles edge rendering with custom edge types.
+
+**Edge types**: `reply`, `branch`, `reference`, `generates` — each registered as a Svelte Flow edge type.
+
+### Pan and Zoom
+
+Svelte Flow provides built-in pan and zoom. Configuration:
+
+```javascript
+const panOnDrag = [1]; // Left mouse button
+const minZoom = 0.1;
+const maxZoom = 3.0;
+const defaultZoom = 1.0;
+```
+
+### Input Methods
+
+| Input                        | Action             |
+| ---------------------------- | ------------------ |
+| Mouse drag (on empty canvas) | Pan                |
+| Ctrl + Scroll wheel          | Zoom toward cursor |
+| Trackpad pinch               | Zoom               |
+| Touch drag (single finger)   | Pan                |
+| Touch pinch (two fingers)    | Zoom               |
+
+## Semantic Zoom
+
+Three levels of detail based on zoom scale:
+
+| Scale    | Class          | Shows               |
+| -------- | -------------- | ------------------- |
+| > 0.6    | `zoom-full`    | Full content        |
+| 0.35-0.6 | `zoom-summary` | Summary text only   |
+| ≤ 0.35   | `zoom-mini`    | Just icon and title |
+
+This lets users see conversation structure at different scales.
+
+## Interactions
+
+### Selection
+
+- **Click**: Select single node
+- **Ctrl+Click**: Toggle node in selection
+- **Drag on selection**: Move multiple nodes
+
+### Dragging
+
+- **Zoomed in**: Drag via handle only
+- **Zoomed out** (≤0.6): Drag from anywhere on node
+
+### Text Selection
+
+When user selects text in node content:
+
+1. Detect via `selectionchange` event
+2. Show "Reply" tooltip near selection
+3. Store selected text for reply context
+
+## Node Protocol Pattern
+
+The canvas uses a protocol pattern to get node-type-specific behavior:
+
+```javascript
+wrapped = wrapNode(node); // Returns BaseNode or custom protocol
+
+wrapped.getTypeIcon(); // Node type emoji
+wrapped.getSummaryText(); // For semantic zoom
+wrapped.renderContent(); // HTML content
+wrapped.getActions(); // Available buttons
+```
+
+This allows custom node types to control their rendering without modifying canvas code.
+
+## Canvas Adapter Strategy (Phases 3-6)
+
+During the transition period, `app.js` (~4,700 lines) and all plugins continue to call `canvas.X()` methods. The old `canvas.js` is **rewritten as a thin adapter** that delegates to Svelte Flow instead of manipulating SVG DOM. The App class and plugins require zero changes.
+
+### Why an adapter instead of refactoring the App class
+
+The App class has 169 calls to 65 unique canvas methods. Plugins add another ~150 calls to the same surface. Refactoring both `app.js` and all plugins to call Svelte Flow directly would change thousands of lines simultaneously — high risk, hard to verify incrementally.
+
+The adapter lets us swap the rendering engine (SVG → Svelte Flow) while keeping all callers unchanged. Phase 8 then deletes the adapter, App class, and `canvas.js` together.
+
+### Method surface analysis
+
+65 unique methods called across `app.js`, `feature-registry.js`, and 25+ plugin files:
+
+#### Category 1: Rendering — become no-ops (16 methods)
+
+Svelte Flow auto-renders when the graph store changes. These methods currently manipulate SVG DOM directly. In the adapter, they update the graph store (or do nothing).
+
+| Method                            | Current behavior                          | Adapter behavior                              |
+| --------------------------------- | ----------------------------------------- | --------------------------------------------- |
+| `renderNode(node)`                | Creates SVG group, appends to DOM         | `graph.updateNode(node)` → Svelte Flow reacts |
+| `updateNodeContent(id, html)`     | Sets innerHTML on node element            | `graph.updateNode(id, { content: html })`     |
+| `removeNode(id)`                  | Removes SVG group from DOM                | `graph.removeNode(id)` → Svelte Flow reacts   |
+| `removeEdge(id)`                  | Removes SVG path from DOM                 | `graph.removeEdge(id)` → Svelte Flow reacts   |
+| `renderEdge(edge, ...)`           | Creates SVG Bezier path                   | No-op (Svelte Flow auto-renders edges)        |
+| `renderGraph(graph)`              | Renders all nodes + edges                 | No-op (Svelte Flow reacts to store)           |
+| `clear()`                         | Removes all SVG elements                  | `graph.clear()`                               |
+| `updateEdgeState(id, state)`      | Sets edge data attributes                 | `graph.updateEdge(id, state)`                 |
+| `updateEdgesForNode(id, pos)`     | Recalculates connected edges              | No-op                                         |
+| `updateAllEdges()`                | Iterates all edges, recalculates          | No-op                                         |
+| `updateNodeSummary(id)`           | Updates summary text element              | `graph.updateNode(id, ...)`                   |
+| `updateNodeVisibility(id)`        | Shows/hides node based on collapsed state | `graph.updateNode(id, ...)`                   |
+| `updateCollapseButton(id)`        | Updates expand/collapse button            | No-op (Svelte node component handles)         |
+| `showNodeError(id, msg)`          | Adds error class + message to node        | `graph.updateNode(id, { error: msg })`        |
+| `clearNodeError(id)`              | Removes error class from node             | `graph.updateNode(id, { error: null })`       |
+| `updateAllNavButtonStates(graph)` | Iterates nodes, updates nav buttons       | No-op (node components handle internally)     |
+
+#### Category 2: Viewport — thin wrappers (8 methods)
+
+Delegate to Svelte Flow's `fitView()`, `setViewport()`, etc.
+
+| Method                                          | Adapter implementation                                   |
+| ----------------------------------------------- | -------------------------------------------------------- |
+| `zoomToSelectionAnimated(ids, scale, duration)` | Svelte Flow `fitView({ nodes: ids, padding, duration })` |
+| `fitToContent()`                                | Svelte Flow `fitView()`                                  |
+| `fitToContentAnimated(duration)`                | Svelte Flow `fitView({ duration })`                      |
+| `centerOnAnimated(nodeId)`                      | Svelte Flow `setViewport({ x, y })`                      |
+| `panToNodeAnimated(nodeId)`                     | Svelte Flow `setViewport({ x, y })`                      |
+| `resizeNodeToViewport(nodeId)`                  | Svelte Flow `setViewport({ zoom })` + update node size   |
+| `animateToLayout(positions)`                    | Svelte Flow `setViewport({ x, y })` for each position    |
+| `getViewportCenter()`                           | Svelte Flow `getViewport()` → calculate center           |
+
+#### Category 3: Selection — read/write Svelte Flow state (3 methods)
+
+| Method                    | Adapter implementation                                                       |
+| ------------------------- | ---------------------------------------------------------------------------- |
+| `getSelectedNodeIds()`    | Return `nodes.filter(n => n.selected).map(n => n.id)` from Svelte Flow state |
+| `clearSelection()`        | `setNodes(nodes.map(n => ({ ...n, selected: false })))`                      |
+| `selectNode(id, isMulti)` | Update node's `selected` property in Svelte Flow state                       |
+
+#### Category 4: Events — EventEmitter (4 methods)
+
+Reuse the existing `EventEmitter` class. Same as current canvas.js behavior.
+
+| Method                                                     | Adapter implementation                            |
+| ---------------------------------------------------------- | ------------------------------------------------- |
+| `on(event, listener)`                                      | `events.on(event, listener)`                      |
+| `off(event, listener)`                                     | `events.off(event, listener)`                     |
+| `emit(event, ...args)`                                     | `events.emit(event, ...args)`                     |
+| Callback properties (`onNodeSelect`, `onNodeDelete`, etc.) | Store in adapter, fire via EventEmitter on events |
+
+#### Category 5: State reads — map to Svelte Flow (8 methods)
+
+These are **the hardest**. Plugins read DOM state that doesn't exist in Svelte Flow.
+
+| Method                       | Problem                                                                     | Adapter approach                                                                                                                                                                                                                                                                                                        |
+| ---------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `nodeElements` (Map)         | Plugins read positions (5 calls) AND do complex DOM manipulation (15 calls) | Hybrid DOM Proxy: intercept `getAttribute('x')`/`('y')`/`('width')`/`('height')` from Svelte Flow store; forward all other access (`querySelector`, `classList`, `textContent`, `innerHTML`) to real Svelte Flow DOM element via `document.querySelector('[data-id="${id}"]')`. See "Strategy: Hybrid DOM Proxy" below. |
+| `edgeElements` (Map)         | Plugins iterate edges for orphan cleanup (5 calls, all simple)              | Hybrid DOM Proxy: intercept `getAttribute('data-source')`/`('data-target')` from Svelte Flow edge store; forward other access to real DOM.                                                                                                                                                                              |
+| `graph` (property)           | Plugins access the CRDT graph instance                                      | Direct reference to the same CRDTGraph instance                                                                                                                                                                                                                                                                         |
+| `getViewportCenter()`        | Returns viewport center coordinates                                         | Read from Svelte Flow `getViewport()`                                                                                                                                                                                                                                                                                   |
+| `getNodeDimensions(id)`      | Reads DOM `getBoundingClientRect()`                                         | Approximate from Svelte Flow node data (`width`, `height`, `position`)                                                                                                                                                                                                                                                  |
+| `getNavButton(nodeId, type)` | Reads DOM element                                                           | Return null or delegate to Svelte node component                                                                                                                                                                                                                                                                        |
+| `getReplyTooltipInput()`     | Reads reply tooltip input element                                           | Return null (reply tooltip becomes Svelte component)                                                                                                                                                                                                                                                                    |
+| `pendingSelectedText`        | Stores selected text state                                                  | Simple property on adapter                                                                                                                                                                                                                                                                                              |
+
+#### Category 6: Utility functions — delegate to correct modules (10 methods)
+
+These are utility functions that live on canvas.js for historical reasons but belong elsewhere.
+
+| Method                            | Adapter delegates to                                            |
+| --------------------------------- | --------------------------------------------------------------- |
+| `escapeHtml(text)`                | `escapeHtmlText()` from `utils.js` (already exists)             |
+| `renderMarkdown(text)`            | `marked.parse(text)` (already used internally)                  |
+| `truncate(text, max)`             | `truncateText()` from `utils.js` (already exists)               |
+| `saveSession()`                   | `storage.saveSession()`                                         |
+| `copyImageToClipboard(...)`       | Standalone function using Canvas API                            |
+| `highlightTextInNode(...)`        | Highlight utility (post-render DOM manipulation — special case) |
+| `highlightTextInOutputPanel(...)` | Highlight utility (post-render DOM manipulation — special case) |
+| `rerenderNodeContent(id)`         | `graph.updateNode(id, ...)` → Svelte reacts                     |
+
+#### Category 7: Node-internal UI — move to Svelte components (10 methods)
+
+These manage UI elements inside node components. They don't belong on a canvas class. The adapter stubs them; the real implementation lives in Svelte node components.
+
+| Method                                                                 | Notes                                                         |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------- |
+| `showCopyFeedback(msg, nodeId)`                                        | Toast notification — move to Svelte component or utility      |
+| `showStopButton(nodeId)` / `hideStopButton(nodeId)`                    | Node-internal UI — Svelte node component                      |
+| `updateOutputPanelContent(nodeId, html)`                               | Code node output panel — Svelte node component                |
+| `clearMatrixCellHighlights()` / `highlightMatrixCell(row, col, color)` | Matrix node UI — Svelte node component                        |
+| `showImageTooltip(...)` / `hideImageTooltip()`                         | Image preview — Svelte component                              |
+| `setPdfViewerHydrator(fn)`                                             | PDF node callback — store on adapter                          |
+| `getContext()`                                                         | SVG 2D context — return null (Svelte Flow doesn't use canvas) |
+| `canvas.width` / `canvas.height`                                       | SVG dimensions — return container dimensions                  |
+
+#### Category 8: Navigation popover — remove or move to Svelte (11 methods)
+
+These implement the parent/child navigation popover UI that is specific to the old SVG canvas. Svelte Flow has different UX patterns for navigation.
+
+| Method                          | Notes                                      |
+| ------------------------------- | ------------------------------------------ |
+| `isNavPopoverOpen()`            | Nav popover — evaluate if needed in Svelte |
+| `hideNavPopover()`              | Same                                       |
+| `navigatePopoverSelection(dir)` | Same                                       |
+| `confirmPopoverSelection()`     | Same                                       |
+| `showNavPopover(...)`           | Same                                       |
+| `handleNavButtonClick(...)`     | Same                                       |
+| `updateNavButtonState(...)`     | Same                                       |
+| `showNavToast(...)`             | Toast — utility                            |
+| `getNavButton(...)`             | Nav UI — Svelte component                  |
+| `clearSourceTextHighlights()`   | Highlight utility                          |
+| `highlightContext(...)`         | Node highlighting                          |
+
+### Adapter size estimate
+
+| Category                    | Methods | Lines (est.) |
+| --------------------------- | ------- | ------------ |
+| 1. Rendering (no-ops)       | 16      | ~50          |
+| 2. Viewport (wrappers)      | 8       | ~60          |
+| 3. Selection (state)        | 3       | ~20          |
+| 4. Events (EventEmitter)    | 4       | ~30          |
+| 5. State reads (Proxy Map)  | 8       | ~120         |
+| 6. Utility delegation       | 10      | ~40          |
+| 7. Node-internal UI (stubs) | 10      | ~50          |
+| 8. Nav popover (stubs)      | 11      | ~50          |
+| Constructor + init          | 1       | ~30          |
+| **Total**                   | **~71** | **~450**     |
+
+### nodeElements / edgeElements access audit (COMPLETE)
+
+All direct `nodeElements` and `edgeElements` accesses catalogued. Two access patterns emerge:
+
+#### Pattern A: Position/size reads via `getAttribute` (5 calls)
+
+| Location | Lines                  | Accesses                                                                                    |
+| -------- | ---------------------- | ------------------------------------------------------------------------------------------- |
+| `app.js` | 2111-2122              | `wrapper.getAttribute('x')`, `getAttribute('y')`                                            |
+| `app.js` | 2144-2156              | Same (collapsed path edges)                                                                 |
+| `app.js` | 3710-3715              | `getAttribute('x')`, `getAttribute('y')`, `getAttribute('width')`, `getAttribute('height')` |
+| `app.js` | 3697                   | `this.canvas.nodeElements.keys()` (existence check)                                         |
+| `app.js` | 5 `edgeElements` calls | `path.getAttribute('data-source')`, `path.getAttribute('data-target')`                      |
+
+#### Pattern B: Complex DOM manipulation via `querySelector` + mutation (15 calls)
+
+| Location              | Lines     | Operation                                                                                       |
+| --------------------- | --------- | ----------------------------------------------------------------------------------------------- |
+| `app.js`              | 2967-2989 | `querySelector('.node')` + `classList.add` + `setAttribute('width')` + `setAttribute('height')` |
+| `app.js`              | 3446-3451 | `querySelector('.summary-text')` + `.textContent =`                                             |
+| `app.js`              | 3898-3908 | `wrapper.classList.remove/add` (zoom class changes)                                             |
+| `app.js`              | 3977-3981 | `wrapper.setAttribute('x')` + `setAttribute('y')` (position writes)                             |
+| `app.js`              | 3989-3998 | `querySelector('.summary-text')` + `.textContent =`                                             |
+| `app.js`              | 4056-4060 | `wrapper.setAttribute('x')` + `setAttribute('y')`                                               |
+| `app.js`              | 4068-4077 | `querySelector('.summary-text')` + `.textContent =`                                             |
+| `code.js`             | 178       | `querySelector('.code-display code')` + highlight.js                                            |
+| `code.js`             | 271       | `querySelector('.node')` + `querySelector('.code-node-content')` + innerHTML                    |
+| `code.js`             | 348       | `querySelector('.code-generate-input')` + `.remove()`                                           |
+| `matrix.js`           | 332       | `querySelector('.matrix-cell[data-row=...]')` + classList                                       |
+| `matrix.js`           | 374       | `querySelector('.matrix-cell[data-row=...]')` + content update                                  |
+| `powerpoint-node.js`  | 865       | `querySelector('.node')` + `querySelector('.node-content')` + `querySelector('.pptx-node')`     |
+| `image-generation.js` | 209, 302  | `querySelector('.image-node-content')` + innerHTML                                              |
+| `flashcards.js`       | 990       | `querySelector('.node')` + `classList.toggle('flashcard-flipped')`                              |
+
+### Strategy: Hybrid DOM Proxy
+
+A simple Proxy Map that only intercepts `getAttribute` is insufficient — only 5 of 20 calls use that pattern. The adapter uses a **Hybrid DOM Proxy** that:
+
+1. **Intercepts `getAttribute('x'|'y'|'width'|'height')`** → reads from Svelte Flow node store (position/dimensions). This replaces SVG attribute reads with reactive store reads.
+2. **Forwards everything else** → delegates to the actual Svelte Flow DOM element. `querySelector`, `classList`, `textContent`, `innerHTML` all work because they operate on real DOM rendered by Svelte Flow.
+
+```javascript
+createNodeProxy(nodeId) {
+    const handler = {
+        get(target, prop) {
+            if (prop === 'getAttribute') {
+                return (attr) => {
+                    const node = getNodeFromStore(nodeId);
+                    if (attr === 'x') return String(node.position.x);
+                    if (attr === 'y') return String(node.position.y);
+                    if (attr === 'width') return String(node.measured?.width ?? node.width ?? 0);
+                    if (attr === 'height') return String(node.measured?.height ?? node.height ?? 0);
+                    return getRealElement(nodeId)?.getAttribute(attr);
+                };
+            }
+            const el = getRealElement(nodeId);
+            if (el && prop in el) return el[prop];
+            return undefined;
+        }
+    };
+    return new Proxy({}, handler);
+}
+```
+
+`getRealElement(nodeId)` uses `document.querySelector('[data-id="${nodeId}"]')` — Svelte Flow's standard data attribute for node elements.
+
+For `edgeElements`: same pattern, intercepting `getAttribute('data-source'|'data-target')` from Svelte Flow edge store.
+
+**Risks and mitigations:**
+
+| Risk                                                                              | Mitigation                                                                                    |
+| --------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| DOM element doesn't exist yet when plugin calls `nodeElements.get()`              | Return a Proxy that returns `null` for DOM operations; queue position reads until node mounts |
+| `querySelector('.summary-text')` depends on Svelte component internal class names | Custom node components use the same CSS class names as current SVG rendering                  |
+| `wrapper.setAttribute('x')` (position writes in app.js:3977-4081)                 | Intercept `setAttribute` for x/y to write to Svelte Flow store instead of DOM attribute       |
+| `wrapper.classList.add/remove` for zoom classes                                   | Forward to real DOM — Svelte node components already have these classes from current CSS      |
+
+### Phase plan for adapter
+
+- **Phase 2**: Create `canvas.js` adapter with categories 1-4 (rendering, viewport, selection, events). Stub categories 5-8. Verify App class still works.
+- **Phase 3**: Complete category 5 (state reads with Proxy Map). Verify plugins still work.
+- **Phase 4-6**: Incrementally move category 6-7 methods to Svelte node components as each node type is migrated.
+- **Phase 8**: Delete adapter, App class, and all remaining category 8 stubs.
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. Svelte Flow chosen over React Flow — Svelte fits the lightweight philosophy; no JSX build chain
+2. Semantic zoom is CSS-based — classes applied to node wrapper elements based on zoom store
+3. foreignObject replaced by Svelte Flow's HTML-based rendering — fixes Safari (issue #247)
+
+### Deferred
+
+1. Auto-layout algorithm? Currently manual placement
+2. Custom Svelte Flow themes? Use default for initial migration
+
+## References
+
+- HLD: `/docs/high-level-design.md`
+- Build & Deploy LLD: `/docs/llds/build-deployment.md`
+- Implementation (current): `src/canvas_chat/static/js/canvas.js`
+- Implementation (target): `src/canvas_chat/static/svelte/CanvasFlow.svelte`

--- a/docs/llds/chat-module.md
+++ b/docs/llds/chat-module.md
@@ -1,0 +1,373 @@
+# Chat Module: LLM Communication
+
+**Created**: 2026-03-16
+**Status**: Design Phase
+**Component**: Frontend JavaScript Module
+
+## Context and Design Philosophy
+
+The Chat module serves as the primary interface between Canvas-Chat and Large Language Model providers. Its existence is fundamental to the application's core purpose: enabling users to have conversations with AI models that are then visualized as nodes on a graph canvas.
+
+### Why a Dedicated Chat Module?
+
+The HLD establishes that Canvas-Chat is fundamentally a chat application with a visual second. The Chat module embodies this philosophy by providing:
+
+1. **Streaming-First Experience**: LLM responses appear token-by-token as they're generated, giving users immediate feedback and reducing perceived latency.
+
+2. **Provider Agnosticism**: Users can switch between OpenAI, Anthropic, Google, GitHub Copilot, and custom endpoints without changing their workflow. The Chat module abstracts these differences.
+
+3. **Local-First Key Management**: API keys never leave the browser (except when sent directly to providers). The module retrieves keys from localStorage and includes them in requests, ensuring no server-side key storage is required.
+
+4. **Graceful Error Handling**: LLM APIs can fail for many reasons (auth expiry, rate limits, network issues). The Chat module provides consistent error handling with user-friendly messages and retry capabilities.
+
+## Technical Details
+
+### Architecture Overview
+
+The Chat module consists of three key files:
+
+| File      | Purpose                                                                         |
+| --------- | ------------------------------------------------------------------------------- |
+| `chat.js` | Main Chat class - provider abstraction, model fetching, message sending         |
+| `sse.js`  | SSE parsing utilities - stream reading, text normalization                      |
+| `app.js`  | Integration layer - orchestrates chat with graph, canvas, and streaming manager |
+
+The flow from user input to streamed response:
+
+```text
+User types message
+    ↓
+App.handleSend() - creates human node
+    ↓
+App.resolveContext() - builds conversation context from graph
+    ↓
+App.streamWithAbort() - sends request and handles streaming
+    ↓
+Chat class (via buildLLMRequest) - builds request body with credentials
+    ↓
+Backend /api/chat - proxies to LiteLLM
+    ↓
+SSE stream → readSSEStream → onChunk callbacks
+    ↓
+Canvas updates node content in real-time
+```
+
+### Server-Sent Events (SSE) Streaming
+
+The streaming implementation uses the browser's Fetch API with a ReadableStream to process SSE events incrementally.
+
+#### Frontend SSE Handling
+
+The `readSSEStream` function in `sse.js` handles the SSE protocol:
+
+```javascript
+async function readSSEStream(response, handlers) {
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = '';
+
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        buffer = buffer.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+
+        const events = buffer.split('\n\n');
+        buffer = events.pop() || ''; // Keep incomplete event in buffer
+
+        for (const event of events) {
+            const parsed = parseSSEEvent(event);
+            if (parsed.eventType === 'message' && parsed.data) {
+                handlers.onEvent('message', parsed.data);
+            } else if (parsed.eventType === 'done') {
+                handlers.onDone();
+                return;
+            } else if (parsed.eventType === 'error') {
+                handlers.onError(new Error(parsed.data));
+                return;
+            }
+        }
+    }
+}
+```
+
+#### Backend SSE Generation
+
+The backend uses LiteLLM with async generation to stream responses:
+
+```python
+@app.post("/api/chat")
+async def chat(request: ChatRequest, http_request: Request):
+    async def generate():
+        try:
+            response = await litellm.acompletion(**kwargs)
+            async for chunk in response:
+                if chunk.choices and chunk.choices[0].delta.content:
+                    content = chunk.choices[0].delta.content
+                    yield {"event": "message", "data": content}
+            yield {"event": "done", "data": ""}
+        except litellm.AuthenticationError as e:
+            yield {"event": "error", "data": f"Authentication failed: {e}"}
+        # ... error handling
+
+    return EventSourceResponse(generate())
+```
+
+#### Text Normalization
+
+LLM tokenization can produce artifacts like spaces before punctuation. The `normalizeText` function addresses this:
+
+```javascript
+function normalizeText(text) {
+    return text
+        .replace(/ - /g, '-') // "matter - of" → "matter-of"
+        .replace(/ +([.,!?;:)\]}])/g, '$1') // "hello ," → "hello,"
+        .replace(/([[({]) +/g, '$1') // "( hello" → "(hello"
+        .replace(/ +'/g, "'") // "don ' t" → "don't"
+        .replace(/' +/g, "'") // "don 't" → "don't"
+        .replace(/ {2,}/g, ' ') // multiple spaces → single
+        .trim();
+}
+```
+
+### Provider Abstraction
+
+The Chat module uses a simple provider naming convention: `provider/model-id`. The provider is extracted from the model string and used to look up the appropriate API key.
+
+#### Provider Detection
+
+```javascript
+getApiKeyForModel(model) {
+    if (!model) return null;
+
+    // DALL-E uses OpenAI keys despite different model prefix
+    if (model.startsWith('dall-e')) {
+        return storage.getApiKeyForProvider('openai');
+    }
+
+    const provider = model.split('/')[0].toLowerCase();
+    return storage.getApiKeyForProvider(provider);
+}
+```
+
+#### Supported Providers
+
+| Provider       | Model Prefix      | Example Model                  |
+| -------------- | ----------------- | ------------------------------ |
+| OpenAI         | `openai/`         | `openai/gpt-4o`                |
+| Anthropic      | `anthropic/`      | `anthropic/claude-sonnet-4-5`  |
+| Google         | `google/`         | `google/gemini-1.5-pro`        |
+| Groq           | `groq/`           | `groq/llama-3.1-70b-versatile` |
+| GitHub Copilot | `github_copilot/` | `github_copilot/gpt-4o`        |
+| Ollama         | (local)           | `ollama/llama3`                |
+
+#### Custom Base URLs
+
+For users with custom LLM endpoints (local models, proxies), the Chat module supports custom base URLs:
+
+```javascript
+getBaseUrl() {
+    return storage.getBaseUrl();
+}
+
+getBaseUrlForModel(modelId) {
+    return storage.getBaseUrlForModel(modelId);
+}
+```
+
+### Message Format
+
+Messages follow the OpenAI chat completion format with role-based messaging:
+
+```javascript
+/**
+ * @typedef {Object} ChatMessage
+ * @property {'user'|'assistant'|'system'} role - Message role
+ * @property {string|Array} content - Text content or multimodal content array
+ * @property {string} [nodeId] - Source node ID (internal use)
+ * @property {string} [imageData] - Base64 image data (for image messages)
+ * @property {string} [mimeType] - Image MIME type (for image messages)
+ */
+```
+
+#### Context Resolution
+
+Before sending to the LLM, the App class resolves the conversation context from the graph. This involves:
+
+1. **Finding relevant nodes**: Starting from the parent node, traverse the graph to build context
+2. **Truncating if needed**: If context exceeds the model's context window, summarize or truncate
+3. **Formatting**: Convert graph nodes to the message format
+
+The `buildMessagesForApi` function (in app.js) handles this transformation. It walks the graph from the selected node back to roots, collecting messages in chronological order.
+
+### Integration with App
+
+The App class orchestrates chat functionality with the graph and canvas:
+
+#### Sending a Message
+
+```javascript
+async handleSend() {
+    const content = this.chatInput.value.trim();
+    if (!content) return;
+
+    // Try slash commands first
+    if (await this.tryHandleSlashCommand(content, context)) {
+        return;
+    }
+
+    // Create human node
+    const humanNode = createNode(NodeType.HUMAN, content, { position });
+    this.addUserNode(humanNode);
+
+    // Create AI response node
+    const aiNode = createNode(NodeType.AI, '', { position, model });
+    this.addUserNode(aiNode);
+
+    // Build context and stream
+    const messages = buildMessagesForApi(this.graph.resolveContext([humanNode.id]));
+    const abortController = new AbortController();
+
+    this.streamWithAbort(aiNode.id, abortController, messages, model,
+        // onChunk
+        (chunk, fullContent) => {
+            this.canvas.updateNodeContent(aiNode.id, fullContent, true);
+            this.graph.updateNode(aiNode.id, { content: fullContent });
+        },
+        // onDone
+        (fullContent) => {
+            this.canvas.updateNodeContent(aiNode.id, fullContent, false);
+            this.graph.updateNode(aiNode.id, { content: fullContent });
+            this.saveSession();
+        },
+        // onError
+        (err) => this.showNodeError(aiNode.id, formatUserError(err))
+    );
+}
+```
+
+#### Streaming with Abort
+
+The `streamWithAbort` method combines request building, fetching, and SSE handling:
+
+```javascript
+async streamWithAbort(nodeId, abortController, messages, model,
+                       onChunk, onDone, onError) {
+    const requestBody = this.buildLLMRequest({
+        messages,
+        temperature: 0.7,
+    });
+
+    const response = await fetch(apiUrl('/api/chat'), {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestBody),
+        signal: abortController.signal,
+    });
+
+    await readSSEStream(response, {
+        onEvent: (eventType, data) => {
+            if (eventType === 'message' && data) {
+                onChunk(data, fullContent + data);
+            }
+        },
+        onDone: () => onDone(normalizeText(fullContent)),
+        onError: (err) => onError(err),
+    });
+}
+```
+
+The AbortController enables stopping generation mid-stream. When the user clicks "Stop", the abort signal is triggered, causing the fetch to throw an AbortError which is caught and handled gracefully.
+
+#### StreamingManager Integration
+
+The StreamingManager tracks active streams and shows stop/continue controls:
+
+```javascript
+this.streamingManager.register(aiNode.id, {
+    abortController,
+    featureId: 'ai',
+    context: { messages, model, humanNodeId },
+    onContinue: async (nodeId, state) => {
+        await this.continueAIResponse(nodeId, state.context);
+    },
+});
+```
+
+This design enables multiple simultaneous AI generations (one per node), each with its own stop control in the node header.
+
+## API Reference
+
+### Chat Class Methods
+
+| Method                   | Signature                                                                         | Description                          |
+| ------------------------ | --------------------------------------------------------------------------------- | ------------------------------------ |
+| `fetchModels`            | `() => Promise<ModelInfo[]>`                                                      | Fetch available models from server   |
+| `fetchProviderModels`    | `(provider: string, apiKey: string) => Promise<ModelInfo[]>`                      | Fetch models for a specific provider |
+| `getApiKeyForModel`      | `(model: string) => string \| null`                                               | Get API key for a model's provider   |
+| `getBaseUrl`             | `() => string \| null`                                                            | Get custom base URL if configured    |
+| `getBaseUrlForModel`     | `(modelId: string) => string \| null`                                             | Get per-model base URL override      |
+| `ensureCopilotAuthFresh` | `(model: string) => Promise<string \| null>`                                      | Refresh Copilot token if needed      |
+| `sendMessage`            | `(messages, model, onChunk, onDone, onError, abortController) => Promise<string>` | Send message and stream response     |
+| `summarize`              | `(messages: ChatMessage[], model: string) => Promise<string>`                     | Summarize a conversation branch      |
+| `estimateTokens`         | `(text: string, model: string) => Promise<number>`                                | Estimate token count for text        |
+| `getContextWindow`       | `(modelId: string) => number`                                                     | Get context window size for model    |
+
+### SSE Event Types
+
+| Event     | Data          | Description                   |
+| --------- | ------------- | ----------------------------- |
+| `message` | text chunk    | New content from LLM          |
+| `done`    | (empty)       | Stream completed successfully |
+| `error`   | error message | Stream failed with error      |
+
+### Request Format (Frontend to Backend)
+
+```javascript
+{
+    messages: [
+        { role: 'user', content: 'Hello' },
+        { role: 'assistant', content: 'Hi there!' },
+        { role: 'user', content: 'How are you?' }
+    ],
+    model: 'openai/gpt-4o',
+    api_key: 'sk-...',           // From localStorage
+    base_url: 'https://api.openai.com/v1',  // Optional, for custom endpoints
+    temperature: 0.3
+}
+```
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. ✅ Context resolution via graph traversal - decided to traverse from selected node back to roots
+
+### Deferred
+
+1. Context window management - how to handle very long conversations
+2. Multimodal content support
+3. Streaming reliability improvements
+4. Provider-specific feature detection
+
+## References to HLD
+
+This LLD supports several design decisions from the High-Level Design:
+
+1. **Streaming-First** (HLD Section 4.4): The SSE implementation delivers responses token-by-token with stop/continue controls in each node header.
+
+2. **Bring Your Own Keys** (HLD Section 4.2): API keys are retrieved from localStorage and sent with requests. The backend proxies requests without storing keys.
+
+3. **Plugin-Extensible** (HLD Section 4.3): The Chat module's sendMessage capability is used by feature plugins (Committee, Factcheck) to query LLMs. The StreamingManager coordinates multiple concurrent streams.
+
+4. **Local-First** (HLD Section 4.1): All conversation state stays in the browser. The backend is a thin proxy that never stores user data.
+
+## References
+
+- **HLD**: `/docs/high-level-design.md`
+- **Implementation**: `src/canvas_chat/static/js/chat.js` - Main Chat class
+- **SSE Utilities**: `src/canvas_chat/static/js/sse.js` - Stream parsing
+- **Streaming Manager**: `src/canvas_chat/static/js/streaming-manager.js` - Concurrent streams
+
+1. **Chat-First, Visual Second** (HLD Section 2): The Chat module is the core interaction. The visual canvas displays what the Chat module produces.

--- a/docs/llds/code-node.md
+++ b/docs/llds/code-node.md
@@ -1,0 +1,501 @@
+# CodeNode Low-Level Design
+
+**Created**: 2026-03-16
+**Status**: Implementation
+**Related HLD**: [High-Level Design](../high-level-design.md)
+
+## Context and Design Philosophy
+
+The CodeNode enables users to write, execute, and debug Python code directly within the canvas environment. This node type exists because LLM workflows frequently require data analysis, computation, and visualization that cannot be accomplished through natural language alone.
+
+### Why a Dedicated Code Node?
+
+The HLD establishes that Canvas-Chat is fundamentally a chat application with visual second. The CodeNode extends this philosophy by enabling computational workflows that complement conversational AI. Several design principles guide its implementation.
+
+First, browser-based execution via Pyodide eliminates the need for a backend code execution service, keeping all computation local and avoiding security concerns associated with server-side code execution. Users can run Python code without any server infrastructure.
+
+Second, self-healing on errors means that when code fails, the system automatically attempts to fix the error using the LLM, providing a form of "self-healing" code that reduces the friction of debugging. This is particularly valuable for users who may not be fluent in Python.
+
+Third, DataFrame integration allows code nodes to automatically access data from linked CSV, Excel, or Prism nodes, enabling data analysis workflows where users can ask questions about their data in natural language and receive executable code that produces results.
+
+Fourth, visual output in the drawer panel displays execution results, errors, and matplotlib figures directly in the canvas, maintaining the visual coherence of the application while providing rich feedback.
+
+## Technical Details
+
+### Architecture Overview
+
+The CodeNode implementation consists of three primary modules working in concert.
+
+```text
+CodeNode Architecture:
+┌─────────────────────────────────────────────────────────────────┐
+│                         Frontend                                │
+├─────────────────────────────────────────────────────────────────┤
+│  plugins/code.js                                               │
+│  ├── CodeNode (node protocol) - Rendering, actions, shortcuts  │
+│  └── CodeFeature (feature plugin) - /code cmd, self-healing    │
+├─────────────────────────────────────────────────────────────────┤
+│  pyodide-runner.js - Pyodide runtime management                │
+├─────────────────────────────────────────────────────────────────┤
+│  modal-manager.js - Code editor modal                           │
+├─────────────────────────────────────────────────────────────────┤
+│  index.html - Code editor modal HTML                           │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                         Backend                                 │
+├─────────────────────────────────────────────────────────────────┤
+│  plugins/code_handler.py                                        │
+│  └── /api/generate-code - LLM-powered code generation          │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Pyodide Runtime in Browser
+
+The `pyodide-runner.js` module provides lazy-loading Pyodide initialization and Python code execution. This is the core runtime that enables browser-based Python execution.
+
+#### Lazy Loading Strategy
+
+Pyodide is loaded on-demand to minimize initial page load time. The loading process follows this flow.
+
+```javascript
+async function ensureLoaded() {
+    if (pyodide) return pyodide;
+
+    loadingPromise = (async () => {
+        // Load Pyodide from CDN
+        pyodide = await loadPyodide({
+            indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.26.4/full/',
+        });
+
+        // Pre-load core packages
+        await pyodide.loadPackage(['pandas', 'numpy', 'micropip']);
+
+        return pyodide;
+    })();
+
+    return loadingPromise;
+}
+```
+
+The module exposes a `preload()` function that CodeFeature calls when a code node is created, starting Pyodide loading in the background so it is ready when the user clicks Run.
+
+#### Package Management
+
+Pyodide supports both prebuilt WebAssembly packages and pure Python packages via micropip. The `autoInstallPackages` function handles automatic installation.
+
+```javascript
+async function autoInstallPackages(packages, onProgress) {
+    // First try Pyodide prebuilt packages (faster)
+    await pyodide.loadPackage(pipName);
+
+    // Fall back to micropip for pure Python packages
+    await micropip.install(pipName);
+}
+```
+
+The function extracts import statements from user code, determines which packages need installation, and installs them before execution. Progress callbacks allow the UI to display installation status.
+
+#### DataFrame Injection
+
+When code nodes are linked to CSV, Excel, or Prism nodes, the CSV data is injected as pandas DataFrames into the Pyodide environment.
+
+```javascript
+// Inject CSV data as DataFrames
+for (const [varName, csvString] of Object.entries(csvDataMap)) {
+    // Escape and inject
+    dataInjection += `${varName} = pd.read_csv(io.StringIO("""${escaped}"""))\n`;
+}
+```
+
+A single linked node becomes `df`, while multiple linked nodes become `df`, `df1`, `df2`, etc.
+
+#### Code Execution
+
+The `run()` function executes Python code and captures output, including stdout, return values, and matplotlib figures.
+
+```javascript
+async function run(code, csvDataMap, onInstallProgress) {
+    await ensureLoaded();
+
+    // Extract imports and install packages
+    const imports = extractImports(code);
+    await autoInstallPackages(imports, onInstallProgress);
+
+    // Wrap user code to capture return value (notebook-style)
+    const wrappedCode = `
+        # Setup: capture stdout, setup matplotlib
+        ${setupCode}
+
+        # Inject DataFrames
+        ${dataInjection}
+
+        # Execute user code
+        # Handle last expression specially for notebook-like behavior
+        _result = None
+        if isinstance(_last, ast.Expr):
+            _result = eval(compile(...))
+        else:
+            exec(compile(...))
+
+        # Return results as dict
+        { 'stdout': ..., 'resultHtml': ..., 'resultText': ..., 'figures': [] }
+    `;
+
+    const result = await pyodide.runPythonAsync(wrappedCode);
+    return result.toJs({ dict_converter: Object.fromEntries });
+}
+```
+
+The execution environment captures matplotlib figures and converts them to base64-encoded data URLs, which can then be rendered as Image nodes in the canvas.
+
+### Code Node Protocol (CodeNode)
+
+The `CodeNode` class in `plugins/code.js` extends `BaseNode` and implements the node protocol for code nodes. This defines how code nodes are rendered and what interactions they support.
+
+#### Rendering
+
+```javascript
+class CodeNode extends BaseNode {
+    renderContent(canvas) {
+        const code = this.node.code || this.node.content || '';
+        const executionState = this.node.executionState || 'idle';
+
+        // Build HTML with syntax highlighting, execution state, errors
+        let html = `<div class="code-node-content ${stateClass}">`;
+        html += `<div class="code-display"><pre><code class="language-python">${escapedCode}</code></pre></div>`;
+        html += stateIndicator;
+        if (this.node.lastError) {
+            html += `<div class="code-error-output">${error}</div>`;
+        }
+        html += `</div>`;
+
+        return html;
+    }
+}
+```
+
+The `renderContent` method produces HTML that displays the code with syntax highlighting (via highlight.js), execution state indicators (Running..., error, self-healing status), and inline error messages.
+
+#### Output Panel
+
+The drawer-style output panel is rendered by the `renderOutputPanel` method.
+
+```javascript
+renderOutputPanel(canvas) {
+    const outputHtml = this.node.outputHtml || null;
+    const outputText = this.node.outputText || null;
+    const outputStdout = this.node.outputStdout || null;
+    const installProgress = this.node.installProgress || null;
+
+    let html = `<div class="code-output-panel-content">`;
+    if (installProgress) {
+        html += `<div class="code-install-progress">...</div>`;
+    }
+    if (outputStdout) {
+        html += `<pre class="code-output-stdout">${stdout}</pre>`;
+    }
+    if (outputHtml) {
+        html += `<div class="code-output-result code-output-html">${outputHtml}</div>`;
+    } else if (outputText) {
+        html += `<pre class="code-output-result code-output-text">${text}</pre>`;
+    }
+    html += `</div>`;
+    return html;
+}
+```
+
+The Canvas module (`canvas.js`) handles the drawer animation and positioning, rendering the output panel as a foreignObject that slides out from beneath the node.
+
+#### Actions and Shortcuts
+
+Code nodes provide custom actions and keyboard shortcuts.
+
+```javascript
+getAdditionalActions() {
+    return [Actions.EDIT_CODE, Actions.GENERATE, Actions.RUN_CODE];
+}
+
+getKeyboardShortcuts() {
+    const shortcuts = super.getKeyboardShortcuts();
+    shortcuts['e'] = { action: 'edit-code', handler: 'nodeEditCode' };
+    shortcuts['A'] = { action: 'generate', handler: 'nodeGenerate', shift: true };
+    return shortcuts;
+}
+```
+
+The 'e' key opens the code editor modal instead of the generic edit content modal. Shift+A opens the inline AI code generation input.
+
+### Code Editor Modal
+
+The code editor modal is implemented in `modal-manager.js` and rendered in `index.html`. It provides a split-pane interface with the code editor on the left and a live syntax-highlighted preview on the right.
+
+#### HTML Structure
+
+```html
+<div id="code-editor-modal" class="modal" style="display: none">
+    <div class="modal-content modal-extra-wide">
+        <div class="modal-header">
+            <h2>Edit Code</h2>
+        </div>
+        <div class="modal-body code-editor-body">
+            <div class="code-editor-pane edit-pane">
+                <textarea id="code-editor-textarea" spellcheck="false"></textarea>
+            </div>
+            <div class="code-editor-pane preview-pane">
+                <pre id="code-editor-preview"><code class="language-python"></code></pre>
+            </div>
+        </div>
+        <div class="modal-actions">
+            <button id="code-editor-cancel">Cancel</button>
+            <button id="code-editor-save">Save</button>
+        </div>
+    </div>
+</div>
+```
+
+#### Live Preview
+
+The modal updates the preview pane on every keystroke using highlight.js.
+
+```javascript
+updateCodeEditorPreview() {
+    const textarea = document.getElementById('code-editor-textarea');
+    const preview = document.getElementById('code-editor-preview');
+    const code = textarea.value;
+
+    const codeEl = preview.querySelector('code');
+    if (codeEl && window.hljs) {
+        codeEl.textContent = code;
+        window.hljs.highlightElement(codeEl);
+    }
+}
+```
+
+This provides immediate feedback on code validity and structure without requiring the code to be executed.
+
+### CodeFeature Plugin
+
+The `CodeFeature` class extends `FeaturePlugin` and provides the slash command handling and self-healing functionality.
+
+#### Slash Command
+
+```javascript
+getSlashCommands() {
+    return [
+        {
+            command: '/code',
+            description: 'Create a Python code node',
+            placeholder: 'Optional: Describe code to generate...',
+        },
+    ];
+}
+```
+
+The `/code` command creates a new code node. If the user provides arguments, it triggers AI code generation. If CSV/Excel/Prism nodes are selected, the code node is pre-populated with a template that includes the DataFrames.
+
+#### Self-Healing
+
+The self-healing mechanism automatically attempts to fix code errors by asking the LLM to regenerate the code.
+
+```javascript
+async selfHealCode(nodeId, originalPrompt, model, context, attemptNum = 1, maxAttempts = 3) {
+    // Run the code
+    const result = await this.pyodideRunner.run(code, csvDataMap, onInstallProgress);
+
+    if (result.error) {
+        if (attemptNum >= maxAttempts) {
+            // Show final error
+            return;
+        }
+
+        // Ask LLM to fix the error
+        await this.fixCodeError(nodeId, originalPrompt, model, context,
+                                 code, result.error, attemptNum, maxAttempts);
+        return;
+    }
+
+    // Success - store output
+}
+```
+
+The flow is as follows. First, the code is executed with Pyodide. If it succeeds, the output is stored and displayed. If it fails, the error message is sent to the LLM along with the original prompt, asking for a fix. This process repeats up to 3 times.
+
+#### Fix Prompt Generation
+
+```javascript
+async fixCodeError(nodeId, originalPrompt, model, context, failedCode, errorMessage, attemptNum) {
+    let fixPrompt = `The previous code failed with this error:
+
+\`\`\`
+${errorMessage}
+\`\`\`
+
+Failed code:
+\`\`\`python
+${failedCode}
+\`\`\`
+
+Please fix the error and provide corrected Python code that accomplishes the original task: "${originalPrompt}"
+
+Output ONLY the corrected Python code, no explanations.`;
+
+    // Stream fixed code, then re-run with selfHealCode
+}
+```
+
+### DataFrame Introspection
+
+Before generating code, the system introspects linked DataFrames to provide the LLM with schema information.
+
+```javascript
+async introspectDataFrames(csvDataMap) {
+    const results = [];
+
+    for (const [varName, csvData] of Object.entries(csvDataMap)) {
+        const code = `
+${varName} = pd.read_csv(io.StringIO("""${escaped}"""))
+info = {
+    "varName": "${varName}",
+    "columns": list(${varName}.columns),
+    "dtypes": {col: str(dtype) for col, dtype in ${varName}.dtypes.items()},
+    "shape": list(${varName}.shape),
+    "head": ${varName}.head(3).to_csv(index=False)
+}
+print(json.dumps(info))
+`;
+        const result = await run(code, {});
+        results.push(JSON.parse(result.stdout));
+    }
+
+    return results;
+}
+```
+
+This metadata is sent to the LLM when generating code, ensuring it uses the correct column names and data types.
+
+### Backend Code Generation
+
+The backend `/api/generate-code` endpoint uses LiteLLM to generate Python code from natural language prompts.
+
+```python
+@app.post("/api/generate-code")
+async def generate_code(request: GenerateCodeRequest, http_request: Request):
+    # Build system prompt with DataFrame context
+    system_parts = []
+    system_parts.append("You are a Python code generator. Output ONLY valid Python code.")
+
+    # Add DataFrame context
+    if request.dataframe_info:
+        for df_info in request.dataframe_info:
+            system_parts.append(f"Variable: {df_info.varName}")
+            system_parts.append(f"Columns: {df_info.columns}")
+            system_parts.append(f"Sample: {df_info.head}")
+
+    # Add conversation context
+    if request.context:
+        system_parts.append(f"[{msg.role}]: {msg.content}")
+
+    # Stream response
+    response = await litellm.acompletion(
+        model=request.model,
+        messages=[{"role": "system", "content": system_prompt},
+                  {"role": "user", "content": request.prompt}],
+        stream=True
+    )
+
+    async for chunk in response:
+        yield {"event": "message", "data": chunk.choices[0].delta.content}
+```
+
+The backend is a thin proxy that constructs prompts and streams responses. All code execution happens in the browser.
+
+## Output Panel Rendering
+
+The drawer-style output panel is implemented in `canvas.js` and follows a consistent pattern used by other node types (PowerPointNode, MatrixNode, etc.).
+
+### Positioning
+
+The panel is positioned beneath the node with a slight overlap, creating the effect of sliding out from underneath.
+
+```javascript
+const panelWidthRatio = 0.9;
+const panelWidth = nodeWidth * panelWidthRatio;
+const panelX = nodeX + (nodeWidth - panelWidth) / 2;
+
+// Slides out from underneath with overlap
+const panelOverlap = 10;
+const panelY = nodeY + nodeHeight - panelOverlap;
+```
+
+### Collapsed and Expanded States
+
+The panel has two states. The collapsed state shows only a small toggle tab (24px height). The expanded state shows the full content up to the configured height (default 200px, user-resizable).
+
+```javascript
+const collapsedHeight = 24;
+const actualHeight = outputExpanded ? panelHeight : collapsedHeight;
+```
+
+### Animation
+
+When the panel first expands, it animates from collapsed to expanded for a smooth visual effect.
+
+```javascript
+if (shouldAnimate) {
+    // Start collapsed
+    panelWrapper.setAttribute('height', collapsedHeight + panelOverlap);
+    panelBody.style.opacity = '0';
+
+    // Animate to expanded
+    // ... animation code with CSS transitions
+}
+```
+
+### Toggle and Resize
+
+The panel footer contains a toggle button and a resize handle for user interaction.
+
+```javascript
+panelDiv.innerHTML = `
+    <div class="code-output-panel-inner">
+        <div class="code-output-panel-body">
+            ${wrapped.renderOutputPanel(this)}
+        </div>
+        <div class="code-output-panel-footer">
+            <button class="code-output-toggle">▲/▼</button>
+            <div class="code-output-resize-handle"></div>
+        </div>
+    </div>
+`;
+```
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. ✅ Python via Pyodide - best ecosystem for data analysis
+2. ✅ Self-healing mechanism - up to 3 auto-fix attempts
+
+### Deferred
+
+1. Multi-language support (R via WebR, JavaScript)
+2. Advanced editor features (Monaco, CodeMirror)
+3. Code persistence/version history
+4. Collaborative editing support
+5. Server-side execution option
+
+## References to HLD
+
+This LLD supports several design decisions from the High-Level Design.
+
+1. **Local-First** (HLD Section 4.1): All code execution happens in the browser via Pyodide. No code is sent to the backend for execution, keeping user data local and eliminating security concerns.
+
+2. **Plugin-Extensible** (HLD Section 4.3): CodeFeature is implemented as a feature plugin with extension hooks for self-healing events (`selfheal:before`, `selfheal:error`, `selfheal:fix`, `selfheal:success`, `selfheal:failed`). This allows other plugins to customize or intercept the self-healing process.
+
+3. **Data Nodes** (HLD Section 6): CodeNode integrates with Data nodes (CSV, Excel, Prism) by automatically injecting their csvData as DataFrames. This enables natural language data analysis workflows.
+
+4. **Streaming-First** (HLD Section 4.4): Code generation streams token-by-token into the editor. The StreamingManager coordinates multiple concurrent code generations if needed.
+
+5. **Chat-First, Visual Second** (HLD Section 2): The /code slash command creates a code node that can then be executed, with results displayed visually in the canvas. The node integrates seamlessly with the conversational workflow.

--- a/docs/llds/committee-feature.md
+++ b/docs/llds/committee-feature.md
@@ -1,0 +1,458 @@
+# Low-Level Design: CommitteeFeature
+
+**Created**: 2026-03-16
+**Status**: Implementation
+**Module**: CommitteeFeature (multi-LLM consultation)
+
+## Context and Design Philosophy
+
+The CommitteeFeature implements a multi-LLM consultation system that queries multiple AI models in parallel and synthesizes their responses into a coherent answer. This feature addresses the fundamental limitation of single-model AI interactions: different models have different strengths, training data, biases, and blind spots.
+
+The design philosophy centers on four principles. First, independence is maintained through parallel opinion generation, ensuring no model is influenced by others' responses before providing its own perspective. Second, transparency keeps all individual opinions visible on the canvas, allowing users to see the full range of perspectives rather than a black-box aggregate. Third, optional depth is provided via an optional peer review phase where models critique each other's opinions before synthesis. Fourth, meta-analysis is delivered through a chairman synthesis step that identifies consensus, disagreement, and provides a coherent final answer.
+
+## Technical Overview
+
+### Slash Command Entry Point
+
+The feature is accessed via the `/committee` slash command, which accepts a question as arguments. The command is registered in the FeatureRegistry and handled by the `handleCommittee` method in `CommitteeFeature`.
+
+```text
+/committee What are the pros and cons of using microservices vs monolithic architecture?
+```
+
+When invoked, the command:
+
+1. Parses the question from command arguments
+2. Checks for selected nodes to use as conversation context
+3. Opens the Committee modal for model selection and configuration
+
+### Modal for Model Selection
+
+The Committee modal (`committee-main-modal`) presents a multi-step configuration interface:
+
+1. **Question Display**: Shows the user's question (read-only, for reference)
+2. **Persona Suggestions**: AI-generated persona suggestions based on the question (optional presets available)
+3. **Committee Members**: 2-5 models with optional persona prompts
+4. **Chairman Selection**: Separate model for synthesis
+5. **Options**: Toggle for review phase and web grounding
+
+The modal enforces validation: exactly 2-5 committee members are required, and the Execute button is disabled until valid.
+
+### Persona System
+
+Each committee member can optionally receive a persona prompt that shapes their perspective. The system provides two sources of personas:
+
+**Static Presets** (8 built-in):
+
+- Skeptical Scientist
+- Optimistic Entrepreneur
+- Cautious Risk Analyst
+- Creative Brainstormer
+- Devil's Advocate
+- Pragmatic Engineer
+- User Experience Advocate
+- Ethical Reviewer
+
+**Dynamic Suggestions**: An LLM generates 3 context-appropriate personas based on the question. These can be accepted (populating a new committee member) or manually edited.
+
+## Node Types
+
+The CommitteeFeature creates three distinct node types on the canvas:
+
+### Opinion Nodes
+
+Each committee member generates an opinion node with type `NodeType.OPINION`. These nodes contain:
+
+- **Header**: Model name and persona (if any)
+- **Content**: The model's response to the question
+- **Metadata**: `{ model, persona }` stored in node data
+- **Dimensions**: Default 640x480 pixels
+
+Opinion nodes are created with "Waiting for..." placeholder content that updates as streaming begins.
+
+### Review Nodes
+
+When the "Include review stage" option is enabled, each model also generates a review node with type `NodeType.REVIEW`. These nodes contain:
+
+- **Header**: "{Model} Review"
+- **Content**: The model's critique of other opinions
+- **Metadata**: `{ model, persona, reviewedOpinions: [...] }`
+- **Edge**: Connected from the reviewer's opinion node
+
+Review nodes are positioned below opinion nodes in the visual layout.
+
+### Synthesis Node
+
+The chairman model generates a synthesis node with type `NodeType.SYNTHESIS`. This node contains:
+
+- **Header**: "Synthesis ({Chairman Name})"
+- **Content**: Meta-analysis of all opinions (and reviews if enabled)
+- **Metadata**: `{ model: chairmanModel }`
+- **Edge**: Connected from all opinion nodes (or review nodes if enabled)
+
+The synthesis node is the final node in the committee flow, positioned below all opinions and reviews.
+
+## Edge Types
+
+The CommitteeFeature creates three edge types to represent relationships between nodes:
+
+| Edge Type            | From                 | To             | Meaning                             |
+| -------------------- | -------------------- | -------------- | ----------------------------------- |
+| `EdgeType.OPINION`   | Human (question)     | Opinion nodes  | How the question reached each model |
+| `EdgeType.REVIEW`    | Opinion node         | Review node    | The opinion being reviewed          |
+| `EdgeType.SYNTHESIS` | Opinion/Review nodes | Synthesis node | Inputs to final synthesis           |
+
+## Execution Flow
+
+### Phase 1: Setup and Web Grounding (Optional)
+
+1. Create the human question node
+2. If web grounding enabled:
+    - Derive search query from question
+    - Run web search
+    - Append sources to question node
+    - Inject search results into message context for all models
+
+### Phase 2: Parallel Opinion Generation
+
+All committee members generate opinions simultaneously:
+
+```text
+Promise.all([
+  generateOpinion(node1, model1, messages),
+  generateOpinion(node2, model2, messages),
+  generateOpinion(node3, model3, messages),
+])
+```
+
+Each opinion:
+
+1. Injects persona as system prompt if provided
+2. Registers with StreamingManager (enables stop/continue buttons)
+3. Streams response to canvas in real-time
+4. Updates graph on completion
+
+The canvas shows a fan layout with opinion nodes spread horizontally below the question node.
+
+### Phase 3: Parallel Review Generation (Optional)
+
+If review is enabled, each model generates a review of all other opinions:
+
+```text
+Promise.all([
+  generateReview(opinion1, model1, [opinion2, opinion3]),
+  generateReview(opinion2, model2, [opinion1, opinion3]),
+  generateReview(opinion3, model3, [opinion1, opinion2]),
+])
+```
+
+Each review prompt includes:
+
+- Original question context
+- All other opinions (anonymized or labeled)
+- Instruction to critique strengths, weaknesses, and disagreements
+
+Review nodes are positioned in a second row below the opinion nodes.
+
+### Phase 4: Chairman Synthesis
+
+After all opinions (and reviews) complete, the chairman model synthesizes:
+
+1. Receives all opinions (and reviews if enabled)
+2. Receives prompt to identify consensus and disagreements
+3. Streams synthesis to final node
+4. Connects all source nodes to synthesis node
+
+### Phase 5: Web Sources Appended
+
+If web grounding was enabled, sources are appended to:
+
+- Each opinion node
+- Synthesis node
+
+This ensures citations are visible at every level.
+
+## Streaming and Abort Handling
+
+### StreamingManager Integration
+
+Each opinion, review, and synthesis generation registers with StreamingManager:
+
+```javascript
+this.streamingManager.register(nodeId, {
+    abortController,
+    featureId: 'committee',
+    context: { model, modelName, messages, index, nodeId, persona },
+    onContinue: async (nodeId, state) => {
+        await this.continueOpinion(nodeId, state.context);
+    },
+});
+```
+
+This enables:
+
+- **Stop button**: Appears in node header, aborts this specific stream
+- **Continue button**: Appears after stopping, resumes from stored content
+- **Parallel abort**: Each stream has independent abort controller
+
+### Continue/Resume Functionality
+
+The feature implements full continue capability for all three phases:
+
+- `continueOpinion()`: Appends "Please continue your response" to messages
+- `continueReview()`: Builds continuation with original review context
+- `continueSynthesis()`: Continues synthesis with all opinions context
+
+Each continue method:
+
+1. Retrieves current node content
+2. Builds messages including that content
+3. Continues streaming from where it left off
+4. Updates both canvas and graph
+
+### Abort Handling
+
+The `abort()` method handles user-initiated cancellation:
+
+```javascript
+abort() {
+    for (const [nodeId, abortController] of this._activeCommittee.abortControllers) {
+        abortController.abort();
+        this.streamingManager.unregister(nodeId);
+    }
+}
+```
+
+Aborts are handled gracefully:
+
+- Aborted opinions resolve with empty string (allowing others to continue)
+- Aborted reviews similarly resolve, preventing cascade failures
+- Synthesis continues if it has at least one opinion to work with
+
+## Data Structures
+
+### Committee Data State
+
+```javascript
+{
+    question: string,           // User's question
+    context: string | null,       // Selected node content
+    members: Array<{              // Committee members
+        model: string,            // Model ID (e.g., "openai/gpt-4o")
+        persona: string           // Persona prompt (optional)
+    }>,
+    chairmanModel: string,        // Chairman model ID
+    includeReview: boolean,      // Whether review phase enabled
+    personaSuggestions: Array,    // AI-generated personas
+}
+```
+
+### Active Committee State
+
+```javascript
+{
+    opinionNodeIds: string[],     // IDs of opinion nodes
+    reviewNodeIds: string[],      // IDs of review nodes
+    synthesisNodeId: string,      // ID of synthesis node
+    abortControllers: Map<string, AbortController>,
+}
+```
+
+### Node Metadata
+
+Opinion nodes store:
+
+```javascript
+{
+    model: string,    // e.g., "openai/gpt-4o"
+    persona: string,  // e.g., "You are a skeptical scientist..."
+}
+```
+
+Review nodes store:
+
+```javascript
+{
+    model: string,
+    persona: string,
+    reviewedOpinions: number[],  // Indices of opinions reviewed
+}
+```
+
+Synthesis nodes store:
+
+```javascript
+{
+    model: string,   // Chairman model
+}
+```
+
+## Layout Algorithm
+
+The committee uses a fan layout calculated in `executeCommittee()`:
+
+```javascript
+const basePos = humanNode.position;
+const spacing = 380;
+const verticalOffset = 200;
+const totalWidth = (members.length - 1) * spacing;
+const startX = basePos.x - totalWidth / 2;
+
+// Opinion nodes: row 1
+position: { x: startX + i * spacing, y: basePos.y + verticalOffset }
+
+// Review nodes: row 2 (if enabled)
+position: { x: startX + i * spacing, y: basePos.y + verticalOffset * 2 }
+
+// Synthesis node: centered below
+position: { x: basePos.x, y: basePos.y + verticalOffset * (includeReview ? 3 : 2) }
+```
+
+After layout is calculated:
+
+1. Nodes are created and added to graph
+2. Edges are created connecting question to opinions
+3. Canvas renders nodes
+4. Viewport zooms to fit entire committee
+
+## Integration Points
+
+### FeatureRegistry Registration
+
+CommitteeFeature is registered as a built-in feature with priority `PRIORITY.BUILTIN`:
+
+```javascript
+import { CommitteeFeature } from './plugins/committee.js';
+
+registry.registerFeature(new CommitteeFeature(ctx), PRIORITY.BUILTIN);
+```
+
+### Slash Command
+
+The `/committee` command is declared in `getSlashCommands()`:
+
+```javascript
+getSlashCommands() {
+    return [
+        {
+            command: '/committee',
+            description: 'Ask multiple LLMs and synthesize their perspectives',
+            placeholder: 'Your question for the committee...',
+        },
+    ];
+}
+```
+
+### AppContext Dependencies
+
+CommitteeFeature uses these injected dependencies:
+
+- `this.graph`: Add/update nodes and edges
+- `this.canvas`: Render nodes, update content, viewport control
+- `this.chat`: Send messages to LLM providers
+- `this.modelPicker`: Get available models, current selection
+- `this.modalManager`: Register and show committee modal
+- `this.streamingManager`: Register streaming, show stop/continue buttons
+- `this.chatInput`: Clear input after execution
+- `this.storage`: Track recently used models
+- `this.saveSession()`: Persist after each phase
+- `this.showToast()`: User notifications
+- `this.buildLLMRequest()`: Used for web search query derivation
+
+## Error Handling
+
+### Opinion Failure
+
+If one opinion fails:
+
+- Committee continues with remaining models
+- Synthesis receives available opinions only
+- Failed node shows error message
+- Other streams continue unaffected
+
+### Review Failure
+
+If review fails:
+
+- Error shown in review node
+- Synthesis proceeds without that review
+- Other reviews continue
+
+### Synthesis Failure
+
+If synthesis fails:
+
+- All opinions remain visible and usable
+- User can read individual opinions as fallback
+- Error shown in synthesis node
+
+### Network/Abort Errors
+
+Distinguished from other errors:
+
+- `AbortError`: Graceful cancellation, resolves with empty content
+- Other errors: Logged, shown in node, may affect downstream phases
+
+## CSS and Styling
+
+Committee modal styles are defined in `modals.css` with these key classes:
+
+- `.committee-question-group`: Question textarea
+- `.committee-suggestions-*`: Persona suggestion cards
+- `.committee-members-*`: Member configuration rows
+- `.committee-member-row`: Individual member configuration
+- `.committee-member-model`: Model dropdown
+- `.committee-member-persona`: Persona input with preset dropdown
+- `.committee-options-group`: Checkboxes for review and web grounding
+- `.committee-chairman-group`: Chairman model selector
+
+## Testing Considerations
+
+### Unit Tests
+
+Key pure functions for testing:
+
+- `formatSourcesSection()`: Formats web search results as markdown
+
+### Integration Tests
+
+Test files:
+
+- `tests/test_committee_plugin.js`: CommitteeFeature plugin tests
+- `tests/test_committee_*.js` (if created): Specific phase tests
+
+### E2E Tests
+
+Relevant Cypress tests:
+
+- Tests for modal interactions
+- Tests for streaming behavior
+- Tests for abort handling
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. **Parallel vs Sequential**: Parallel was chosen for speed and independence
+2. **Optional Review**: Review is optional to balance cost vs thoroughness
+3. **Persona Sources**: Both static presets and dynamic suggestions implemented
+4. **Web Grounding**: Optional feature to provide current information to all models
+
+### Deferred / Future
+
+1. **Configurable synthesis prompts**: Allow customizing chairman instructions
+2. **Model expertise hints**: Tag models with domains, weight opinions accordingly
+3. **Cost estimation**: Show estimated API cost before starting committee
+4. **Multiple chairmen**: Run parallel syntheses with different chairmen
+5. **Follow-up committees**: Iterative refinement after initial synthesis
+6. **Tournament bracket**: Large model sets (10+) compete in rounds
+
+## References
+
+- **HLD**: `/docs/high-level-design.md` - Context on multi-LLM as a core feature
+- **Explanation**: `/docs/explanation/committee-architecture.md` - Design rationale and alternatives
+- **How-to**: `/docs/how-to/llm-committee.md` - User documentation
+- **Implementation**: `src/canvas_chat/static/js/plugins/committee.js` - Full source
+- **Node Types**: `src/canvas_chat/static/js/graph-types.js:235-237`
+- **Edge Types**: `src/canvas_chat/static/js/graph-types.js:304-306`
+- **Default Sizes**: `src/canvas_chat/static/js/graph-types.js:265-267`

--- a/docs/llds/crdt-graph.md
+++ b/docs/llds/crdt-graph.md
@@ -1,0 +1,113 @@
+# CRDTGraph: Chat History Data Model
+
+**Created**: 2026-03-16
+**Status**: Design Phase
+
+## Context and Design Philosophy
+
+The graph data model stores chat conversation history. Every message, its position on canvas, and relationships to other messages (replies, branches) are tracked here. Using CRDT (Conflict-free Replicated Data Type) enables future multiplayer collaboration and handles conflict resolution gracefully.
+
+## Yjs Integration
+
+### CRDT Structures
+
+```javascript
+yNodes; // Y.Map - nodeId → node properties
+yEdges; // Y.Array - array of edge objects
+yTags; // Y.Map - tag color → {name, color}
+```
+
+### Value Handling
+
+Different node properties use different Yjs types:
+
+| Property         | Yjs Type  | Why                                  |
+| ---------------- | --------- | ------------------------------------ |
+| `content`        | `Y.Text`  | Collaborative editing, delta updates |
+| `position`       | `Y.Map`   | x, y coordinates                     |
+| `tags`           | `Y.Array` | List of tag colors                   |
+| `cells` (matrix) | `Y.Map`   | Nested object structure              |
+| `metadata`       | `Y.Map`   | Generic nested, recursively handled  |
+
+### Duck Typing
+
+The graph uses duck typing instead of `instanceof` to check Yjs types. This avoids issues with Yjs object duplication after IndexedDB round-trips.
+
+## Persistence
+
+### IndexedDB
+
+Data persists to browser IndexedDB via `y-indexeddb`:
+
+```text
+Database: crdt-{sessionId}
+```
+
+### Legacy Data Fallback
+
+On load:
+
+1. Load from IndexedDB (CRDT)
+2. Also load from legacy IndexedDB (simple JSON)
+3. CRDT data overlays on legacy
+4. This ensures backward compatibility
+
+## Graph Traversal
+
+### Relationships
+
+- **Parents**: Nodes that this node replies to
+- **Children**: Nodes that reply to this node
+- **Descendants**: All children, recursively
+- **Ancestors**: All parents, recursively
+
+### Useful Queries
+
+| Method                | Returns                                |
+| --------------------- | -------------------------------------- |
+| `getParents(nodeId)`  | Nodes with edges pointing to this node |
+| `getChildren(nodeId)` | Nodes this node points to              |
+| `getRootNodes()`      | Nodes with no parents                  |
+| `getLeafNodes()`      | Nodes with no children                 |
+| `topologicalSort()`   | Nodes in dependency order              |
+
+## Events
+
+The graph emits events when data changes:
+
+| Event                        | When                |
+| ---------------------------- | ------------------- |
+| `nodeAdded`                  | Node added to graph |
+| `nodeRemoved`                | Node removed        |
+| `nodeUpdated`                | Properties changed  |
+| `edgeAdded`                  | Edge created        |
+| `edgeRemoved`                | Edge removed        |
+| `tagCreated/Updated/Deleted` | Tag changes         |
+
+These events let the Canvas know to re-render.
+
+## Multiplayer (Optional)
+
+WebRTC provider enables peer-to-peer sync:
+
+- **Signaling**: Current host + `/signal` endpoint
+- **Awareness**: See other users' cursors, lock nodes during edit
+
+This is optional - single-user mode works without it.
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. ✅ CRDT chosen over OT or simple JSON - better conflict resolution for multiplayer
+2. ✅ Legacy data as source of truth - ensures consistency during migration
+
+### Deferred
+
+1. How to handle very large graphs? Virtualization?
+2. Sync conflicts in multiplayer - need UX for resolution
+
+## References
+
+- HLD: `/docs/high-level-design.md`
+- Implementation: `src/canvas_chat/static/js/crdt-graph.js`

--- a/docs/llds/data-import-nodes.md
+++ b/docs/llds/data-import-nodes.md
@@ -1,0 +1,442 @@
+# Data Import Nodes Low-Level Design
+
+**Project:** Canvas-Chat
+**Created:** 2026-03-16
+**Status:** Implementation
+**Related HLD:** `/docs/high-level-design.md`
+
+## Context and Design Philosophy
+
+The data import nodes exist to bridge external tabular data with Canvas-Chat's conversational workflow. Users frequently work with spreadsheet-like data from CSV files, Excel workbooks, and scientific software exports, and need a way to visualize, explore, and analyze this data within their conversations.
+
+The design philosophy centers on three principles:
+
+1. **Seamless import workflow** - Users drag or drop files, and nodes appear automatically. No intermediate steps or configuration dialogs. The system intelligently parses the file format and creates appropriately typed nodes.
+
+2. **One-to-many node creation** - When a file contains multiple logical tables (Excel sheets, Prism tables), the system creates multiple nodes. This preserves the conceptual structure of the data rather than flattening it into a single node.
+
+3. **Code-ready data** - Every imported table exposes its data as a CSV string (`csvData`), enabling immediate analysis via the `/code` feature. This tight coupling between data import and code execution makes iterative analysis frictionless.
+
+This node type directly supports the HLD's "Data" category: "Matrices for evaluation, tables from CSV/Excel."
+
+## Technical Details
+
+### Node Data Structure
+
+All three data import node types share a common structure, with type-specific metadata:
+
+```javascript
+{
+    id: string,                    // UUID
+    type: 'csv' | 'excel' | 'prism', // Node type identifier
+    content: string,               // Markdown table preview (first 5 rows)
+    csvData: string,               // Full data as CSV string for /code integration
+    filename: string,              // Original filename
+    columns: string[],             // Column headers
+    rowCount: number,              // Total row count
+    columnCount: number,           // Total column count
+
+    // Type-specific fields
+    // Excel only:
+    sheetName: string,             // Sheet name (one node per sheet)
+
+    // Prism only:
+    tableTitle: string,            // Table title from .pzfx
+    tableIndex: number,            // Zero-based table index
+
+    position: { x: number, y: number },
+    width: number,                 // Default: 640
+    height: number,                // Default: 480
+    created_at: number,
+    tags: string[],
+    title: string | null,
+    summary: string | null,
+    model: string | null,
+    selection: any,
+}
+```
+
+### Three-Component Architecture
+
+Each data import type combines three plugin concepts:
+
+1. **Node Protocol** (Level 1): Extends `BaseNode` protocol. Handles rendering, action buttons, and the Analyze workflow. Registered with `NodeRegistry`.
+
+2. **File Upload Handler** (Level 1 extension): Extends `FileUploadHandlerPlugin`. Handles file parsing, multi-node creation, and csvData generation. Registered with `FileUploadRegistry`.
+
+3. **Shared UI Pattern**: All three types render similarly via `renderContent()`, showing metadata header (filename, dimensions, columns) followed by markdown table preview.
+
+This architecture follows the plugin system: node protocols handle rendering, upload handlers handle file processing.
+
+### CSV Handler
+
+#### CSV Parsing Pipeline
+
+The CSV handler uses Papa Parse for robust CSV parsing:
+
+```javascript
+// Read file as text
+const text = await file.text();
+
+// Parse with Papa Parse
+const parseResult = Papa.parse(text, {
+    header: true, // First row as column names
+    skipEmptyLines: true, // Ignore empty rows
+    dynamicTyping: true, // Auto-convert numbers/booleans
+});
+
+const data = parseResult.data;
+const columns = parseResult.meta.fields;
+```
+
+#### CSV Validation
+
+- **File extension**: Must end with `.csv`
+- **MIME type**: Must be `text/csv`
+- **Size limit**: 10 MB maximum
+
+#### CSV csvData Generation
+
+The raw file text is stored directly as `csvData`:
+
+```javascript
+csvData: text; // Store raw CSV string for code execution
+```
+
+This preserves the original formatting and lets pandas infer types during parsing in Python.
+
+### Excel Handler
+
+#### Excel Parsing Pipeline
+
+The Excel handler uses SheetJS (XLSX) library:
+
+```javascript
+// Read file as ArrayBuffer
+const arrayBuffer = await file.arrayBuffer();
+const workbook = XLSX.read(arrayBuffer, { type: 'array' });
+
+// Iterate over all sheets
+for (const sheetName of workbook.SheetNames) {
+    const sheet = workbook.Sheets[sheetName];
+
+    // Convert to array-of-arrays (header: 1 means first row as header)
+    const rows = XLSX.utils.sheet_to_json(sheet, { header: 1, defval: '' });
+}
+```
+
+#### Excel Multi-Node Creation
+
+One node is created for each sheet in the workbook:
+
+```javascript
+for (const sheetName of workbook.SheetNames) {
+    // ... parse sheet data ...
+
+    const excelNode = createNode(NodeType.EXCEL, previewContent, {
+        position: nodePosition,
+        title: `${file.name} — ${sheetName}`,
+        filename: file.name,
+        sheetName,
+        csvData: csvString,
+        columns,
+        rowCount,
+        columnCount,
+    });
+
+    createdNodes.push(excelNode);
+    nodePosition = graph.autoPosition(createdNodes.map((n) => n.id));
+}
+```
+
+Nodes are positioned automatically using `graph.autoPosition()` to avoid overlaps.
+
+#### Excel csvData Generation
+
+Excel data is converted to CSV format with proper escaping:
+
+```javascript
+const escapeCsv = (val) => {
+    const s = String(val ?? '');
+    if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+        return '"' + s.replace(/"/g, '""') + '"';
+    }
+    return s;
+};
+
+const csvLines = [columns.map(escapeCsv).join(',')];
+for (const row of dataRows) {
+    csvLines.push(columns.map((_, i) => escapeCsv(row[i])).join(','));
+}
+const csvString = csvLines.join('\n');
+```
+
+#### Excel Validation
+
+- **File extension**: Must end with `.xlsx` or `.xls`
+- **MIME types**: `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet` or `application/vnd.ms-excel`
+- **Size limit**: 15 MB maximum
+- **Library check**: Validates that `XLSX` is loaded before parsing
+
+### Prism Handler
+
+#### File Format
+
+GraphPad Prism `.pzfx` files are XML documents containing one or more data tables. The structure:
+
+```xml
+<GraphPad Prism file>
+    <Table Title="Data 1">
+        <XColumn>
+            <Subcolumn>
+                <d>value</d>  <!-- One d per row -->
+            </Subcolumn>
+        </XColumn>
+        <YColumn>
+            <Subcolumn>
+                <d>value</d>
+            </Subcolumn>
+        </YColumn>
+    </Table>
+    <HugeTable Title="Data 2">
+        <!-- Alternative table type -->
+    </HugeTable>
+</GraphPad>
+```
+
+Key structural concepts:
+
+- **Table/HugeTable**: Container for one data table
+- **XColumn/YColumn**: Data columns (X is typically independent variable)
+- **Subcolumn**: Prism allows replicates within a column; each subcolumn is one logical column in the output
+- **d elements**: One value per row
+
+#### Prism Parsing Pipeline
+
+The handler uses DOMParser to read the XML:
+
+```javascript
+const text = await file.text();
+const parser = new DOMParser();
+const doc = parser.parseFromString(text, 'text/xml');
+
+// Check for parse errors
+const parseError = doc.querySelector('parsererror');
+if (parseError) {
+    throw new Error('Invalid or unsupported Prism XML.');
+}
+```
+
+#### Prism Multi-Node Creation
+
+One node is created for each Table or HugeTable element:
+
+```javascript
+function parsePzfxTables(doc) {
+    const allTables = getByLocalName(doc.documentElement, 'Table');
+    const allHuge = getByLocalName(doc.documentElement, 'HugeTable');
+
+    for (const tableEl of [...allTables, ...allHuge]) {
+        // Extract column data, handle subcolumns
+        // Create table object with rows and columnHeaders
+    }
+    return tables;
+}
+```
+
+#### Column Expansion
+
+Prism's subcolumn structure is flattened into standard CSV columns:
+
+```javascript
+// Each subcolumn becomes one CSV column
+for (const subcolumnValues of subcolumnValuesArray) {
+    expandedColumns.push(subcolumnValues);
+    const header = subcolumnValues.length === 1 ? colTitle : `${colTitle} (${subcolumnIndex + 1})`;
+    columnHeaders.push(header);
+}
+```
+
+#### Prism csvData Generation
+
+Same CSV escaping pattern as Excel:
+
+```javascript
+const escapeCsv = (val) => {
+    const s = String(val ?? '');
+    if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+        return '"' + s.replace(/"/g, '""') + '"';
+    }
+    return s;
+};
+```
+
+#### Prism Validation
+
+- **File extension**: Must end with `.pzfx`
+- **Size limit**: 10 MB maximum
+- **XML validation**: Parser must not produce errors
+
+## csvData for /code Integration
+
+### Overview
+
+The `csvData` property is the key integration point between data import nodes and the `/code` feature. It stores the complete table data as a CSV-formatted string, enabling direct analysis without re-parsing.
+
+### Detection Logic
+
+When `/code` is invoked (slash command or Analyze button), the system identifies linked data nodes:
+
+```javascript
+const csvNodeIds = selectedIds.filter((id) => {
+    const node = graph.getNode(id);
+    return node && node.csvData && [NodeType.CSV, NodeType.EXCEL, NodeType.PRISM].includes(node.type);
+});
+```
+
+### Variable Naming
+
+When multiple data nodes are linked, variables are named systematically:
+
+```javascript
+const csvNames = csvNodeIds.length === 1 ? ['df'] : csvNodeIds.map((_, i) => `df${i + 1}`);
+// Example: ['df'] or ['df1', 'df2', 'df3']
+```
+
+### Code Template Generation
+
+The `/code` feature generates starter code that pre-loads the data:
+
+```javascript
+if (csvNodeIds.length > 0) {
+    initialCode = `# Available DataFrames: ${csvNames.join(', ')}
+# Analyze the data
+
+import pandas as pd
+
+# Example: Display first few rows
+${csvNames[0]}.head()
+`;
+}
+```
+
+### Pyodide Execution
+
+When the code runs, the `csvData` is injected into the Pyodide environment:
+
+```javascript
+async function run(code, csvDataMap, onInstallProgress) {
+    await ensureLoaded();
+
+    // Inject CSV data as DataFrames
+    let dataInjection = '';
+    for (const [varName, csvString] of Object.entries(csvDataMap)) {
+        const escaped = csvString.replace(/\\/g, '\\\\').replace(/"""/g, '\\"""').replace(/\n/g, '\\n');
+        dataInjection += `${varName} = pd.read_csv(io.StringIO("""${escaped}"""))\n`;
+    }
+
+    // Execute with data injected
+    await pyodide.runPythonAsync(`${dataInjection}\n${code}`);
+}
+```
+
+### Analyze Button Workflow
+
+Each data node type provides an Analyze action that creates a linked Code node:
+
+```javascript
+analyze(nodeId, canvas, graph) {
+    const dataNode = graph.getNode(nodeId);
+
+    const starterCode = `# Analyzing: ${dataNode.title}
+import pandas as pd
+
+# DataFrame is pre-loaded as 'df'
+df.head()
+`;
+
+    const codeNode = createNode(NodeType.CODE, starterCode, {
+        csvNodeIds: [nodeId],  // Link to source data node
+    });
+
+    // Create GENERATES edge from data to code
+    const edge = createEdge(nodeId, codeNode.id, EdgeType.GENERATES);
+}
+```
+
+This creates a visual and functional relationship between the data and analysis.
+
+## Extension Hooks
+
+Currently, data import nodes do not emit custom events. Future plugins could hook into:
+
+- `dataimport:before` - Fires before file processing starts
+- `dataimport:after` - Fires after nodes are created
+- `dataimport:error` - Fires on parsing or validation errors
+
+## Limits and Constraints
+
+| Limit           | Value | Rationale                                                     |
+| --------------- | ----- | ------------------------------------------------------------- |
+| CSV file size   | 10 MB | Browser memory, Papa Parse performance                        |
+| Excel file size | 15 MB | SheetJS overhead, slightly larger limit for multi-sheet files |
+| Prism file size | 10 MB | XML parsing memory usage                                      |
+| Preview rows    | 5     | Display performance, memory for markdown rendering            |
+| Column display  | All   | Scrollable metadata section shows all columns                 |
+
+## Open Questions & Future Decisions
+
+### Resolved (Implementation Complete)
+
+1. **CSV parsing library** - Papa Parse chosen for browser compatibility and dynamic typing
+2. **Excel multi-sheet handling** - One node per sheet, positioned automatically
+3. **Prism subcolumn expansion** - Each subcolumn becomes one CSV column with indexed header
+4. **csvData format** - Raw CSV string chosen over JSON for pandas compatibility
+
+### Deferred / Future Considerations
+
+1. **Large file handling** - Currently limited to 10-15 MB. Future could implement streaming parse for larger files with row sampling in preview.
+
+2. **Column type inference display** - Currently columns are displayed as strings. Future could show detected types (number, date, boolean) in the metadata header.
+
+3. **Data transformation on import** - Users might want to filter rows, rename columns, or pivot during import. Future could add import-time transformation modal.
+
+4. **Multiple file drag-and-drop** - Currently one file at a time. Future could handle multiple files, creating linked nodes.
+
+5. **Export back to original format** - Currently one-way import. Future could allow exporting modified data back to CSV/Excel.
+
+6. **Prism column types** - Prism distinguishes X columns (independent), Y columns (dependent), and row titles. Future could preserve this metadata for specialized analysis.
+
+## References
+
+### High-Level Design
+
+- `/docs/high-level-design.md` - Core canvas-chat architecture, node types, plugin system
+
+### Implementation
+
+**Frontend:**
+
+- `src/canvas_chat/static/js/plugins/csv-node.js` - CSV node protocol and upload handler
+- `src/canvas_chat/static/js/plugins/excel-node.js` - Excel node protocol and upload handler
+- `src/canvas_chat/static/js/plugins/prism-node.js` - Prism node protocol and upload handler
+- `src/canvas_chat/static/js/graph-types.js` - NodeType enum and createNode factory
+- `src/canvas_chat/static/js/node-protocols.js` - BaseNode protocol class
+- `src/canvas_chat/static/js/plugins/code.js` - /code feature integration with csvData
+- `src/canvas_chat/static/js/pyodide-runner.js` - Python execution with CSV injection
+
+**Backend:**
+
+- No backend required - all parsing happens in browser
+
+**Tests:**
+
+- `tests/test_excel_node.js` - Excel handler tests (multi-sheet, csvData)
+- `tests/test_prism_node.js` - Prism handler tests (multi-table, csvData)
+- `tests/test_code_plugin.js` - /code integration with csvDataMap
+
+### Related Features
+
+- `/code` feature: `src/canvas_chat/static/js/plugins/code.js`
+- File upload system: `src/canvas_chat/static/js/file-upload-registry.js`
+- Node protocols: `src/canvas_chat/static/js/node-protocols.js`

--- a/docs/llds/event-system.md
+++ b/docs/llds/event-system.md
@@ -1,0 +1,260 @@
+# Event System: Low-Level Design
+
+**Created**: 2026-03-16
+**Status**: Complete
+**HLD Reference**: [High-Level Design](../high-level-design.md)
+
+## Context and Design Philosophy
+
+The Event system exists because Canvas-Chat is a modular application with multiple independent components that need to communicate without tight coupling. The Canvas must know when the Graph changes. Feature plugins need to respond to user actions. The application needs to coordinate between its core modules (Chat, Graph, Canvas) while remaining extensible.
+
+The design philosophy centers on three principles. First, decoupling through pub/sub: components communicate through events rather than direct method calls, allowing them to evolve independently. Second, structured events over raw payloads: rather than passing arbitrary data, events carry typed payloads that make the system self-documenting and easier to debug. Third, optional cancellation: certain events represent pre-conditions where plugins should be able to intervene before an action completes.
+
+The event system serves as the connective tissue between the CRDT-backed graph, the SVG canvas renderer, and the feature plugins. Without it, each component would need direct references to every other component, creating a tangled architecture that would be difficult to maintain or extend.
+
+## Technical Details
+
+### Core Implementation: EventEmitter
+
+The foundation is a simple pub/sub implementation in `event-emitter.js`. This class provides the standard event emitter pattern with four primary methods: `on()` registers listeners, `off()` removes them, `once()` registers single-fire listeners, and `emit()` dispatches to all registered handlers. The implementation copies the listener array before iteration to prevent modification during emission, which could cause bugs if a handler adds or removes other handlers.
+
+```javascript
+class EventEmitter {
+    constructor() {
+        this._events = new Map();
+    }
+
+    on(event, listener) {
+        if (!this._events.has(event)) {
+            this._events.set(event, []);
+        }
+        this._events.get(event).push(listener);
+        return this;
+    }
+
+    emit(event, ...args) {
+        if (!this._events.has(event)) return false;
+        const listeners = this._events.get(event).slice();
+        for (const listener of listeners) {
+            listener.apply(this, args);
+        }
+        return true;
+    }
+}
+```
+
+Three classes extend EventEmitter to serve different roles: Canvas emits UI interaction events, CRDTGraph emits data change events, and FeatureRegistry maintains an internal event bus for plugin communication.
+
+### Structured Event Classes
+
+Rather than passing raw data to emitters, the system uses structured event classes that provide consistency and a cleaner API. The `CanvasEvent` class wraps a type string and data payload with a timestamp, similar to DOM events. The `CancellableEvent` extends this to support the prevention pattern, allowing handlers to call `preventDefault()` and optionally provide a reason.
+
+```javascript
+class CancellableEvent extends CanvasEvent {
+    constructor(type, data = {}) {
+        super(type, data);
+        this.cancelled = false;
+        this.reason = null;
+    }
+
+    preventDefault(reason = '') {
+        this.cancelled = true;
+        this.reason = reason;
+    }
+
+    get defaultPrevented() {
+        return this.cancelled;
+    }
+}
+```
+
+This pattern appears throughout the plugin system. When the FeatureRegistry processes slash commands, it emits a `command:before` event using CancellableEvent, allowing plugins to intercept and cancel the command if needed.
+
+### Canvas Events
+
+The Canvas class uses a hybrid approach combining callback properties with event emission. Callback properties serve for high-frequency UI interactions where a single handler is expected, while the internal event system handles broader notifications.
+
+The Canvas defines numerous callback properties in its constructor that App wires to handlers:
+
+| Callback Property | Purpose                      | Handler Location     |
+| ----------------- | ---------------------------- | -------------------- |
+| `onNodeSelect`    | Node selection changed       | App.handleNodeSelect |
+| `onNodeMove`      | Node dragged to new position | App.handleNodeMove   |
+| `onNodeDrag`      | Real-time during drag        | Multiplayer sync     |
+| `onNodeResize`    | Node resized                 | App.handleNodeResize |
+| `onNodeResizing`  | Real-time during resize      | Multiplayer sync     |
+| `onNodeDelete`    | Delete key pressed           | App.handleNodeDelete |
+| `onNodeReply`     | Reply action triggered       | App.handleNodeReply  |
+| `onNodeBranch`    | Branch action triggered      | App.handleNodeBranch |
+| `onTagRemove`     | Tag removed from node        | App.handleTagRemove  |
+
+These callbacks are set directly on the Canvas instance rather than using the event emitter, which was a design decision made early in development when the event system was simpler. Newer code prefers the event emitter pattern for its flexibility.
+
+For custom node types, the Canvas also emits events that plugins can intercept. These include actions like `nodeRunCode`, `nodeGenerate`, `nodeSummarize`, and `nodeEditContent`. When a user triggers an action on a node, the Canvas emits the corresponding event, and the App dispatches it to the appropriate handler based on node type.
+
+### Graph Events
+
+The CRDTGraph class extends EventEmitter and emits events when the underlying data model changes. These events notify the Canvas that re-rendering is needed.
+
+| Event         | When Fired            | Data               |
+| ------------- | --------------------- | ------------------ |
+| `nodeAdded`   | Node created in graph | Node object        |
+| `nodeRemoved` | Node deleted          | Node ID            |
+| `nodeUpdated` | Properties changed    | Node object        |
+| `edgeAdded`   | Edge created          | Edge object        |
+| `edgeRemoved` | Edge deleted          | Edge ID            |
+| `tagCreated`  | New tag added         | Tag color and name |
+| `tagUpdated`  | Tag modified          | Tag color and name |
+| `tagDeleted`  | Tag removed           | Tag color          |
+
+The graph emits these events after applying changes to the Yjs data structures. Plugins or UI components that need to react to data changes subscribe to these events on the graph instance.
+
+### Feature Events
+
+The FeatureRegistry maintains an internal event bus that coordinates between plugins and the core application. This bus handles slash command lifecycle events and provides extension points for plugins.
+
+Command events follow a before/after pattern:
+
+| Event            | Type             | Purpose                                                               |
+| ---------------- | ---------------- | --------------------------------------------------------------------- |
+| `command:before` | CancellableEvent | Fired before command handler executes; handlers can prevent execution |
+| `command:after`  | CanvasEvent      | Fired after successful command completion                             |
+| `command:error`  | CanvasEvent      | Fired when command throws an exception                                |
+
+The registry emits these during `handleSlashCommand()`. Plugins can subscribe to these events to implement cross-cutting concerns like logging, analytics, or command modification.
+
+```javascript
+async handleSlashCommand(command, args, context) {
+    const beforeEvent = new CancellableEvent('command:before', { command, args, context });
+    this._eventBus.emit('command:before', beforeEvent);
+
+    if (beforeEvent.cancelled) {
+        return true;
+    }
+
+    try {
+        await handlerMethod.call(feature, command, args, context);
+        this._eventBus.emit('command:after', new CanvasEvent('command:after', { command, result: 'success' }));
+    } catch (error) {
+        this._eventBus.emit('command:error', new CanvasEvent('command:error', { command, error }));
+        throw error;
+    }
+}
+```
+
+### Extension Hooks
+
+Beyond core events, individual features emit their own events that plugins can intercept. The code execution feature, for example, emits a rich set of events around self-healing: `selfheal:before`, `selfheal:error`, `selfheal:fix`, `selfheal:success`, and `selfheal:failed`. These allow plugins to analyze errors, provide custom fix prompts, or prevent default behavior.
+
+Matrix evaluation similarly emits `matrix:before:fill`, `matrix:cell:prompt`, and `matrix:after:fill` events that plugins can use to intercept cell filling operations.
+
+### Event Flow Summary
+
+The complete event flow spans three layers. At the data layer, CRDTGraph emits node and edge change events when the underlying Yjs structures are modified. At the presentation layer, Canvas emits UI interaction events (selection, dragging, resizing) that App handles. At the application layer, FeatureRegistry emits command lifecycle events that plugins can intercept.
+
+Communication flows upward through events: Graph notifies Canvas of data changes, Canvas notifies App of user actions, and App coordinates FeatureRegistry for plugin handling. This upward flow keeps higher-level components unaware of lower-level implementation details.
+
+## Event Type Reference
+
+### Canvas Callback Properties
+
+The following callback properties are defined on Canvas instances. Set these in App initialization to handle specific interactions:
+
+- `onNodeSelect(selection: string[])` - Selection changed
+- `onNodeDeselect(selection: string[])` - Deselected all nodes
+- `onNodeMove(nodeId: string, newPos: Position, oldPos: Position)` - Node drag completed
+- `onNodeDrag(nodeId: string, pos: Position)` - Real-time during drag
+- `onNodeResize(nodeId: string, width: number, height: number)` - Resize completed
+- `onNodeResizing(nodeId: string, width: number, height: number)` - Real-time during resize
+- `onNodeReply(nodeId: string)` - Reply action triggered
+- `onNodeBranch(nodeId: string, text: string, reply: string)` - Branch action triggered
+- `onNodeDelete(nodeId: string)` - Delete action triggered
+- `onNodeCopy(nodeId: string)` - Copy action triggered
+- `onNodeTitleEdit(nodeId: string)` - Title edit initiated
+- `onNodeStopGeneration(nodeId: string)` - Stop streaming
+- `onNodeContinueGeneration(nodeId: string)` - Continue stopped generation
+- `onNodeRetry(nodeId: string)` - Retry failed operation
+- `onNodeDismissError(nodeId: string)` - Dismiss error node
+- `onNodeFitToViewport(nodeId: string)` - Resize node to viewport
+- `onNodeResetSize(nodeId: string)` - Reset node to default size
+- `onNodeEditContent(nodeId: string)` - Edit node content
+- `onCreateFlashcards(nodeId: string)` - Generate flashcards
+- `onNodeRunCode(nodeId: string)` - Execute code
+- `onNodeGenerate(nodeId: string)` - Generate code via LLM
+- `onTagChipClick(color: string)` - Tag chip clicked
+- `onTagRemove(color: string, nodeId: string)` - Tag removed from node
+
+### Canvas Emitted Events
+
+The Canvas emits the following events via its internal EventEmitter:
+
+- `nodeSelect(selection: string[])` - Selection changed
+- `nodeDeselect(selection: string[])` - Deselected
+- `nodeNavigate(nodeId: string)` - Navigate to node
+- `fileDrop(file: File, position: Position)` - File dropped on canvas
+- `nodeDrag(nodeId: string, pos: Position)` - Real-time drag
+- `nodeMove(nodeId: string, newPos: Position, oldPos: Position)` - Drag completed
+- `nodeResize(nodeId: string, width: number, height: number)` - Resize completed
+- `nodeResizing(nodeId: string, width: number, height: number)` - Real-time resize
+- `nodeOutputResize(nodeId: string, height: number)` - Output panel resized
+- `nodeOutputToggle(nodeId: string)` - Output panel toggled
+- `imageClick(nodeId: string, src: string, data)` - Image clicked
+
+### Canvas Graph Events
+
+| Event         | Payload                         |
+| ------------- | ------------------------------- |
+| `nodeAdded`   | `{Node}`                        |
+| `nodeRemoved` | `{id: string}`                  |
+| `nodeUpdated` | `{Node}`                        |
+| `edgeAdded`   | `{Edge}`                        |
+| `edgeRemoved` | `{id: string}`                  |
+| `tagCreated`  | `{color: string, name: string}` |
+| `tagUpdated`  | `{color: string, name: string}` |
+| `tagDeleted`  | `{color: string}`               |
+
+### Feature Registry Events
+
+| Event            | Type             | Payload                        |
+| ---------------- | ---------------- | ------------------------------ |
+| `command:before` | CancellableEvent | `{command, args, context}`     |
+| `command:after`  | CanvasEvent      | `{command, result: 'success'}` |
+| `command:error`  | CanvasEvent      | `{command, error}`             |
+
+### Feature-Specific Extension Hooks
+
+Code self-healing hooks:
+
+- `selfheal:before` - Before healing begins (cancellable)
+- `selfheal:error` - After execution error
+- `selfheal:fix` - Before LLM generates fix (cancellable, modifiable)
+- `selfheal:success` - After successful fix
+- `selfheal:failed` - After exhausting retries
+
+Matrix hooks:
+
+- `matrix:before:fill` - Before cell fill (cancellable)
+- `matrix:cell:prompt` - During cell processing
+- `matrix:after:fill` - After cell fill completes
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. ✅ Hybrid approach (callbacks + events) - keeps backward compatibility
+
+### Deferred
+
+1. Callback properties vs events - whether to migrate all callbacks to event listeners
+2. Event namespacing - adopt namespacing for feature-specific events
+3. Async event handling - support async handlers
+4. Event history/replay - for debugging and undo/redo
+
+## References
+
+- [High-Level Design](../high-level-design.md) - Architecture overview
+- [Plugin Architecture](../explanation/plugin-architecture.md) - Three-level plugin system
+- [Canvas Event Handlers](../reference/canvas-event-handlers.md) - Handler registration pattern
+- [Extension Hooks](../reference/extension-hooks.md) - Plugin hook reference
+- [Feature Registry API](../reference/feature-registry-api.md) - Event bus methods
+- [Feature Plugin API](../reference/feature-plugin-api.md) - Plugin event subscription

--- a/docs/llds/factcheck-feature.md
+++ b/docs/llds/factcheck-feature.md
@@ -1,0 +1,516 @@
+# Low-Level Design: FactcheckFeature
+
+**Created**: 2026-03-16
+**Status**: Implementation
+**Module**: FactcheckFeature (claim verification)
+
+## Context and Design Philosophy
+
+The FactcheckFeature implements a claim verification system that extracts factual claims from text, verifies them against web sources, and presents verdicts with explanations and citations. This feature addresses a fundamental need in AI-assisted workflows: determining the accuracy of factual statements made in conversations.
+
+The design philosophy centers on four principles. First, user control is paramount through a claim review modal that lets users edit, add, or remove claims before verification begins, ensuring only relevant claims are checked. Second, transparency is maintained by showing all sources used in the verification process, allowing users to click through to original sources and verify themselves. Third, parallel processing accelerates verification by checking multiple claims simultaneously rather than sequentially. Fourth, graceful degradation ensures the feature works even without premium search APIs by falling back to DuckDuckGo when Exa is unavailable.
+
+This feature directly supports the HLD's vision of Canvas-Chat as a toolkit for working with LLMs, specifically the fact-checking capability mentioned in Section 3.3 under "Rich LLM Features."
+
+## Technical Overview
+
+### Slash Command Entry Point
+
+The feature is accessed via the `/factcheck` slash command, which accepts either direct claims as arguments or operates on selected node content. The command is registered in the FeatureRegistry and handled by the `handleFactcheck` method in `FactcheckFeature`.
+
+```text
+/factcheck The Eiffel Tower is 330 meters tall. Paris is the capital of France.
+```
+
+When invoked with selected nodes, the command uses the selected node's content as context:
+
+```text
+/factcheck verify these
+```
+
+The command handles several variations:
+
+1. **Direct claims**: Arguments after `/factcheck` are treated as claims to verify
+2. **Vague references**: Phrases like "verify these" or "fact check this" trigger use of selected node content
+3. **Empty input with selection**: If no arguments are provided but nodes are selected, the selected content becomes the source
+4. **Refinement**: When input is vague, the system optionally calls `/api/refine-query` to extract specific claims from context
+
+### Claim Extraction
+
+Claims are extracted from input text using an LLM with a specialized system prompt. The extraction process:
+
+1. Identifies discrete, verifiable factual claims within the input
+2. Rephrases fragments into complete, standalone statements
+3. Handles numbered lists and bulleted lists by extracting each item as a separate claim
+4. Limits extraction to a maximum of 10 claims, prioritizing the most significant ones
+5. Returns an empty array if the input contains no factual content (only greetings or questions)
+
+The extraction prompt instructs the LLM to be inclusive, treating even seemingly obvious claims (like "The Earth is flat" or "Water boils at 100°C") as verifiable. This ensures users can verify any claim without special handling.
+
+### Claim Review Modal
+
+Before verification begins, a modal (`factcheck-main-modal`) presents extracted claims for user review:
+
+- **Claim rows**: Each extracted claim appears as a textarea for editing
+- **Add claim**: Users can add custom claims not captured by extraction
+- **Remove claim**: Each row has a remove button to delete irrelevant claims
+- **Claim count**: Shows number of claims ready for verification
+- **Warning**: Displays when more than 5 claims are selected (informational only)
+- **Execute button**: Disabled until at least one valid claim exists
+
+The modal enforces validation: at least one non-empty claim is required to proceed. This ensures users intentionally confirm what they want verified.
+
+### Web Search Integration
+
+The feature supports two search backends for finding sources:
+
+**Exa Search** (preferred when available):
+
+- Requires Exa API key in settings
+- Returns high-quality, AI-optimized search results
+- Uses `/api/exa/search` endpoint
+- Up to 3 queries per claim, 3 results per query
+
+**DuckDuckGo Search** (fallback):
+
+- No API key required
+- Uses `/api/ddg/search` endpoint
+- Returns 5 results per query
+- Activated automatically when Exa key is not configured
+
+For each claim, the system:
+
+1. Generates 2-3 search queries optimized for finding verification sources
+2. Executes searches in parallel for all queries
+3. Deduplicates results by URL
+4. Limits to top 8 unique sources per claim
+
+The query generation uses an LLM to craft searches that would find authoritative sources (news, official documents, Wikipedia). The LLM varies query phrasing to capture different perspectives and includes keywords like "fact check" or "true" when helpful.
+
+### LLM Verdict Analysis
+
+After gathering search results, an LLM analyzes the evidence to produce a verdict:
+
+**Verdict Types**:
+
+- **VERIFIED**: The claim is accurate and supported by reliable sources
+- **PARTIALLY_TRUE**: The claim is mostly correct but contains inaccuracies or missing context
+- **MISLEADING**: The claim is technically true but presented in a misleading way
+- **FALSE**: The claim is factually incorrect
+- **UNVERIFIABLE**: Cannot determine truth due to lack of reliable sources
+
+The analysis prompt includes:
+
+- The original claim
+- Up to 8 search results with title, URL, and snippet
+- Instructions to respond in exact JSON format
+- Requirement to cite max 3 relevant sources
+
+The LLM must provide:
+
+- `verdict`: One of the five verdict types
+- `explanation`: Brief 1-2 sentence explanation of why the verdict was reached
+- `sources`: Array of {title, url} objects (max 3)
+
+## Node Types
+
+### FactcheckNode
+
+The FactcheckNode protocol class defines how factcheck nodes are rendered and what actions they support. It extends BaseNode and provides custom rendering for claim verification results.
+
+**Header Information**:
+
+- Type label: "Factcheck"
+- Type icon: "🔍"
+- Summary text: Shows claim count at lower zoom levels
+
+**Content Rendering**:
+
+- Accordion-style claim display
+- Each claim shows verdict badge, claim text, and expand/collapse toggle
+- Expanded state reveals explanation and source links
+- Multiple claims can be expanded simultaneously
+
+**Verdict Badges**:
+
+- 🔄 checking: Verification in progress
+- ✅ verified: Claim confirmed accurate
+- ⚠️ partially_true: Mostly correct with caveats
+- 🔶 misleading: Technically true but misleading
+- ❌ false: Factually incorrect
+- ❓ unverifiable: Cannot verify with available sources
+- ⚠️ error: Verification failed
+
+**Actions and Shortcuts**:
+
+- Only COPY action available (via action bar and Ctrl+C)
+- Edit content disabled (E key does nothing)
+- Reply disabled (R key does nothing)
+- This makes factcheck nodes read-only, preserving verification integrity
+
+**Event Bindings**:
+
+- Click on claim header toggles expanded state
+- Only functional for non-checking claims
+- Multiple claims can be expanded simultaneously
+
+**Default Dimensions**: 640x480 pixels
+
+### Loading Node
+
+During the initial processing phase, a temporary loading node displays status:
+
+- "Analyzing text for claims..." during extraction
+- "Refining query..." when improving vague input
+- "Extracting claims..." during claim extraction
+- "Extracted N claims. Review before verifying." after extraction
+
+This node transforms into the FactcheckNode once verification begins or errors occur.
+
+## Edge Types
+
+The FactcheckFeature creates edges to represent relationships between nodes:
+
+| Edge Type            | From         | To             | Meaning                    |
+| -------------------- | ------------ | -------------- | -------------------------- |
+| `EdgeType.REFERENCE` | Source node  | Factcheck node | Content being verified     |
+| `EdgeType.REFERENCE` | Parent nodes | Loading node   | Initial context connection |
+
+When multiple nodes are selected for verification, each parent node receives an edge to the factcheck node. This maintains the graph relationship showing which content was examined.
+
+## Execution Flow
+
+### Phase 1: Input Processing and Claim Extraction
+
+1. User invokes `/factcheck` with optional arguments and/or node selection
+2. System determines effective input:
+    - Use direct arguments if provided and substantive (>20 characters)
+    - If arguments are vague ("verify these"), use selected node content
+    - If no arguments, use selected node content
+3. If input is vague but context exists, optionally refine via `/api/refine-query`
+4. Create loading node at calculated position
+5. Connect loading node to parent nodes (if any)
+6. Call LLM to extract claims from effective input
+7. Display claim count in loading node
+8. Show claim review modal
+
+### Phase 2: Claim Review and Selection
+
+1. Modal displays extracted claims
+2. User can edit, add, or remove claims
+3. Execute button enables when at least one valid claim exists
+4. On Execute: collect all non-empty claims, close modal
+5. On Cancel: remove loading node, close modal
+
+### Phase 3: Parallel Verification
+
+For each claim in the selected set:
+
+1. Generate 2-3 search queries via LLM
+2. Execute searches (Exa or DuckDuckGo) in parallel
+3. Deduplicate results by URL
+4. Send claim + results to LLM for verdict analysis
+5. Update the specific claim in the node (status, explanation, sources)
+6. Re-render the node to show progress
+7. Save session after each claim completes
+
+All claims verify in parallel using `Promise.allSettled`, ensuring:
+
+- Maximum throughput (no waiting for slow claims)
+- Individual failure isolation (one failure doesn't block others)
+- Results available as soon as each claim completes
+
+### Phase 4: Final Display
+
+1. After all verifications complete, final save to IndexedDB
+2. Node shows all claims with verdicts
+3. Users can expand each claim to read explanations and click sources
+
+## Data Structures
+
+### Claim Data Object
+
+```javascript
+{
+    text: string,           // The claim text being verified
+    status: string,         // checking | verified | partially_true | misleading | false | unverifiable | error
+    verdict: string | null, // VERIFIED | PARTIALLY_TRUE | MISLEADING | FALSE | UNVERIFIABLE
+    explanation: string | null, // Brief explanation of verdict
+    sources: Array<{       // Source citations
+        title: string,     // Source title
+        url: string        // Source URL
+    }>
+}
+```
+
+### Factcheck Node Data
+
+```javascript
+{
+    id: string,             // Unique node ID
+    type: 'factcheck',      // Node type
+    content: string,        // Markdown-formatted content
+    claims: Array<ClaimDataObject>, // All claims with verdicts
+    position: { x, y },     // Canvas position
+    width: 640,             // Default width
+    height: 480             // Default height
+}
+```
+
+### Internal State (\_factcheckData)
+
+```javascript
+{
+    claims: string[],       // Claims from modal
+    parentIds: string[],    // Source node IDs
+    model: string,          // LLM model for verification
+    apiKey: string,         // API key for model
+    loadingNodeId: string   // ID of loading/factcheck node
+}
+```
+
+### LLM Request/Response Formats
+
+**Claim Extraction Request**:
+
+```javascript
+{
+    messages: [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: inputText }
+    ],
+    model: selectedModel
+}
+```
+
+**Query Generation Request**:
+
+```javascript
+{
+    messages: [
+        { role: 'system', content: queryGenerationPrompt },
+        { role: 'user', content: claimText }
+    ],
+    model: selectedModel
+}
+```
+
+**Verdict Analysis Request**:
+
+```javascript
+{
+    messages: [
+        { role: 'system', content: verdictAnalysisPrompt },
+        { role: 'user', content: `CLAIM: ${claim}\n\nSEARCH RESULTS:\n${formattedResults}` }
+    ],
+    model: selectedModel
+}
+```
+
+## Integration Points
+
+### FeatureRegistry Registration
+
+FactcheckFeature is registered as a built-in feature with priority `PRIORITY.BUILTIN`:
+
+```javascript
+import { FactcheckFeature } from './plugins/factcheck.js';
+
+registry.registerFeature(new FactcheckFeature(ctx), PRIORITY.BUILTIN);
+```
+
+### Slash Command
+
+The `/factcheck` command is declared in `getSlashCommands()`:
+
+```javascript
+getSlashCommands() {
+    return [
+        {
+            command: '/factcheck',
+            description: 'Verify claims with web search',
+            placeholder: 'Claims to verify...',
+        },
+    ];
+}
+```
+
+### AppContext Dependencies
+
+FactcheckFeature uses these injected dependencies:
+
+- `this.graph`: Add/update nodes and edges
+- `this.canvas`: Render nodes, update content, viewport control
+- `this.chat`: Send messages to LLM providers via sendMessage
+- `this.modelPicker`: Get available models, current selection
+- `this.modalManager`: Register and show factcheck modal
+- `this.chatInput`: Clear input after execution
+- `this.storage`: Check for Exa API key availability
+- `this.saveSession()`: Persist after each verification
+- `this.showToast()`: User notifications
+- `this.buildLLMRequest()`: Used for refine-query calls
+
+### NodeRegistry Registration
+
+FactcheckNode is registered as a custom node type:
+
+```javascript
+NodeRegistry.register({
+    type: 'factcheck',
+    protocol: FactcheckNode,
+    defaultSize: { width: 640, height: 480 },
+});
+```
+
+### API Endpoints
+
+The feature uses these backend endpoints:
+
+- `/api/exa/search`: Exa-powered web search (when Exa key available)
+- `/api/ddg/search`: DuckDuckGo search (fallback)
+- `/api/refine-query`: Refine vague inputs into specific claims (optional)
+
+## Error Handling
+
+### Extraction Failure
+
+If claim extraction fails:
+
+- Display error in loading node
+- Show "No claims extracted" message
+- Allow user to add claims manually via modal
+
+### Search Failure
+
+If search fails for a claim:
+
+- Mark claim as "error" status
+- Show error explanation in the claim
+- Continue with other claims
+- Don't block entire verification
+
+### Analysis Failure
+
+If LLM verdict analysis fails:
+
+- Mark claim as "unverifiable" status
+- Show "Failed to analyze search results" explanation
+- Continue with other claims
+
+### Network Errors
+
+Distinguished from other errors:
+
+- Network timeout: Retry once, then mark as error
+- API rate limit: Queue remaining claims, process when allowed
+- AbortError: Graceful cancellation (user cancelled)
+
+### Modal Cancellation
+
+If user cancels before execution:
+
+- Remove loading node from graph
+- Clear internal state
+- No factcheck node created
+
+## CSS and Styling
+
+Factcheck styling is distributed across multiple CSS files:
+
+### modals.css
+
+- `.factcheck-main-modal`: Main modal container
+- `.factcheck-modal-subtitle`: Instructional text
+- `.factcheck-claims-list`: Container for claim rows
+- `.factcheck-claim-row`: Individual claim edit row
+- `.factcheck-claim-input`: Textarea for claim editing
+- `.factcheck-claim-remove`: Remove button
+- `.factcheck-add-claim`: Add new claim section
+- `.factcheck-selection-info`: Claim count and warnings
+- `.factcheck-selection-count`: Count display
+- `.factcheck-limit-warning`: Warning for many claims
+
+### nodes.css
+
+- `.factcheck-content`: Content wrapper
+- `.factcheck-claims`: Claims container
+- `.factcheck-claim`: Individual claim container
+- `.factcheck-claim-header`: Clickable header with badge and text
+- `.factcheck-badge`: Verdict badge emoji
+- `.factcheck-claim-text`: Claim text display
+- `.factcheck-toggle`: Expand/collapse indicator
+- `.factcheck-details`: Expanded explanation and sources
+- `.factcheck-sources`: Sources container with links
+
+### Animation
+
+- `.factcheck-claim.expanded .factcheck-details`: max-height transition for smooth accordion effect
+
+## Testing Considerations
+
+### Unit Tests
+
+Key pure functions for testing:
+
+- `getVerdictBadge(status)`: Returns correct emoji for each status
+- `buildFactcheckContent(claimsData)`: Formats node content correctly
+- `collectFactcheckClaimsFromModal()`: Extracts valid claims from modal inputs
+
+### Integration Tests
+
+Test files:
+
+- `tests/test_factcheck_plugin.js`: FactcheckFeature plugin tests
+- Tests for claim extraction parsing
+- Tests for verdict response parsing
+
+### E2E Tests
+
+Relevant Cypress tests:
+
+- `cypress/e2e/factcheck_modal.cy.js`: Modal interaction tests
+- Tests for claim selection
+- Tests for verification execution
+
+### Manual Testing Scenarios
+
+- Verify claims from typed input
+- Verify claims from selected node
+- Verify claims from numbered lists
+- Test with Exa API key
+- Test fallback without Exa key
+- Test parallel verification completion
+- Test accordion expand/collapse
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. **Parallel vs Sequential**: Parallel verification chosen for speed
+2. **Search Backend**: Exa primary, DuckDuckGo fallback implemented
+3. **Modal Confirmation**: Users must confirm claims before verification
+4. **Node Editability**: Factcheck nodes are read-only to preserve integrity
+5. **Source Limits**: Maximum 3 sources per claim to keep UI clean
+
+### Deferred / Future
+
+1. **Claim prioritization**: Allow users to order claims by importance
+2. **Historical verification**: Re-verify claims against newer sources
+3. **Batch operations**: Verify claims across multiple factcheck nodes
+4. **Custom verdict criteria**: Allow users to define what makes something "verified"
+5. **Citation format**: Support different citation styles (APA, MLA, etc.)
+6. **Multi-language support**: Verify claims in non-English languages
+7. **Trend analysis**: Show how verification results change over time
+8. **Shareable reports**: Generate shareable factcheck reports
+
+## References
+
+- **HLD**: `/docs/high-level-design.md` - Context on fact-checking as core LLM feature
+- **How-to**: `/docs/how-to/factcheck.md` - User documentation for the feature
+- **Implementation**: `src/canvas_chat/static/js/plugins/factcheck.js` - Full source (1065 lines)
+- **Node Types**: `src/canvas_chat/static/js/graph-types.js` - NodeType.FACTCHECK definition
+- **Node Protocols**: `/docs/explanation/node-protocols.md` - FactcheckNode protocol documentation
+- **Plugin API**: `/docs/reference/feature-plugin-api.md` - FeaturePlugin base class
+- **Web Search**: `/docs/how-to/web-search.md` - Search functionality used by factcheck
+- **E2E Tests**: `cypress/e2e/factcheck_modal.cy.js` - Modal interaction tests
+- **Unit Tests**: `tests/test_factcheck_plugin.js` - Plugin tests

--- a/docs/llds/flashcards-feature.md
+++ b/docs/llds/flashcards-feature.md
@@ -1,0 +1,437 @@
+# FlashcardsFeature Low-Level Design
+
+**Project:** Canvas-Chat
+**Created:** 2026-03-16
+**Status:** Implementation
+**Related HLD:** `/docs/high-level-design.md`
+
+## Context and Design Philosophy
+
+The FlashcardsFeature exists to transform static content from LLM conversations into active learning tools. When users receive explanations, tutorials, or summaries from LLMs, the information is often consumed once and forgotten. Spaced repetition transforms this passive consumption into durable learning.
+
+The design philosophy centers on three principles:
+
+1. **Seamless extraction** - Flashcards are generated directly from existing content nodes. Users select a node and request flashcards without copying/pasting or switching contexts. The generation is grounded in the selected content, ensuring cards test actual knowledge from the source.
+
+2. **Minimal friction review** - When flashcards are due, users receive a non-intrusive toast notification. The review flow is self-contained in a modal: see question, type answer, get immediate feedback via LLM grading, apply SM-2 scheduling. No external apps or accounts required.
+
+3. **Transparent scheduling** - The SM-2 algorithm runs entirely client-side. Users can see card status (New, Due, Learning) directly on the node. There's no "black box" - the next review date is computable from the node's SRS metadata.
+
+This feature directly supports the "Rich LLM Features" principle from the HLD: "Flashcards - Generate spaced-repetition cards from content."
+
+## Technical Details
+
+### SM-2 Spaced Repetition Algorithm
+
+The implementation follows the standard SM-2 algorithm with minor adaptations for web use:
+
+**Quality Ratings:**
+
+- `0-2` = Fail (complete blackout to serious difficulty)
+- `3` = Hard (correct with significant difficulty)
+- `4` = Good (correct with some hesitation)
+- `5` = Easy (perfect response)
+
+**Algorithm Implementation:**
+
+```javascript
+function applySM2(srs, quality) {
+    const result = { ...srs };
+
+    if (quality < 3) {
+        // Failed: reset to beginning
+        result.repetitions = 0;
+        result.interval = 1;
+    } else {
+        // Passed: calculate new interval
+        if (result.repetitions === 0) {
+            result.interval = 1;
+        } else if (result.repetitions === 1) {
+            result.interval = 6;
+        } else {
+            result.interval = Math.round(result.interval * result.easeFactor);
+        }
+
+        // Update ease factor based on quality
+        result.easeFactor += 0.1 - (5 - quality) * (0.08 + (5 - quality) * 0.02);
+        result.easeFactor = Math.max(1.3, result.easeFactor); // Minimum 1.3
+        result.repetitions++;
+    }
+
+    result.lastReviewDate = new Date().toISOString();
+    result.nextReviewDate = new Date(Date.now() + result.interval * 86400000).toISOString();
+
+    return result;
+}
+```
+
+**Interval Progression:**
+
+| Repetitions | Interval (days)       |
+| ----------- | --------------------- |
+| 0 → 1       | 1                     |
+| 1 → 2       | 6                     |
+| 2+          | interval × easeFactor |
+
+**Ease Factor Range:** Minimum 1.3, default 2.5. Higher values indicate easier cards.
+
+**Due Date Calculation:** A card is due when `nextReviewDate <= now`. New cards (no SRS data) are always due.
+
+### Flashcard Node Structure
+
+Flashcard nodes store their state in the graph's Yjs CRDT:
+
+```javascript
+{
+    id: string,                    // UUID
+    type: 'flashcard',
+    content: string,               // Question (front of card)
+    back: string,                  // Answer (back of card)
+    srs: {
+        easeFactor: number,        // Default 2.5, min 1.3
+        interval: number,          // Days until next review
+        repetitions: number,       // Successful review count
+        nextReviewDate: string,    // ISO timestamp
+        lastReviewDate: string     // ISO timestamp
+    },
+    position: { x: number, y: number },
+    width: number,                 // Default 400
+    height: number,                // Default 280
+    created_at: number,
+    tags: string[],
+    title: string | null,
+    summary: string | null,
+    model: string | null
+}
+```
+
+### Two-Component Architecture
+
+The flashcard feature combines two distinct plugin concepts:
+
+1. **FlashcardNode** (Level 1 - Custom Node Type): Extends `BaseNode` protocol. Handles rendering, status display, flip animation, edit fields. Registered with `NodeRegistry`.
+
+2. **FlashcardFeature** (Level 2 - Feature Plugin): Extends `FeaturePlugin`. Handles flashcard generation, grading, review workflow, and due card tracking. Registered with `FeatureRegistry`.
+
+This separation follows the plugin architecture guidelines: node rendering logic stays with the node type, while complex workflows (generation, grading, review) stay with the feature.
+
+### FlashcardNode Rendering
+
+The FlashcardNode protocol renders the card with SRS status:
+
+```javascript
+renderContent(canvas) {
+    // Determine SRS status for display
+    let statusClass = 'new';
+    let statusText = 'New';
+    if (this.node.srs?.nextReviewDate) {
+        const reviewDate = new Date(this.node.srs.nextReviewDate);
+        if (reviewDate <= new Date()) {
+            statusClass = 'due';
+            statusText = 'Due';
+        } else {
+            statusClass = 'learning';
+            const daysUntil = Math.ceil((reviewDate - now) / 86400000);
+            statusText = daysUntil === 1 ? 'Due tomorrow' : `Due in ${daysUntil} days`;
+        }
+    }
+
+    return `
+        <div class="flashcard-container">
+            <div class="flashcard-status ${statusClass}">${statusText}</div>
+            <div class="flashcard-card">
+                <div class="flashcard-front">...</div>
+                <div class="flashcard-back">...</div>
+            </div>
+        </div>
+    `;
+}
+```
+
+### Node Actions
+
+FlashcardNode provides these actions in the action bar:
+
+- **Flip Card** - Toggle CSS class to reveal answer (keyboard: `f`)
+- **Review Card** - Open review modal for single card
+- **Edit Content** - Open edit modal with question and answer fields
+- **Copy** - Copy card content to clipboard
+- **Reply** - Create a reply node
+
+## Flashcard Generation Workflow
+
+### Trigger: Create Flashcards Button
+
+Flashcards are created from content nodes via the "Create Flashcards" button that appears on content nodes (AI responses, notes, summaries). The flow:
+
+1. User clicks "Create Flashcards" button on a content node
+2. Canvas emits `createFlashcards` event
+3. `FlashcardFeature.handleCreateFlashcards()` is invoked with the source node ID
+
+### Generation Modal
+
+The generation modal (`flashcard:generation`) provides:
+
+- **Number of cards** - Input (1-10, default 5)
+- **Focus/angle** - Optional textarea for guiding generation (e.g., "focus on definitions")
+- **Generate button** - Triggers LLM generation
+- **Candidate list** - Shows generated cards with:
+  - Checkbox for selection
+  - Question/answer display
+  - Edit button for modification
+- **Accept Selected** - Creates flashcard nodes from selected candidates
+
+### LLM Prompt for Generation
+
+```javascript
+buildFlashcardPrompt({ content, count, focus, existingCards }) {
+    return `Based on the following content, generate exactly ${count} flashcards for spaced repetition learning.
+Each flashcard should test a key concept, fact, or relationship grounded in the content.
+
+Focus/angle: ${focus || '(none)'}
+
+Rules:
+- Ground every question and answer strictly in the provided content
+- Keep answers concise (1-2 sentences)
+- Return ONLY a JSON array with no additional text
+- Use the format: [{"front": "question", "back": "concise answer"}, ...]
+${existingCardsSection}
+Content:
+${content}`;
+}
+```
+
+### Node Creation
+
+When cards are accepted:
+
+1. Each card becomes a `FlashcardNode` with:
+    - `content` = question
+    - `back` = answer
+    - `srs` = initial SRS data (interval: 0, easeFactor: 2.5, repetitions: 0)
+2. Nodes are positioned in a row below the source node
+3. Edges of type `GENERATES` connect source node to each flashcard
+4. Session saves automatically
+
+## Review Workflow
+
+### Due Card Detection
+
+On app load, `FlashcardFeature.checkDueFlashcardsOnLoad()` runs:
+
+```javascript
+function isFlashcardDue(card) {
+    if (card.type !== NodeType.FLASHCARD) return false;
+    if (!card.srs || !card.srs.nextReviewDate) return true; // New card
+    return new Date(card.srs.nextReviewDate) <= new Date();
+}
+```
+
+### Toast Notification
+
+If due cards exist, a toast appears:
+
+- Message: "You have N card(s) due for review"
+- "Review Now" button - Opens review modal
+- "Later" button - Dismisses toast (auto-dismisses after 10 seconds)
+
+### Review Modal
+
+The review modal (`flashcard:review`) provides:
+
+- **Progress indicator** - "1/5", "2/5", etc.
+- **Question display** - Shows the flashcard question
+- **Answer input** - Textarea for user's answer
+- **Submit button** - Grades the answer via LLM
+- **Result section** (shown after submit):
+  - Correct answer display
+  - Verdict (Correct / Partially Correct / Incorrect)
+  - LLM explanation
+  - Override buttons ("I knew this" / "I didn't know this")
+- **Next button** - Applies SM-2 and moves to next card
+
+### LLM Grading
+
+The grading prompt considers a "strictness" setting (stored in localStorage):
+
+- **Lenient** - Accepts paraphrasing, synonyms, general gist
+- **Medium** (default) - Requires key concepts, accepts terminology differences
+- **Strict** - Requires precise terminology, complete coverage
+
+```javascript
+const prompt = `You are grading a flashcard answer. Compare the user's answer to the correct answer...
+
+Question: ${card.content}
+Correct Answer: ${card.back}
+User's Answer: ${userAnswer}
+
+Respond with ONLY a JSON object:
+{"correct": true/false, "partial": true/false, "explanation": "brief explanation"}
+
+${gradingRules}`;
+```
+
+The LLM returns structured JSON which determines:
+
+- Quality 4 (Good) for correct
+- Quality 3 (Hard) for partial
+- Quality 1 (Fail) for incorrect
+
+### SM-2 Application
+
+After grading (or override), `handleReviewNext()` applies SM-2:
+
+```javascript
+const quality = this.reviewState.currentQuality || 4;
+const currentSrs = card.srs || { interval: 0, easeFactor: 2.5, repetitions: 0 };
+const newSrs = applySM2(currentSrs, quality);
+this.graph.updateNode(cardId, { srs: newSrs });
+this.canvas.renderNode(updatedCard); // Re-render to show new status
+```
+
+### Review Completion
+
+When all cards are reviewed:
+
+1. Modal closes
+2. Session saves
+3. Toast shows "Reviewed N cards"
+4. Nodes re-render with updated SRS status
+
+## Due Cards Tracking
+
+### Storage Location
+
+SRS data is stored directly on each FlashcardNode in the CRDT graph:
+
+```javascript
+// In graph Y.Map
+node.set('srs', {
+    easeFactor: 2.5,
+    interval: 6,
+    repetitions: 2,
+    nextReviewDate: '2026-03-25T00:00:00.000Z',
+    lastReviewDate: '2026-03-19T00:00:00.000Z',
+});
+```
+
+### Persistence
+
+SRS data persists with the session via IndexedDB. No additional storage mechanism required.
+
+### Query Functions
+
+Two pure functions in `utils.js` enable due card queries:
+
+```javascript
+function isFlashcardDue(card) { ... }
+function getDueFlashcards(nodes) { ... }
+```
+
+Used by:
+
+- `checkDueFlashcardsOnLoad()` - App startup
+- `startFlashcardReview()` - "Review All" feature
+
+## Integration Points
+
+### FeatureRegistry Registration
+
+FlashcardFeature is registered as a built-in feature (no slash commands):
+
+```javascript
+{
+    id: 'flashcards',
+    feature: FlashcardFeature,
+    slashCommands: [], // Event-driven, no slash commands
+    priority: PRIORITY.BUILTIN
+}
+```
+
+### Canvas Event Handlers
+
+FlashcardFeature provides canvas event handlers:
+
+```javascript
+getCanvasEventHandlers() {
+    return {
+        createFlashcards: this.handleCreateFlashcards.bind(this),
+        reviewCard: this.reviewSingleCard.bind(this),
+        flipCard: this.handleFlipCard.bind(this),
+    };
+}
+```
+
+### Modal Registration
+
+Two modals are registered in `onLoad()`:
+
+1. **Generation Modal** (`flashcard:generation`): Flashcard creation UI
+2. **Review Modal** (`flashcard:review`): Review session UI
+
+## Limits and Constraints
+
+| Limit                     | Value         | Rationale                                               |
+| ------------------------- | ------------- | ------------------------------------------------------- |
+| Cards per generation      | 10 max        | Prevents overwhelming API costs; user can generate more |
+| Answer length for grading | ~50 words max | LLM grading degrades with very long inputs              |
+| Ease factor minimum       | 1.3           | Prevents cards from becoming too frequent               |
+| Toast auto-dismiss        | 10 seconds    | Non-intrusive but allows time to notice                 |
+
+## Open Questions & Future Decisions
+
+### Resolved (Implementation Complete)
+
+1. ✅ **No slash command** - Flashcards are triggered via button on content nodes, not `/flashcards`. This keeps the UI cleaner and makes generation more contextual (source node is explicit).
+
+2. ✅ **LLM grading** - Answers are graded by the LLM rather than simple string matching. This allows partial credit and handles paraphrasing.
+
+3. ✅ **Strictness setting** - Users can choose lenient/medium/strict grading via settings modal.
+
+4. ✅ **Edit after creation** - FlashcardNode provides custom edit fields for question and answer.
+
+5. ✅ **Override buttons** - Users can manually mark correct/incorrect regardless of LLM verdict.
+
+### Deferred / Future Considerations
+
+1. **Export/Import** - Flashcard decks could be exported as JSON for backup or import from Anki format.
+
+2. **Deck organization** - Currently all flashcards exist in a flat list. Could add tagging or folders for organization.
+
+3. **Statistics** - Track review history over time: accuracy rate, cards mastered, time spent. Display in a "stats" view.
+
+4. **Cram mode** - Option to review cards regardless of due date (useful before exams).
+
+5. **Audio pronunciation** - Text-to-speech for questions and answers (useful for language learning).
+
+6. **Image support** - Allow images on cards (currently text-only).
+
+7. **Multi-side cards** - Cards with more than 2 sides (e.g., front → back1 → back2 → ...).
+
+## References
+
+### High-Level Design
+
+- `/docs/high-level-design.md` - Core canvas-chat architecture, node types, plugin system
+
+### Implementation
+
+**Frontend:**
+
+- `src/canvas_chat/static/js/plugins/flashcards.js` - Complete FlashcardFeature implementation
+- `src/canvas_chat/static/js/plugins/flashcard-node.js` - FlashcardNode protocol
+- `src/canvas_chat/static/js/graph-types.js` - `FlashcardNode` typedef and factory functions
+- `src/canvas_chat/static/js/utils.js` - `applySM2()`, `isFlashcardDue()`, `getDueFlashcards()`
+- `src/canvas_chat/static/js/feature-registry.js` - Feature registration
+- `src/canvas_chat/static/css/nodes.css` - Flashcard node styles
+
+**Tests:**
+
+- `tests/test_flashcards.js` - SM-2 algorithm tests, due detection tests, FlashcardNode tests
+- `tests/test_flashcards_plugin.js` - FlashcardFeature plugin tests
+
+### Related Features
+
+- Node protocols: `src/canvas_chat/static/js/node-protocols.js`
+- Storage: `src/canvas_chat/static/js/storage.js` (strictness setting)
+- Chat: `src/canvas_chat/static/js/chat.js` (LLM grading calls)

--- a/docs/llds/git-repo-node.md
+++ b/docs/llds/git-repo-node.md
@@ -1,0 +1,246 @@
+# GitRepoNode Low-Level Design
+
+**Project:** Canvas-Chat
+**Created:** 2026-03-16
+**Status:** Implementation
+**Related HLD:** [High-Level Design](../high-level-design.md)
+
+## Context and Design Philosophy
+
+The GitRepoNode exists to enable users to fetch and explore git repositories directly within the canvas environment. This node type addresses a common workflow in LLM-assisted development: analyzing codebases, reading documentation, and incorporating repository context into conversations.
+
+The design philosophy centers on several key principles that guide its implementation and user experience.
+
+First, interactive file selection distinguishes this node from simple URL fetch results. Rather than downloading an entire repository blindly, users can browse the file tree and select specific files they want to analyze. This approach respects bandwidth and API limits while giving users precise control over what content enters their conversation context.
+
+Second, the node stores the complete repository state including file tree structure, selected files, and fetched content. This persistent storage enables users to revisit their selections, modify file choices through an edit workflow, and reference specific files later without re-fetching from the remote repository.
+
+Third, private repository support through Personal Access Tokens extends functionality beyond public repositories. Users can securely store credentials for GitHub, GitLab, and Bitbucket, enabling the same interactive workflow for private codebases they host on these platforms.
+
+Fourth, native integration with the canvas ecosystem allows git repo nodes to participate fully in the conversation graph. Users can reply to specific repository nodes, branch conversations from file selections, and use repository content as context for subsequent LLM queries.
+
+This node type supports the broader application philosophy of treating repositories as first-class content sources that can be queried, analyzed, and integrated into conversational workflows. The HLD establishes that Canvas-Chat is fundamentally a chat application with visual representation as a secondary concern. The GitRepoNode extends this foundation by introducing repository content as a structured data source that users can explore and reference within their conversations.
+
+## Technical Details
+
+### Architecture Overview
+
+The GitRepoNode implementation combines frontend and backend components that work together to provide a complete repository fetching and browsing experience. The architecture follows the plugin-based design pattern established by other features in the application, with clear separation between node rendering logic and feature workflow management.
+
+```text
+GitRepoNode Architecture:
+┌─────────────────────────────────────────────────────────────────┐
+│                         Frontend                                │
+├─────────────────────────────────────────────────────────────────┤
+│  plugins/git-repo.js                                           │
+│  ├── GitRepoNode (node protocol) - Rendering, file tree, drawer│
+│  └── GitRepoFeature (feature plugin) - /git cmd, modal, creds  │
+├─────────────────────────────────────────────────────────────────┤
+│  Modal System                                                  │
+│  └── File Selection Modal - Tree browser, checkboxes, fetch    │
+├─────────────────────────────────────────────────────────────────┤
+│  Settings Integration                                          │
+│  └── Git Credentials UI - PAT management for private repos     │
+└─────────────────────────────────────────────────────────────────┘
+                               │
+                               ▼
+┌─────────────────────────────────────────────────────────────────┐
+│                         Backend                                 │
+├─────────────────────────────────────────────────────────────────┤
+│  plugins/git_repo_handler.py                                    │
+│  ├── GitRepoHandler - Clone, file tree, content extraction     │
+│  └── Endpoints: /api/url-fetch/list-files, fetch-files        │
+├─────────────────────────────────────────────────────────────────┤
+│  Git Operations                                                │
+│  └── subprocess.run(['git', 'clone', ...])                    │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Node Data Structure
+
+Git repository nodes store their state in the graph's Yjs CRDT, maintaining both the repository metadata and the complete file tree structure. The data structure enables full reconstruction of the node's state from persisted storage.
+
+```javascript
+{
+    id: string,                      // UUID
+    type: 'git_repo',
+    content: string,                 // Markdown content with all file contents
+    gitRepoData: {
+        url: string,                 // Original repository URL
+        title: string,               // Repository name
+        fileTree: Array,             // Complete file tree structure
+        selectedFiles: string[],     // User-selected file paths
+        fetchedFilePaths: string[],  // Actually fetched file paths
+        files: {                      // Map of file paths to file data
+            [filePath: string]: {
+                content: string | null,
+                lang: string | null,
+                status: string,       // 'success', 'not_found', 'permission_denied', 'error'
+                isBinary: boolean,
+                isSvg: boolean,
+                imageData: string,    // Base64 for binary images
+                mimeType: string,
+                error: string
+            }
+        }
+    },
+    selectedFilePath: string | null, // Currently viewed file in drawer
+    position: { x: number, y: number },
+    width: number,
+    height: number,
+    created_at: number,
+    tags: string[],
+    title: string | null,
+    summary: string | null,
+    model: string | null,
+    versions: Array                  // Version history for undo
+}
+```
+
+### Two-Component Architecture
+
+Similar to the MatrixNode implementation, the GitRepoNode combines two distinct plugin concepts within a single file.
+
+GitRepoNode operates as a Level 1 custom node type, extending the BaseNode protocol to handle rendering logic, file tree display within the node, drawer panel content for viewing individual files, and clipboard operations for copying file contents. This component manages how the node appears visually and how users interact with its content.
+
+GitRepoFeature functions as a Level 2 feature plugin, extending FeaturePlugin to handle the /git slash command processing, file selection modal management including tree rendering and checkbox handling, repository fetching coordination with the backend, credentials management for private repositories, and edit workflow for modifying previously fetched repositories. This component manages the complex workflows that surround repository interaction.
+
+This separation follows the established plugin architecture guidelines where node rendering logic remains with the node type while complex workflows stay with the feature plugin. The GitRepoFeature is self-contained and injects its own CSS rather than requiring modifications to the core application.
+
+### URL Pattern Matching
+
+The backend uses URL pattern matching to identify git repository URLs and route them to the appropriate handler. The UrlFetchRegistry in the backend contains patterns that recognize various git hosting platforms.
+
+```python
+UrlFetchRegistry.register(
+    id="git-repo",
+    url_patterns=[
+        r"^https?://(github|gitlab|bitbucket|gitea|codeberg)\.(com|org)/[\w\-\.]+/[\w\-\.]+(?:\.git)?/?$",
+        r"^git@[\w\-\.]+:[\w\-\.]+/[\w\-\.]+(?:\.git)?$",
+    ],
+    handler=GitRepoHandler,
+    priority=PRIORITY["BUILTIN"],
+)
+```
+
+This pattern recognizes HTTPS URLs for GitHub, GitLab, Bitbucket, Gitea, and Codeberg, along with SSH URLs in the git@host:user/repo format. When a user enters a repository URL in the chat input, the NoteFeature detects the URL pattern and delegates handling to the GitRepoFeature.
+
+### Backend Git Operations
+
+The GitRepoHandler in the backend performs several critical operations that enable the repository fetching functionality. Each operation serves a specific purpose in the overall workflow.
+
+The clone operation uses git subprocess to create a shallow clone of the repository. The implementation uses depth=1 to minimize download size and transfer time since only the latest commit is needed for file access. When credentials are provided, they are embedded in the HTTPS URL as a token for authentication. Error handling covers timeouts, permission denied scenarios, and invalid repository URLs.
+
+The file tree building operation recursively traverses the cloned repository to construct a hierarchical structure representing directories and files. The backend skips the .git directory to avoid unnecessary data. Each item includes the path, type (file or directory), size for files, and children arrays for directories.
+
+The content extraction operation reads selected files from the cloned repository. Binary images are handled specially with PIL-based resizing and base64 encoding to enable inline display in the canvas. SVGs are sanitized using defusedxml to remove potentially dangerous content like script tags and event handlers before being rendered natively. Text files are read with UTF-8 encoding and errors ignored to handle encoding edge cases gracefully.
+
+### File Selection Modal
+
+The file selection modal provides the primary interface for browsing and selecting repository files. This modal appears after entering a repository URL and enables users to explore the file tree before committing to fetching content.
+
+The modal displays the repository URL at the top for reference, a loading indicator during tree fetching, an error message area for failure notifications, selection controls including a Select All / Deselect All button and a running count of selected files, a warning area that appears for large selections over 20 files, the scrollable file tree with expand/collapse functionality for directories, and action buttons for Cancel and Fetch Selected Files.
+
+The file tree renders with a classic OS-style appearance where directories show expand/collapse triangles and files display checkboxes. Directories can be expanded or collapsed by clicking the triangle, and checking a directory checkbox selects all files within it recursively. Parent directory checkboxes update to reflect the selection state of their children, showing indeterminate state when some but not all children are selected.
+
+Smart defaults automatically select README files, configuration files like .gitignore, pyproject.toml, package.json, requirements.txt, Cargo.toml, and go.mod, and main entry points such as main.py, index.js, index.ts, and app.py. Files in src/ and lib/ directories are also included by default. This approach ensures users get meaningful content immediately without needing to manually select common files.
+
+### Drawer Panel for File Viewing
+
+When users click on fetched files in the node's file tree, a drawer panel slides out to display the file's content. This design allows users to browse multiple files without cluttering the canvas with multiple nodes.
+
+The drawer content varies based on file type. For regular text files, syntax highlighting applies using highlight.js with language detection based on file extension. For binary images, the image displays inline after base64 decoding and resizing. For SVG files, the sanitized content renders natively through a blob URL. For files with errors, appropriate error messages display including not_found, permission_denied, and generic error states.
+
+The drawer panel integrates with the node protocol system through the hasOutput() method, which returns true only when a file is selected for viewing. This prevents the drawer from appearing by default and ensures it opens only when users explicitly click on a file.
+
+### Credentials Management
+
+Private repository support requires secure storage and retrieval of Personal Access Tokens. The GitRepoFeature manages credentials through a dedicated settings section in the Settings modal.
+
+The credentials system supports multiple git hosting platforms. GitHub credentials use either classic PATs with repo scope or fine-grained tokens. GitLab credentials require PATs with read_repository scope. Bitbucket credentials use app passwords with repository read permission. Additionally, a generic credential system allows users to add tokens for other git hosts by specifying the hostname and token pair.
+
+Credentials store in localStorage under the key git-repo-plugin-credentials as a JSON object mapping hostnames to tokens. This storage is plugin-specific and separate from other application settings, allowing users to manage git credentials independently from API keys and other configuration.
+
+The settings UI provides inline help with links to each platform's token creation pages, making it easy for users to generate appropriate credentials. When fetching from a private repository, the plugin automatically includes the relevant credential based on the repository's hostname.
+
+### Edit Workflow
+
+Users can modify their file selection for previously fetched repositories through an edit workflow. This enables iterative refinement where users might initially select certain files, use them in conversation, then decide to add or remove files based on their needs.
+
+The edit workflow begins when users click the Edit button on a git repo node. The GitRepoFeature detects that the node has gitRepoData and opens the file selection modal in edit mode. The modal loads with the original repository URL, fetches the current file tree, and pre-selects files that were previously selected. Users can then modify their selections and click Fetch to update the node with new file contents.
+
+The edit workflow updates the existing node rather than creating a new one, preserving the node's position in the canvas and its connections to other nodes. The node's versions array tracks the history of edits for potential undo functionality.
+
+## Extension Hooks
+
+The GitRepoNode participates in the extension hook system, though it currently emits fewer events than features like the matrix. The node primarily interacts with the broader canvas ecosystem through its node protocol and the modal system.
+
+Future plugins could extend GitRepoNode functionality by hooking into events like before:fetch to modify file selections before fetching, after:fetch to perform additional processing on fetched content, or node:fileSelected to react when users click files in the drawer.
+
+## Limits and Constraints
+
+| Limit                      | Value                                      | Rationale                                                         |
+| -------------------------- | ------------------------------------------ | ----------------------------------------------------------------- |
+| Clone depth                | 1                                          | Shallow clone minimizes bandwidth and time for large repositories |
+| Max selected files warning | 20                                         | Warns users about large selections that may slow down fetching    |
+| Hard selection limit       | 50+                                        | Display warning but allow exceeding to support larger codebases   |
+| Max image size             | 5MB                                        | Prevents memory issues with very large binary files               |
+| Image max dimension        | 1920px                                     | Balances display quality with memory usage for images             |
+| Clone timeout              | 60 seconds                                 | Prevents hanging on slow or unresponsive repositories             |
+| Supported hosts            | GitHub, GitLab, Bitbucket, Gitea, Codeberg | Covers major git hosting platforms plus self-hosted Gitea         |
+
+## Open Questions and Future Decisions
+
+### Resolved Implementation Decisions
+
+Several design decisions were made during implementation that are now settled.
+
+The first decision concerned where to store file contents. The implementation stores all file contents in the node's gitRepoData.files object, enabling drawer display and offline access. An alternative approach of storing only references and fetching on demand would reduce node size but require network access for every file view.
+
+The second decision involved clone depth. Using depth=1 provides fast clones but means historical commits are not accessible. For most use cases involving reading current code, this trade-off is acceptable.
+
+The third decision covered image handling. Binary images are resized server-side and embedded as base64, providing reliable display at the cost of increased node size. Alternative approaches like blob URLs or external hosting were considered but would complicate the offline-first architecture.
+
+### Deferred Considerations
+
+Several features remain unimplemented but could enhance the node in future iterations.
+
+Branch and commit selection would allow users to specify which branch or commit to fetch rather than always using the default branch. This would require additional UI for branch selection and potentially deeper git clones.
+
+Repository search within fetched repos would enable users to search across all files in a repository using semantic or keyword search. This could surface relevant code without requiring users to manually browse the entire tree.
+
+Partial directory fetching would allow users to fetch only specific subdirectories rather than cloning the entire repository. This optimization could significantly reduce bandwidth for large monorepos.
+
+Git history integration would display commit history, blame information, or diffs between commits. This would appeal to users interested in understanding code evolution rather than just current state.
+
+Large file handling improvements could add pagination or streaming for very large files, better error messages for binary files, or selective display of large files in chunks.
+
+Multi-repository nodes could link multiple repositories in a single node for comparing or cross-referencing code across projects.
+
+## References
+
+### High-Level Design
+
+The main architectural document covering canvas-chat's design principles, plugin system, and node type categorization is available at /docs/high-level-design.md.
+
+### User Guides
+
+End-user documentation for the git repository feature is located at /docs/how-to/git-repo-fetch.md, providing instructions on entering repository URLs, selecting files, and managing credentials.
+
+### Implementation Details
+
+Frontend implementation resides in src/canvas_chat/static/js/plugins/git-repo.js, containing both the GitRepoNode protocol and GitRepoFeature plugin classes. The node protocol handles rendering and drawer display while the feature manages commands, modals, and credentials.
+
+Backend implementation is in src/canvas_chat/plugins/git_repo_handler.py, implementing the GitRepoHandler class that performs repository cloning, file tree construction, and content extraction.
+
+Styling is in src/canvas_chat/static/css/git-repo.css, providing the visual appearance for file trees, modals, and the drawer panel.
+
+The node type is defined in src/canvas_chat/static/js/graph-types.js with the NodeType.GIT_REPO constant and corresponding default dimensions.
+
+### Testing
+
+The implementation is tested through the overall application. Unit tests for file tree rendering and selection logic could be added to tests/test_git_repo.js in the future.
+
+### Related Features
+
+The git repository feature interacts with several other components in the application. The NoteFeature provides URL detection and delegates to GitRepoFeature for git URLs. The modal system handles the file selection dialog. The Settings modal integrates the credentials management UI. The node protocol system provides the rendering infrastructure.

--- a/docs/llds/html-slides.md
+++ b/docs/llds/html-slides.md
@@ -1,0 +1,227 @@
+# HTMLSlides: Single-File HTML Presentation Node
+
+**Created**: 2026-03-16
+**Status**: Implementation
+**Related HLD**: [High-Level Design](../high-level-design.md)
+
+## Context and Design Philosophy
+
+The HTMLSlides feature provides a way to create, display, and interact with single-file HTML presentations directly on the canvas. It enables users to generate or paste HTML slide decks and view them inline within nodes, with navigation controls and the ability to open or download for sharing.
+
+### Why This Feature Exists
+
+HTML slide presentations are a common output format for LLM-generated content. Users often want to create quick presentations from research, meeting notes, or topic explanations without leaving the canvas-chat workflow. The design philosophy centers on three key principles:
+
+**Seamless generation and embedding**: Users can either type a topic and have the LLM generate slides, or paste existing HTML. Both paths result in the same embedded presentation node, creating a unified experience regardless of content source.
+
+**Self-contained presentations**: The feature specifically targets single-file HTML presentations where all CSS and JavaScript are inline. This ensures presentations work reliably when embedded via blob URLs and can be easily shared or downloaded without external dependencies.
+
+**Interactive navigation**: Rather than treating slides as static content, the feature provides toolbar controls (Prev/Next) and leverages a postMessage bridge to enable keyboard navigation within the embedded iframe. This preserves the native presentation experience while keeping users in the canvas.
+
+### Design Decisions
+
+1. **Dual-path command handling**: The `/slides` command detects whether the user pasted HTML (starts with `<!` or contains `<div class="deck"`) or provided a topic. This enables both quick content embedding and LLM-assisted generation without requiring separate commands.
+
+2. **Blob URL embedding**: Slides are embedded using blob URLs created from the stored HTML content, rather than srcdoc. This approach avoids escaping issues with long HTML content and provides consistent behavior with "Open in new tab" functionality.
+
+3. **postMessage bridge injection**: A small script is injected into the HTML before loading it in the iframe. This bridge listens for postMessage commands (`next`, `prev`) and dispatches keyboard events that the presentation's own JavaScript responds to. This decouples the canvas from the presentation's internal implementation.
+
+4. **HTML stored in dedicated field**: The presentation HTML is stored in `node.htmlSlidesContent` rather than the generic `node.content` field. This keeps the content separate from searchable/displayed text and allows the node to have a clean title while carrying large HTML payloads.
+
+5. **Generation state tracking**: When generating slides via LLM, the node tracks a `generating: true` state that displays a spinner UI. Once generation completes, the field is cleared and content is populated.
+
+## Technical Details
+
+### Architecture Overview
+
+The HTMLSlides feature spans two main components:
+
+| Component        | Location                             | Responsibility                         |
+| ---------------- | ------------------------------------ | -------------------------------------- |
+| `html-slides.js` | `src/canvas_chat/static/js/plugins/` | Feature plugin, node protocol, helpers |
+| `nodes.css`      | `src/canvas_chat/static/css/`        | Styling for slides node and toolbar    |
+
+The feature implements both a **node protocol** (`HtmlSlidesNode`) for rendering and a **feature plugin** (`HtmlSlidesFeature`) for slash command handling. This follows the Level 2 feature plugin pattern where the plugin provides both the node appearance and the command workflow.
+
+### The `/slides` Slash Command
+
+The slash command is registered via `HtmlSlidesFeature.getSlashCommands()`:
+
+```javascript
+getSlashCommands() {
+    return [
+        {
+            command: '/slides',
+            description: 'Create HTML slides (topic or paste HTML)',
+            placeholder: 'Topic or paste HTML...',
+        },
+    ];
+}
+```
+
+When the user enters `/slides <args>`, the `handleCommand` method determines the content path:
+
+**Pasted HTML path** (detected via `isPastedHtml()`):
+
+1. Extract title from `<title>` tag or default to "Slides"
+2. Create node with `htmlSlidesContent` set to the raw HTML
+3. Add to graph and render immediately
+
+**Topic generation path**:
+
+1. Create placeholder node with `generating: true` and empty `htmlSlidesContent`
+2. Send topic to LLM with system prompt instructing raw HTML output
+3. On completion, strip any markdown wrapper (`stripMarkdownHtmlWrapper()`) and update node
+4. Render updates the node with the embedded presentation
+
+### Helper Functions
+
+The module exports several pure helper functions for testing:
+
+**`isPastedHtml(args)`**: Detects if the argument string contains pasted HTML by checking for `<!DOCTYPE` or `<div class="deck"` patterns. Used to route between the paste and generation paths.
+
+**`stripMarkdownHtmlWrapper(text)`**: Removes common wrappers from LLM output. Handles:
+
+- Code fences: `html ... ``` ` or ``...`
+- Preamble text: Extracts from `<!DOCTYPE` or `<html>` to end of string
+
+**`extractTitleFromHtml(html)`**: Parses the `<title>` tag from HTML to use as the node title. Falls back to "Slides" if no title exists.
+
+**`injectPostMessageBridge(html)`**: Injects a script that listens for `postMessage('next')` and `postMessage('prev')` and dispatches corresponding keyboard events. This enables the toolbar buttons to drive navigation in presentations that use keyboard handlers.
+
+### Node Protocol: HtmlSlidesNode
+
+The `HtmlSlidesNode` class extends `BaseNode` and provides:
+
+**`renderContent(canvas)`**: Renders the node body with three states:
+
+- **Generating**: Shows spinner with "Generating slides..." text
+- **Empty**: Shows placeholder with instructions
+- **Content**: Renders iframe embed with toolbar
+
+The toolbar includes four buttons: Prev, Next, Open in new tab, and Download.
+
+**`getEventBindings()`**: Returns event handlers for:
+
+- `.html-slides-iframe` (init): Creates blob URL from `htmlSlidesContent` and injects the postMessage bridge
+- `.html-slides-prev`: Sends `postMessage('prev')` to iframe
+- `.html-slides-next`: Sends `postMessage('next')` to iframe
+- `.html-slides-open`: Opens blob URL in new tab
+- `.html-slides-download`: Triggers download of HTML file
+
+**`getActions()`**: Returns `[Actions.REPLY, Actions.COPY]`. The COPY action copies the raw HTML to clipboard.
+
+**`hasOutput()`**: Returns `false` since the presentation is fully contained in the node body.
+
+### Data Storage
+
+Nodes of type `html_slides` store the following fields:
+
+| Field               | Type    | Purpose                                      |
+| ------------------- | ------- | -------------------------------------------- |
+| `htmlSlidesContent` | string  | Full HTML presentation content               |
+| `title`             | string  | Display title (from `<title>` or user topic) |
+| `generating`        | boolean | True during LLM generation                   |
+
+The `htmlSlidesContent` field is stored directly in the Yjs CRDT node map, allowing persistence across sessions.
+
+### CSS Styling
+
+The node styling is defined in `nodes.css` under `.html-slides-node` and related selectors:
+
+- `.html-slides-node`: Flex container with column layout
+- `.html-slides-embed`: Contains the iframe with rounded corners
+- `.html-slides-iframe`: Full width/height within embed, minimum height 280px
+- `.html-slides-toolbar`: Fixed height toolbar at bottom with button row
+
+The toolbar uses secondary background color and matches the general node styling conventions.
+
+## Single-File Presentation Embed
+
+### Embedding Mechanism
+
+The presentation is embedded in an iframe with an empty `src` attribute. On node initialization, the iframe's `init` event handler:
+
+1. Retrieves the stored `htmlSlidesContent` from the node
+2. Revokes any existing blob URL for this node to prevent memory leaks
+3. Creates a new Blob from the HTML with `injectPostMessageBridge()` applied
+4. Generates a blob URL and assigns it to `iframe.src`
+
+This approach avoids the length and escaping limitations of srcdoc while ensuring the presentation behaves the same as when opened in a new tab.
+
+### postMessage Bridge
+
+The injected script runs inside the iframe:
+
+```javascript
+window.addEventListener('message', function (e) {
+    if (e.data === 'next') document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }));
+    if (e.data === 'prev') document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }));
+});
+```
+
+This allows the Prev/Next toolbar buttons to trigger keyboard-based navigation in presentations that use arrow key handlers (such as decks generated by the html-presentations skill).
+
+### Download and Open
+
+- **Open in new tab**: Creates a fresh blob URL from the raw HTML (without the bridge script) and opens in a new window
+- **Download**: Creates a blob URL and triggers a download with a filename derived from the node title
+
+Both operations revoke their blob URLs immediately after use to prevent memory leaks.
+
+## Slide Navigation
+
+### Toolbar Buttons
+
+The toolbar provides four buttons:
+
+| Button          | Action                                |
+| --------------- | ------------------------------------- |
+| Prev            | Sends `postMessage('prev')` to iframe |
+| Next            | Sends `postMessage('next')` to iframe |
+| Open in new tab | Opens presentation in new browser tab |
+| Download        | Downloads HTML file                   |
+
+### Keyboard Navigation
+
+Within the embedded iframe, users can interact with the presentation's native navigation:
+
+- **Space / Arrow Right**: Next slide (in standard html-presentations format)
+- **Shift+Space / Arrow Left**: Previous slide
+- **Escape**: Overview grid (when supported)
+
+The keyboard navigation works because the injected postMessage bridge translates parent-originated messages into keyboard events that the presentation's JavaScript handles normally.
+
+### External Navigation
+
+The toolbar buttons communicate from the parent window to the iframe via postMessage. This architecture keeps the canvas implementation agnostic to the specific presentation format while supporting standard keyboard-based navigation.
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. ✅ Blob URL embedding - self-contained presentations
+2. ✅ postMessage bridge for navigation
+
+### Deferred
+
+1. Presenter mode - notes and timer overlay
+2. Slide number display - show current/total
+3. PDF export - browser print or backend conversion
+4. Multiple slide formats - detect and adapt
+5. Real-time collaboration - sync slide position
+
+## References to HLD
+
+This feature relates to the following sections of the [High-Level Design](../high-level-design.md):
+
+- **Section 4.3: Plugin-Extensible**: The feature uses the three-level plugin system. It is a Level 2 feature plugin that provides both a custom node type and slash command handling.
+- **Section 6: Node Types**: HTML slides falls under the "Documents" category alongside PDF and PowerPoint nodes.
+- **Section 8.1: Vanilla JavaScript**: The implementation uses plain JavaScript with JSDoc annotations, consistent with the project's frontend architecture.
+- **Section 8.3: SVG Canvas with foreignObject**: The slides node uses the canvas's node rendering system with an iframe inside the node body.
+
+### Related Documentation
+
+- [How to create HTML slides](../how-to/html-slides.md) - User-facing guide for the feature
+- [Feature Plugin API](../reference/feature-plugin-api.md) - API reference for the `FeaturePlugin` base class
+- [Node Protocols](../explanation/node-protocols.md) - Design decisions for the node protocol system

--- a/docs/llds/image-generation.md
+++ b/docs/llds/image-generation.md
@@ -1,0 +1,469 @@
+# Low-Level Design: ImageGenerationFeature
+
+**Created**: 2026-03-16
+**Status**: Implementation
+**Module**: ImageGenerationFeature (AI image generation)
+
+## Context and Design Philosophy
+
+ImageGenerationFeature brings AI-powered image generation directly into the visual canvas workflow. The design philosophy centers on three principles. First, seamless integration means users can generate images without leaving the canvas context, combining image generation with chat, research, and other features. Second, provider choice offers flexibility through multiple backends (DALL-E, Gemini, Ollama), allowing users to balance quality, speed, cost, and privacy based on their needs. Third, visual feedback provides immediate canvas-based feedback with loading states, progress indicators, and error handling displayed directly on the generated image node.
+
+The feature builds on the existing image analysis workflow documented in `use-images.md`. Where that document covers analyzing uploaded images with vision-capable LLMs, this feature covers the inverse: generating new images from text prompts.
+
+## Technical Overview
+
+### Slash Command Entry Point
+
+The feature is accessed via the `/image` slash command, registered in FeatureRegistry and handled by `ImageGenerationFeature.handleCommand()`:
+
+```text
+/image A serene mountain lake at sunset with snow-capped peaks
+```
+
+When invoked, the command:
+
+1. Parses the prompt from command arguments
+2. Checks for selected nodes to use as conversation context
+3. Optionally combines selected text with additional instructions
+4. Opens the settings modal for model and parameter selection
+
+The command accepts optional arguments that are combined with any selected node content:
+
+```text
+# With selected node text + additional instructions
+/image make it more vibrant and add birds
+```
+
+The prompt is built by combining `selectedContext` and `additionalInstructions` with a separator:
+
+```javascript
+if (selectedContext && additionalInstructions) {
+    prompt = `${selectedContext}\n\nAdditional instructions: ${additionalInstructions}`;
+}
+```
+
+### Settings Modal
+
+The ImageGeneration settings modal (`image-generation-settings-modal`) provides provider and parameter configuration:
+
+**Model Selection** (dropdown):
+
+| Model ID                              | Provider | Description            |
+| ------------------------------------- | -------- | ---------------------- |
+| `dall-e-3`                            | OpenAI   | Best quality, slower   |
+| `dall-e-2`                            | OpenAI   | Lower cost, faster     |
+| `gemini/imagen-4.0-generate-001`      | Google   | Fast generation        |
+| `ollama_image/x/z-image-turbo:latest` | Ollama   | Local, privacy-focused |
+
+**Size Options** (dropdown):
+
+| Value       | Dimensions | Use Case              |
+| ----------- | ---------- | --------------------- |
+| `1024x1024` | Square     | Social media, general |
+| `1792x1024` | Landscape  | Wide banners          |
+| `1024x1792` | Portrait   | Stories, mobile       |
+
+**Quality Options** (dropdown):
+
+| Value      | Model Support      | Description                |
+| ---------- | ------------------ | -------------------------- |
+| `hd`       | DALL-E 3           | Higher detail, recommended |
+| `standard` | DALL-E 2/3, Imagen | Faster, lower cost         |
+
+The modal is registered in `onLoad()` using the plugin modal system:
+
+```javascript
+this.modalManager.registerModal('image-generation', 'settings', modalTemplate);
+```
+
+### Provider Abstraction
+
+The frontend determines the provider from the model ID and retrieves the appropriate API key:
+
+```javascript
+if (model.startsWith('dall-e')) {
+    provider = 'openai';
+} else if (model.startsWith('gemini')) {
+    provider = 'google';
+} else {
+    provider = model.split('/')[0]; // e.g., 'ollama'
+}
+
+const apiKey = this.storage.getApiKeyForProvider(provider);
+const baseUrl = this.storage.getBaseUrlForModel(model);
+```
+
+This enables the same settings modal to work with any LiteLLM-compatible image generation model.
+
+## Node Types
+
+### Image Node
+
+Generated images are displayed in `NodeType.IMAGE` nodes, which are also used for uploaded images. The node stores:
+
+- **imageData**: Base64-encoded image data
+- **mimeType**: Image MIME type (typically `image/png`)
+- **content**: Revised prompt (if returned by provider) or error message
+- **model**: Model ID used for generation
+
+The default size for image nodes is 640x480 pixels (defined in `graph-types.js`):
+
+```javascript
+[NodeType.IMAGE]: { width: 640, height: 480 },
+```
+
+### Human Prompt Node
+
+The user's prompt is stored in a `NodeType.HUMAN` node for full conversation traceability:
+
+- **content**: The full prompt including any context from selected nodes
+- **Edges**: Connected from parent nodes (selected nodes) via `EdgeType.REPLY`
+
+### Loading State
+
+During generation, the image node displays a loading indicator:
+
+```html
+<div class="image-loading">
+    <div class="spinner"></div>
+    <p>Generating image...</p>
+</div>
+```
+
+## Edge Types
+
+The ImageGenerationFeature creates edges to maintain conversation flow:
+
+| Edge Type        | From              | To                | Meaning                |
+| ---------------- | ----------------- | ----------------- | ---------------------- |
+| `EdgeType.REPLY` | Selected nodes    | Human prompt node | Context for the prompt |
+| `EdgeType.REPLY` | Human prompt node | Image node        | Generated from prompt  |
+
+## Execution Flow
+
+### Phase 1: Command Parsing
+
+1. User types `/image [optional prompt text]`
+2. Slash command menu shows "Generate an image from text"
+3. User presses Enter to select
+4. `handleCommand()` is invoked with command and arguments
+5. Selected node content is retrieved as context
+
+### Phase 2: Modal Display
+
+1. Settings modal opens with default selections
+2. User selects model, size, and quality
+3. User clicks "Generate Image" or "Cancel"
+
+### Phase 3: Node Creation
+
+If "Generate Image" is clicked:
+
+1. Modal closes
+2. Human prompt node is created at auto-positioned location
+3. Edges created from selected parent nodes to prompt node
+4. Image node created with loading state placeholder
+5. Edge created from prompt node to image node
+6. Viewport pans to show the new image node
+
+### Phase 4: API Request
+
+1. Build request body with prompt, model, size, quality
+2. Determine provider from model ID
+3. Retrieve API key from storage for that provider
+4. Call backend endpoint `/api/generate-image`
+
+```javascript
+const response = await fetch(apiUrl('/api/generate-image'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+        prompt: this.currentPrompt,
+        model: model,
+        size: size,
+        quality: quality,
+        n: 1,
+        api_key: apiKey,
+        base_url: baseUrl,
+    }),
+});
+```
+
+### Phase 5: Response Handling
+
+On success:
+
+1. Extract base64 image data from response
+2. Update image node with imageData and mimeType
+3. Force re-render to display the image
+4. Save session to persist changes
+
+On error:
+
+1. Display error message in image node content
+2. Log error details to console
+3. Update node with error state
+4. Save session
+
+## Backend Implementation
+
+### Endpoint
+
+The backend exposes `/api/generate-image` (FastAPI endpoint in `app.py`):
+
+```python
+@app.post("/api/generate-image")
+async def generate_image(request: ImageGenerationRequest):
+```
+
+### Request Model
+
+```python
+class ImageGenerationRequest(BaseModel):
+    prompt: str
+    model: str = "dall-e-3"
+    size: str = "1024x1024"
+    quality: str = "hd"
+    n: int = 1
+    api_key: str | None = None
+    base_url: str | None = None
+```
+
+### Provider-Specific Handling
+
+**OpenAI (DALL-E)**:
+
+- Uses LiteLLM's `aimage_generation()` for standardized API
+- Supports DALL-E 2 and DALL-E 3
+- Quality parameter: `hd` or `standard`
+
+**Google (Imagen)**:
+
+- Model ID: `gemini/imagen-4.0-generate-001`
+- Uses LiteLLM for API call
+- Returns base64-encoded image
+
+**Ollama (Local)**:
+
+- Model prefix: `ollama_image/`
+- Converted to `ollama/` for API call
+- Direct HTTP to Ollama's `/api/generate` endpoint
+- No API key required (uses dummy value for LiteLLM)
+- Quality parameter not supported (set to None)
+
+### Response Format
+
+```javascript
+{
+    "imageData": "base64-encoded-image-data",
+    "mimeType": "image/png",
+    "revised_prompt": null | "refined prompt from provider"
+}
+```
+
+### Error Handling
+
+| Error Type          | HTTP Status | User Message                                        |
+| ------------------- | ----------- | --------------------------------------------------- |
+| AuthenticationError | 401         | "Authentication failed. Please check your API key." |
+| RateLimitError      | 429         | "Rate limit exceeded. Please try again later."      |
+| Network Error       | 500         | "Network error. Could not connect to the server."   |
+| Other               | 500         | Raw error message                                   |
+
+## Data Structures
+
+### Image Generation State
+
+```javascript
+{
+    currentPrompt: string,        // Combined prompt from context + args
+    parentNodeIds: string[],      // Selected nodes used as context
+    model: string,                // Selected model ID
+    size: string,                 // Image dimensions
+    quality: string,              // 'hd' or 'standard'
+}
+```
+
+### Node Metadata
+
+Image nodes store generation metadata:
+
+```javascript
+{
+    imageData: string,    // Base64-encoded image
+    mimeType: string,     // e.g., "image/png"
+    content: string,     // Revised prompt or error message
+    model: string,       // Model ID used
+}
+```
+
+### Storage Keys
+
+API keys are stored per-provider in localStorage:
+
+| Provider | Storage Key              | Required                |
+| -------- | ------------------------ | ----------------------- |
+| OpenAI   | `canvas-chat-openai-key` | Yes (unless admin mode) |
+| Google   | `canvas-chat-google-key` | Yes (unless admin mode) |
+| Ollama   | N/A                      | No (local only)         |
+
+## Integration Points
+
+### FeatureRegistry Registration
+
+ImageGenerationFeature is registered as a built-in feature:
+
+```javascript
+import { ImageGenerationFeature } from './plugins/image-generation.js';
+
+registry.registerFeature(new ImageGenerationFeature(ctx), PRIORITY.BUILTIN);
+```
+
+### Slash Command
+
+Declared in `getSlashCommands()`:
+
+```javascript
+getSlashCommands() {
+    return [
+        {
+            command: '/image',
+            description: 'Generate an image from text',
+            placeholder: 'optional additional instructions...',
+        },
+    ];
+}
+```
+
+### AppContext Dependencies
+
+The feature uses these injected dependencies:
+
+- `this.graph`: Add/update nodes and edges
+- `this.canvas`: Render nodes, viewport control, copy to clipboard
+- `this.modalManager`: Register and show settings modal
+- `this.storage`: Retrieve API keys for providers
+- `this.saveSession()`: Persist after generation
+
+## Image Display
+
+### Rendering
+
+Image nodes use the ImageNode protocol from `image-node.js`:
+
+```javascript
+renderContent(_canvas) {
+    const imgSrc = `data:${this.node.mimeType || 'image/png'};base64,${this.node.imageData}`;
+    return `<div class="image-node-content"><img src="${imgSrc}" class="node-image" alt="Image"></div>`;
+}
+```
+
+### Copy to Clipboard
+
+Generated images can be copied to clipboard using the ImageNode's `copyToClipboard()` method, which leverages Canvas's `copyImageToClipboard()`:
+
+```javascript
+async copyToClipboard(canvas, _app) {
+    await canvas.copyImageToClipboard(this.node.imageData, this.node.mimeType);
+    canvas.showCopyFeedback(this.node.id);
+}
+```
+
+### CSS Styling
+
+Image nodes use these CSS classes:
+
+- `.image-node-content`: Container for image (flex, centered)
+- `.node-image`: The actual image element
+- `.image-loading`: Loading state container
+- `.spinner`: CSS animation for loading indicator
+
+## Error Handling Reference
+
+### Frontend Errors
+
+The `_getUserFriendlyErrorMessage()` method maps common errors to user-friendly messages:
+
+```javascript
+if (message.includes('Authentication failed')) {
+    return 'Authentication failed. Please check your API key in Settings.';
+}
+if (message.includes('Rate limit')) {
+    return 'Rate limit exceeded. Please try again later.';
+}
+if (message.includes('Failed to fetch')) {
+    return 'Network error. Could not connect to the server.';
+}
+```
+
+### Backend Errors
+
+The backend catches and transforms LiteLLM exceptions:
+
+- `AuthenticationError`: Returns 401 with helpful message
+- `RateLimitError`: Returns 429 with retry message
+- Generic exceptions: Logged with traceback, returns 500
+
+### XSS Prevention
+
+Error messages are escaped before display:
+
+```javascript
+escapeHtml(text) {
+    const div = document.createElement('div');
+    div.textContent = text;
+    return div.innerHTML;
+}
+```
+
+## Testing Considerations
+
+### Unit Tests
+
+Pure functions for testing:
+
+- `_getUserFriendlyErrorMessage()`: Error message transformation
+- `escapeHtml()`: XSS prevention
+
+### Integration Tests
+
+- `/image` command parsing
+- Modal interaction flow
+- Node creation and positioning
+- API request building
+
+### E2E Tests
+
+- Slash command menu interaction
+- Settings modal form submission
+- Image node rendering
+- Error state display
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. **Single vs multiple images**: Single image (n=1) for simplicity; multiple could be added later
+2. **Provider determination**: Model ID prefix pattern (`dall-e`, `gemini`, `ollama_image`)
+3. **API key storage**: Reuses existing storage.getApiKeyForProvider() pattern
+4. **Modal vs inline**: Settings modal provides cleaner UX for model/size selection
+
+### Deferred / Future
+
+1. **Image editing**: Regeneration or inpainting with selected regions
+2. **Multiple image generation**: Support n>1 for multiple variations
+3. **Style presets**: Quick-select common styles (photorealistic, illustration, etc.)
+4. **Seed control**: Reproducible generation with seed parameter
+5. **Image-to-image**: Generation based on uploaded reference image
+6. **Provider comparison**: Side-by-side generation from multiple providers
+
+## References
+
+- **HLD**: `/docs/high-level-design.md` - Context on multimodal LLM features
+- **How-to (Images)**: `/docs/how-to/use-images.md` - Image analysis workflow (inverse feature)
+- **Implementation**: `src/canvas_chat/static/js/plugins/image-generation.js` - Full source
+- **Node Protocol**: `src/canvas_chat/static/js/plugins/image-node.js` - ImageNode class
+- **Backend**: `src/canvas_chat/app.py:1676-1819` - `/api/generate-image` endpoint
+- **Node Type**: `src/canvas_chat/static/js/graph-types.js:238` - NodeType.IMAGE
+- **Default Size**: `src/canvas_chat/static/js/graph-types.js:269` - IMAGE size (640x480)
+- **CSS**: `src/canvas_chat/static/css/nodes.css:1316-1336` - Image node styles

--- a/docs/llds/instant-ai-response.md
+++ b/docs/llds/instant-ai-response.md
@@ -1,0 +1,261 @@
+# Instant AI Response (Copilot Mode)
+
+**Created**: 2026-03-18
+**Status**: Design Phase
+**Component**: Frontend Feature Plugin
+**Supersedes**: N/A
+
+## Context and Design Philosophy
+
+### Problem Statement
+
+Traditional chat interfaces require an explicit "send" action to trigger AI responses. While functional, this creates friction in fluid conversations where users want immediate AI assistance as they think out loud. GitHub Copilot demonstrated that AI can feel more like a collaborator when it anticipates and responds in real-time.
+
+### Design Goals
+
+1. **Immediate presence**: AI node appears as the user types, not after sending
+2. **Non-blocking**: User remains in control - can accept, ignore, or override
+3. **Resource efficient**: Debounced requests prevent excessive API calls
+4. **Opt-in**: Traditional send-button flow remains the default
+
+### User Experience Flow
+
+```text
+User starts typing message
+    ↓
+[Debounce 500ms]
+    ↓
+If Instant AI Response enabled + API keys set:
+    Create "ghost" AI node on canvas
+    Stream suggestion in real-time
+    ↓
+User actions:
+  - Press Tab → Accept suggestion (finalize node)
+  - Continue typing → Suggestion updates, original becomes human node
+  - Press Escape → Cancel suggestion
+  - Press Enter → Treat as normal send
+```
+
+## Technical Design
+
+### Architecture
+
+The feature is implemented as a **Feature Plugin** (`instant-ai.js`) that:
+
+1. Watches chat input for changes
+2. Debounces input to avoid excessive API calls
+3. Creates a special "pending" AI node that streams in real-time
+4. Handles Tab acceptance, Escape cancellation, and continuation scenarios
+
+### State Machine
+
+```text
+IDLE → TRIGGERED → STREAMING → ACCEPTED | CANCELLED | SUPERSEDED
+
+- IDLE: No pending suggestion, normal typing
+- TRIGGERED: Debounce complete, request sent
+- STREAMING: Receiving tokens, showing in ghost node
+- ACCEPTED: User pressed Tab, ghost becomes real node
+- CANCELLED: User pressed Escape, ghost removed
+- SUPERSEDED: User kept typing, suggestion cancelled (new suggestion starts)
+```
+
+### Debouncing Strategy
+
+- **Delay**: 500ms after last keystroke before triggering
+- **Minimum length**: 10 characters minimum to trigger (avoid trivial suggestions)
+- **Reset**: Any input change resets the debounce timer
+
+### Ghost Node Behavior
+
+A "ghost" AI node differs from a regular AI node:
+
+| Property | Regular AI Node     | Ghost AI Node                  |
+| -------- | ------------------- | ------------------------------ |
+| Visual   | Solid styling       | 50% opacity, dashed border     |
+| Content  | Saved to graph      | Temporarily displayed          |
+| Edges    | Created immediately | Edges created on accept        |
+| Undo     | Normal undo         | Cancel restores previous state |
+
+### API Request Batching
+
+The feature batches the user's typed content with context:
+
+```javascript
+async triggerSuggestion(inputText, context) {
+    // Build messages: context + user's current input
+    const messages = [
+        ...context,
+        { role: 'user', content: inputText }
+    ];
+
+    // Send to /api/chat with streaming
+    await streamWithAbort(pendingNodeId, abortController, messages, model,
+        onChunk: (chunk) => updateGhostNode(chunk),
+        onDone: () => finalizeGhostNode(),
+        onError: () => showGhostNodeError()
+    );
+}
+```
+
+### Key Interactions
+
+#### Tab to Accept
+
+When user presses Tab:
+
+1. Cancel any ongoing streaming
+2. Create human node with typed content
+3. Convert ghost AI node to real AI node
+4. Create reply edge from human to AI
+5. Save to graph, clear pending state
+
+#### Typing Continuation
+
+When user continues typing while ghost is streaming:
+
+1. Cancel current streaming (abort signal)
+2. Create human node with previous typed content
+3. Convert ghost to real AI node
+4. Start new debounce with new content
+
+#### Escape to Cancel
+
+When user presses Escape:
+
+1. Remove ghost node from canvas
+2. Cancel any ongoing streaming
+3. Return to IDLE state
+4. Chat input retains focus
+
+#### Enter Without Suggestion
+
+If user presses Enter before suggestion triggers:
+
+- Treat as normal send (no ghost, just human + AI flow)
+
+## Component Inventory
+
+### InstantAIPlugin Class
+
+```javascript
+export class InstantAIPlugin extends FeaturePlugin {
+    constructor(context) {
+        super(context);
+        this.state = 'IDLE';
+        this.debounceTimer = null;
+        this.pendingNodeId = null;
+        this.abortController = null;
+        this.currentInput = '';
+    }
+
+    getSlashCommands() {
+        return [
+            {
+                command: '/instant',
+                description: 'Toggle instant AI response mode',
+                placeholder: null,
+            },
+        ];
+    }
+}
+```
+
+### Ghost Node Renderer
+
+Ghost nodes render identically to AI nodes except:
+
+- `opacity: 0.5` on container
+- `border-style: dashed` instead of solid
+- No content saved until accepted
+
+### Settings Toggle
+
+In Settings modal, add new section:
+
+```text
+┌─────────────────────────────────────┐
+│ Instant AI Response                 │
+│                                     │
+│ [✓] Enable instant AI suggestions  │
+│                                     │
+│ Model: [dropdown]                    │
+│ Debounce delay: [500ms ▼]           │
+│ Min characters: [10 ▼]              │
+└─────────────────────────────────────┘
+```
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. ✅ Feature is opt-in, not default behavior
+2. ✅ Uses existing `/api/chat` endpoint with streaming
+3. ✅ Ghost node visual distinction via CSS
+
+### Deferred
+
+1. Context window management - should we limit context for suggestions?
+2. Mobile/touch handling - Tab key not available on mobile
+3. Keyboard shortcut customization - allow users to remap Tab acceptance
+4. Suggestion quality tuning - how to balance speed vs. quality?
+
+## Edge Cases
+
+### No API Keys Set
+
+When Instant AI is enabled but no API keys are configured:
+
+- Show toast notification: "Enable instant AI response in Settings"
+- Disable trigger until keys are added
+
+### Network Failure
+
+If the suggestion request fails:
+
+- Remove ghost node
+- Show subtle error indicator on chat input
+- Continue allowing normal send flow
+
+### Very Long Responses
+
+If AI response exceeds reasonable length:
+
+- Cap at ~2000 tokens for suggestions
+- Show "..." truncation indicator
+- Full response available after acceptance
+
+### Multiple Rapid Inputs
+
+If user types, deletes, types again quickly:
+
+- Cancel previous suggestion
+- Start new debounce
+- No race conditions (abort cancels old streams)
+
+## Data Flow
+
+```text
+ChatInput 'input' event
+    ↓
+InstantAIPlugin.handleInputChange()
+    ↓
+If (enabled && input.length >= minChars):
+    Clear previous timer
+    Start new debounce (500ms)
+    ↓
+After debounce:
+    Create ghost AI node
+    Build context + input
+    Start streaming
+    ↓
+User action (Tab/Escape/Continue):
+    Accept/Cancel/Supersede
+```
+
+## References
+
+- **HLD**: `/docs/high-level-design.md` (Section 4.6)
+- **Feature Plugin Base**: `/docs/reference/feature-plugin-api.md`
+- **Streaming Architecture**: `/docs/explanation/streaming-architecture.md`
+- **Chat Module LLD**: `/docs/llds/chat-module.md`

--- a/docs/llds/keybindings.md
+++ b/docs/llds/keybindings.md
@@ -1,0 +1,180 @@
+# Keybindings System
+
+**Created**: 2026-03-16
+**Status**: Design Phase
+
+## Context and Design Philosophy
+
+The keybindings system exists to provide a keyboard-driven interface for Canvas-Chat, enabling power users to navigate the canvas, manage nodes, and trigger actions without reaching for the mouse. This aligns with the broader design philosophy of treating the canvas as a workspace where keyboard efficiency matters.
+
+The system was designed with three core principles in mind. First, defaults should be sensible out of the box, with common actions mapped to intuitive keys that follow established conventions from popular applications. Second, users should be able to customize any shortcut through a settings interface, with those preferences persisted locally. Third, the system must work seamlessly across platforms, abstracting away the difference between Ctrl on Windows/Linux and Cmd on macOS so that users on either platform get a native-feeling experience.
+
+A key architectural decision was to separate the keybinding definition from the action dispatch. The keybindings module provides pure functions that transform key events into action identifiers, while the App class contains the actual handlers that execute those actions. This separation makes the system testable and allows node types to declare their own keyboard shortcuts through the node protocol.
+
+## Technical Details
+
+### Default Shortcuts
+
+The default keybindings define a comprehensive set of actions covering global operations, navigation, and node-specific behaviors. Each action is identified by a unique actionId that corresponds to a handler in the application.
+
+| Action ID        | Keys              | Description                             |
+| ---------------- | ----------------- | --------------------------------------- |
+| `search`         | Ctrl+K            | Open the search panel                   |
+| `popoverConfirm` | Enter             | Confirm navigation menu selection       |
+| `navigateParent` | ArrowUp, j        | Navigate to parent node                 |
+| `navigateChild`  | ArrowDown, k      | Navigate to child node                  |
+| `help`           | ?                 | Show help modal with all shortcuts      |
+| `undo`           | Ctrl+z            | Undo last action                        |
+| `redo`           | Ctrl+Shift+z      | Redo previously undone action           |
+| `deleteNodes`    | Delete, Backspace | Delete selected nodes                   |
+| `reply`          | r                 | Focus input to reply to selected node   |
+| `copy`           | c                 | Copy selected node content to clipboard |
+| `edit-content`   | e                 | Edit content of selected node           |
+| `edit-code`      | e                 | Edit code in selected node              |
+| `fitViewport`    | f                 | Fit selected node to viewport           |
+| `collapse`       | -                 | Collapse children of selected node      |
+| `expand`         | =                 | Expand children of selected node        |
+| `zoomSelection`  | z                 | Zoom to selected node                   |
+| `zoomFitAll`     | Shift+Z           | Zoom to fit all nodes                   |
+| `runCode`        | Ctrl+Enter        | Execute code in selected node           |
+| `generate`       | Shift+A           | Trigger AI generation                   |
+| `analyze`        | Shift+A           | Trigger AI analysis                     |
+| `flip-card`      | f                 | Flip flashcard                          |
+| `prev-slide`     | ArrowLeft         | Navigate to previous slide              |
+| `next-slide`     | ArrowRight        | Navigate to next slide                  |
+
+The defaults are stored in `DEFAULT_KEYBINDINGS`, a constant in `keybindings.js`. Each action maps to an array of key specs, allowing an action to have multiple default keys. For example, `navigateParent` responds to both ArrowUp and j, while `deleteNodes` responds to both Delete and Backspace.
+
+### Key String Format
+
+The system uses a canonical key string format for storage and lookup. Single letter keys without modifiers are stored lowercase. Modifier combinations are formatted as "Modifier+Key", where modifiers appear in alphabetical order. The format always uses "Ctrl" rather than "Meta", treating the Command key on Mac as equivalent to Ctrl for cross-platform consistency.
+
+```text
+"k"           // single letter
+"Ctrl+k"      // with Ctrl
+"Shift+Z"     // with Shift
+"Ctrl+Shift+z // with both
+"ArrowUp"    // special key
+```
+
+The `keyAndModifiersToKeyString` function in `keybindings.js` is the single source of truth for this format. It handles the conversion from KeyboardEvent properties to the canonical string representation, ensuring consistent behavior across all parts of the system.
+
+### Override System
+
+Users can customize any shortcut through the Settings modal. When a user remaps a key, the override is stored in localStorage under the key `canvas-chat-keybindings`. The stored format is an object where each key is an actionId and each value is a key spec object containing `key`, optional `shift` boolean, and optional `ctrl` boolean.
+
+```javascript
+// Stored in localStorage as JSON
+{
+  "reply": { "key": "x" },
+  "undo": { "key": "u", "ctrl": true }
+}
+```
+
+Only overrides are persisted; any action not present in the stored object falls back to its default. This approach keeps the stored data small while allowing full customization. Unknown actionIds in overrides are silently ignored, preventing errors from stale or malformed override data.
+
+The `storage.js` module provides `getKeybindings()` and `setKeybindings()` methods that wrap localStorage access with JSON parsing and error handling. These methods are called by the keybindings module to retrieve user preferences.
+
+### Effective Keybindings Merging
+
+When the application initializes, it merges default keybindings with user overrides to produce the "effective" keybindings that are actually active. The `mergeKeybindings` function takes the defaults and overrides as parameters and returns a new object containing the merged result.
+
+The merge strategy is straightforward: for each actionId in the defaults, copy its key specs to the result. Then, for each actionId present in overrides, replace the result's array with a single-element array containing the override spec. This means overrides completely replace the default keys rather than adding to them.
+
+After merging, the effective keybindings are converted into a lookup map using `buildKeyToActionMap`. This map goes from key strings to actionIds, enabling fast O(1) lookup when processing keyboard events. If two actions somehow end up mapped to the same key, the last one in the iteration wins.
+
+```javascript
+// Internal flow
+const defaults = DEFAULT_KEYBINDINGS;
+const overrides = storage.getKeybindings();
+const effective = mergeKeybindings(defaults, overrides);
+const keyToActionMap = buildKeyToActionMap(effective);
+```
+
+The `getEffectiveKeybindings` function encapsulates this flow, accepting an optional custom overrides getter for testing purposes. By default, it calls `storage.getKeybindings()` to retrieve the user's overrides.
+
+### Cross-Platform Handling
+
+Cross-platform support is critical for a web application that may be used on Windows, Linux, or macOS. The keybindings system handles this through normalization at two points: event capture and display.
+
+When a keyboard event arrives, the `eventToKeyString` function normalizes it by treating `metaKey` (the Command key on Mac) as equivalent to `ctrlKey`. This means a user pressing Cmd+K on Mac produces the same key string as a user pressing Ctrl+K on Windows. Users can bind their preferred platform's key, and it will work on both.
+
+```javascript
+// In eventToKeyString
+const ctrl = !!(e.ctrlKey || e.metaKey);
+return keyAndModifiersToKeyString(e.key, !!e.shiftKey, ctrl);
+```
+
+For display purposes, the `formatKeyForDisplay` function detects the platform using `navigator.platform` and transforms key strings for presentation. On Mac, it replaces "Ctrl+" with the Cmd symbol (⌘), showing users their native key notation.
+
+```javascript
+// On Mac: "Ctrl+k" becomes "⌘k"
+// On Windows: "Ctrl+k" stays "Ctrl+k"
+```
+
+This normalization happens only in the display layer; internally, all key strings consistently use "Ctrl" regardless of platform.
+
+### Event Flow
+
+When the user presses a key, the following sequence occurs in the App class:
+
+1. The document-level `keydown` listener fires with the KeyboardEvent.
+2. If the Settings modal is in "shortcut capture" mode, it handles the event specially.
+3. If the user is typing in an input field (textarea or input), keyboard shortcuts are disabled to avoid interfering with typing.
+4. Escape is always handled first as a special case, since it should never be remappable.
+5. The event is converted to a key string using `eventToKeyString`.
+6. The key string is looked up in the `keyToActionMap` to get an actionId.
+7. The actionId is dispatched to the appropriate handler in App.
+
+```javascript
+// Simplified flow from app.js
+document.addEventListener('keydown', (e) => {
+    if (e.target.matches('input, textarea')) return;
+
+    const effective = getEffectiveKeybindings();
+    const keyToActionMap = buildKeyToActionMap(effective);
+    const actionId = getActionForKey(e, keyToActionMap);
+
+    if (actionId === 'search') this.openSearch();
+    if (actionId === 'undo') this.undo();
+    // ... other actions
+});
+```
+
+### Node-Specific Shortcuts
+
+Beyond global shortcuts, individual node types can declare their own keyboard shortcuts through the node protocol. The `getKeyboardShortcuts()` method on node protocols returns an array of shortcuts specific to that node type. When a node is selected, these shortcuts are merged with the global keybindings to produce the complete set of active shortcuts.
+
+For example, code nodes support `runCode` (Ctrl+Enter) and `edit-code` (e), while flashcard nodes support `flip-card` (f). This allows the same key to have different meanings depending on context, with the selected node's shortcuts taking precedence.
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. ✅ Cross-platform handling - Meta (Cmd) normalized to Ctrl
+2. ✅ Override system - localStorage with merge logic
+
+### Deferred
+
+1. Multiple override keys - add vs replace
+2. Conflict detection in Settings UI
+3. Import/export keybinding configurations
+4. Per-session override profiles
+
+## References to HLD
+
+This document describes the implementation of keyboard shortcut functionality as outlined in the High-Level Design. The keybindings system supports the design principle that users should be able to navigate and interact with the canvas efficiently using keyboard shortcuts.
+
+The HLD establishes that Canvas-Chat is a local-first application where all data stays in the browser. Keybinding overrides are stored in localStorage alongside other user preferences like API keys and model selections, consistent with the dual storage strategy (localStorage for settings, IndexedDB for session data).
+
+The plugin architecture described in the HLD influences how node-specific shortcuts work. Node types declare their keyboard capabilities through the node protocol, allowing the core system to remain unaware of specific node types while still supporting their interaction needs.
+
+## Implementation Reference
+
+| File                                          | Purpose                                                    |
+| --------------------------------------------- | ---------------------------------------------------------- |
+| `src/canvas_chat/static/js/keybindings.js`    | Core keybindings module with defaults, merging, and lookup |
+| `src/canvas_chat/static/js/storage.js`        | localStorage wrapper for keybinding overrides              |
+| `src/canvas_chat/static/js/app.js`            | Event handling and action dispatch                         |
+| `src/canvas_chat/static/js/node-protocols.js` | Node protocol for declaring node-specific shortcuts        |
+| `tests/test_keybindings.js`                   | Unit tests for keybindings module                          |

--- a/docs/llds/matrix-node.md
+++ b/docs/llds/matrix-node.md
@@ -1,0 +1,388 @@
+# MatrixNode Low-Level Design
+
+**Project:** Canvas-Chat
+**Created:** 2026-03-16
+**Status:** Implementation
+**Related HLD:** `/docs/high-level-design.md`
+
+## Context and Design Philosophy
+
+The MatrixNode exists to solve a specific user pain point in LLM-assisted ideation: systematic cross-product evaluation. When users explore multiple options against multiple criteria, doing this manually creates either a flood of individual nodes (losing structure) or a flat markdown table (losing interactivity).
+
+The design philosophy centers on three principles:
+
+1. **Structured visualization** - Rows and columns create a visual grid that makes comparison natural. Users can scan across rows to see how one option performs across all criteria, or down columns to see how all options compare on one criterion.
+
+2. **Incremental evaluation** - Unlike generating an entire table at once, users can fill cells individually, row-by-row, column-by-column, or all at once. This supports iterative refinement where users might evaluate a few options first, decide to add or remove criteria, then continue filling.
+
+3. **Integration with the conversation DAG** - Each cell evaluation includes the full DAG context (ancestor nodes), meaning evaluations are informed by prior conversation. Pinned cells become first-class nodes that can be replied to, branched from, or used as context for follow-up questions.
+
+This node type directly supports the "Rich LLM Features" principle from the HLD: "Matrix evaluation - Compare options across multiple criteria."
+
+## Technical Details
+
+### Node Data Structure
+
+Matrix nodes store their state in the graph's Yjs CRDT. The structure is:
+
+```javascript
+{
+    id: string,                    // UUID
+    type: 'matrix',
+    context: string,               // User-provided evaluation goal (e.g., "evaluate languages")
+    contextNodeIds: string[],      // Source node IDs used for context
+    rowItems: string[],            // Row labels (max 10)
+    colItems: string[],            // Column labels (max 10)
+    cells: {                       // Object keyed by "rowIdx-colIdx"
+        [cellKey: string]: {
+            content: string | null,
+            filled: boolean,
+            filling: boolean       // True during streaming generation
+        }
+    },
+    groundWithWeb: boolean,        // Whether to use web search grounding
+    webSearchResults: Array<{      // Cached web search results
+        title: string,
+        url: string,
+        snippet: string,
+        content?: string           // Full page content if fetched
+    }>,
+    indexColWidth: string,         // CSS percentage for row header width
+    position: { x: number, y: number },
+    width: number,
+    height: number,
+    created_at: number,
+    tags: string[],
+    title: string | null,
+    summary: string | null,
+    model: string | null,
+    selection: any,
+    outputExpanded: boolean,       // Sources drawer state
+    outputPanelHeight: number      // Sources drawer height
+}
+```
+
+### Two-Component Architecture
+
+The matrix feature combines two distinct plugin concepts:
+
+1. **MatrixNode** (Level 1 - Custom Node Type): Extends `BaseNode` protocol. Handles rendering, event bindings, cell updates, and clipboard formatting. Registered with `NodeRegistry`.
+
+2. **MatrixFeature** (Level 2 - Feature Plugin): Extends `FeaturePlugin`. Handles slash command processing, modal management, cell filling, web grounding, and undo/redo. Registered with `FeatureRegistry`.
+
+This separation follows the plugin architecture guidelines: node rendering logic stays with the node type, while complex workflows (creation, filling, extraction) stay with the feature.
+
+### Rendering Pipeline
+
+The matrix renders through several layers:
+
+1. **Canvas** detects a `matrix` type node and wraps it with `wrapNode()` to get the `MatrixNode` protocol
+2. **MatrixNode.renderContent()** generates the HTML for:
+    - Context bar (evaluation goal text + copy button)
+    - Table with `<thead>` for columns, `<tbody>` for rows
+    - Action buttons (Edit, Fill All, Clear All)
+3. **CSS flexbox** overrides table layout to enable:
+    - Equal row height distribution (`flex: 1` on `<tr>`)
+    - Dynamic content truncation with fade effect
+    - Scroll-free visibility of all rows
+4. **Event bindings** connect cell clicks, button clicks, and header clicks to canvas events
+
+### CSS Architecture for Dynamic Sizing
+
+The matrix uses a specialized CSS approach to handle variable content heights within fixed node dimensions:
+
+```css
+.matrix-table {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    min-height: 0; /* Critical: allows shrinking below content size */
+}
+
+.matrix-table tbody {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+}
+
+.matrix-table tbody tr {
+    display: flex;
+    flex: 1; /* Equal distribution of available height */
+    min-height: 0;
+}
+```
+
+The fade effect uses a gradient pseudo-element at the bottom of filled cells:
+
+```css
+.matrix-cell-content::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    height: 1.4em;
+    background: linear-gradient(transparent, white);
+    pointer-events: none;
+}
+```
+
+This creates visual feedback that content extends beyond what's visible, rather than abruptly cutting off text.
+
+### Index Column Resize
+
+The row headers (first column) have a draggable resize handle in the corner cell. The flow:
+
+1. User mousedowns on `.index-col-resize-handle`
+2. `MatrixNode.handleCustomResize()` captures the event
+3. Mouse move calculates new width as percentage of table width
+4. CSS variable `--index-col-width` updates the column width
+5. On mouseup, the final width is persisted to the node via `graph.updateNode()`
+
+## Cell Filling with LLM
+
+### Single Cell Fill
+
+When a user clicks an empty cell (the `+` button), this flow executes:
+
+1. **UI Update**: Cell immediately shows a spinner with "Filling..." text
+2. **Context Gathering**: The system collects:
+    - Matrix context (user's evaluation goal)
+    - Row item name and column item name
+    - Full DAG history (all ancestor nodes via `graph.resolveContext()`)
+3. **Optional Web Grounding**: If `groundWithWeb` is enabled:
+    - Web search is performed using the matrix context as query
+    - Search results are enriched with full page content
+    - A map-reduce pipeline summarizes relevant sources for this specific cell
+4. **LLM Request**: POST to `/api/matrix/fill` with:
+
+    ```json
+    {
+        "row_item": "Python",
+        "col_item": "Ease of Learning",
+        "context": "evaluate programming languages",
+        "messages": [...],
+        "model": "openai/gpt-4o-mini"
+    }
+    ```
+
+5. **Streaming Response**: The backend streams tokens via SSE. The frontend:
+    - Updates cell content in real-time (throttled to 50ms intervals)
+    - Syncs to CRDT periodically to enable multiplayer sync
+    - Shows final content when `done` event arrives
+6. **Completion**: Cell state updates to `{ content: "...", filled: true, filling: false }`, undo action is pushed, session saves
+
+### Fill All
+
+The "Fill All" button fills every empty cell in sequence:
+
+1. All empty cells immediately show spinners
+2. If web grounding is enabled, search runs once before any cells fill
+3. Cells fill in parallel using `Promise.all()` - each cell handles its own streaming
+4. The stop button on the matrix node can cancel all in-progress fills
+
+### Web Grounding Pipeline
+
+When `groundWithWeb` is enabled, the system performs a sophisticated grounding operation:
+
+1. **Query Derivation**: An LLM call derives a search query from the matrix context
+2. **Search Execution**: Web search (Exa or DuckDuckGo) returns URLs and snippets
+3. **Content Enrichment**: Each URL is fetched and full page content extracted
+4. **Cell-Specific Summarization**: For each cell:
+    - An LLM generates a summarization prompt specific to that row×column
+    - Each source is summarized against that prompt in parallel
+    - Summaries are formatted and injected into the cell's context
+
+This is a map-reduce pattern: map (parallel source summarization) → reduce (final synthesis into cell content).
+
+### Backend Endpoint: `/api/matrix/fill`
+
+The backend uses litellm to proxy to the configured LLM:
+
+```python
+system_prompt = """You are evaluating items in a matrix.
+Matrix context: {request.context}
+
+You will be given a row item and a column item. Evaluate or analyze the row
+item against the column item. Be concise (2-3 sentences). Focus on the specific
+intersection of these two items."""
+
+# Messages include DAG history + final user message:
+# "Row item: {row_item}\nColumn item: {col_item}"
+```
+
+The response streams via SSE with events: `message` (content chunks), `done` (completion), `error` (failures).
+
+## Row/Column Extraction
+
+### Slice Modal
+
+Clicking a row header or column header opens a "slice" modal showing:
+
+- The row or column label
+- All cell contents for that slice, formatted as:
+
+    ```text
+    Column1:
+    [cell content or "(empty)"]
+
+    Column2:
+    [cell content or "(empty)"]
+    ```
+
+This allows users to review an entire row or column in isolation before pinning.
+
+### Pin to Canvas
+
+From either the cell detail modal or the slice modal, users can "Pin to Canvas":
+
+1. A new node is created (`CellNode`, `RowNode`, or `ColumnNode` type)
+2. The node is positioned to the right of the matrix
+3. An edge connects the matrix to the new node (MATRIX_CELL edge type)
+4. The new node becomes selected and can be:
+    - Replied to directly
+    - Branched from (select text and create new conversation)
+    - Used as context for future matrix fills or questions
+
+This bridges the structured matrix world with the freeform conversation DAG.
+
+## Modal System
+
+The MatrixFeature registers four modals:
+
+1. **Create Modal** (`matrix:create`):
+    - Context input (readonly, shows parsed context)
+    - Two-axis editor with add/remove/swap controls
+    - "Ground with web search" checkbox
+    - Warning when >10 items per axis
+
+2. **Edit Modal** (`matrix:edit`):
+    - Same axis editing as create
+    - Cell preservation when items reordered/removed
+    - Web grounding toggle
+
+3. **Cell Detail Modal** (`matrix:cell`):
+    - Row label, column label, full evaluation text
+    - Copy button, Pin to Canvas button
+
+4. **Slice Modal** (`matrix:slice`):
+    - Row or column label, all cell contents
+    - Copy button, Pin to Canvas button
+
+All modals follow the standard plugin modal registration pattern via `modalManager.registerModal()`.
+
+## Undo/Redo Support
+
+The matrix registers custom undo/redo handlers for cell fills:
+
+```javascript
+this.undoManager.registerActionHandler('FILL_CELL', {
+    undo: this.undoFillCell.bind(this),
+    redo: this.redoFillCell.bind(this),
+});
+```
+
+The action stores: `nodeId`, `row`, `col`, `oldCell`, `newCell`. Undo restores the previous cell state; redo re-applies the fill.
+
+## Streaming Manager Integration
+
+Matrix cell fills integrate with the app's `StreamingManager` for concurrent streaming management:
+
+- Each cell fill registers with group ID `matrix-{nodeId}`
+- The stop button on the matrix node stops all fills in its group
+- Fill state (spinner vs content) is tracked per-cell
+
+This enables:
+
+- Parallel cell fills without UI jank
+- Single stop button to cancel all in-progress fills
+- Proper cleanup when fills complete or abort
+
+## Extension Hooks
+
+The matrix emits events that other plugins can intercept:
+
+- `matrix:before:fill` - Cancellable, fires before cell fill starts
+- `matrix:cell:prompt` - Cancellable, allows custom prompt injection
+- `matrix:after:fill` - Notification after fill completes (success or failure)
+
+Plugins can use these to:
+
+- Log all cell fills for analytics
+- Validate or modify prompts before generation
+- Trigger side effects after completion
+
+## Limits and Constraints
+
+| Limit                 | Value                   | Rationale                                                                     |
+| --------------------- | ----------------------- | ----------------------------------------------------------------------------- |
+| Items per axis        | 10 max (100 cells)      | Prevents overwhelming API costs, UI performance issues, unreadable tables     |
+| Cell content length   | Truncated in table view | Full content in modal; table shows preview with fade                          |
+| Fill All processing   | Sequential per cell     | Parallel fills could exceed rate limits; sequential provides visible progress |
+| Web grounding sources | All results cached      | Avoids redundant search per cell; map-reduce summarization is expensive       |
+
+## Open Questions & Future Decisions
+
+### Resolved (Implementation Complete)
+
+1. ✅ **Cell editing after fill** - Currently cells are read-only after generation. Future could allow manual edits.
+2. ✅ **Row/column reordering** - Edit modal supports this with cell remapping.
+3. ✅ **Export to CSV** - Not implemented; could use clipboard copy of markdown table.
+4. ✅ **Re-fill cells** - Not implemented; would replace existing content.
+
+### Deferred / Future Considerations
+
+1. **Sort/filter rows based on column values** - Could rank rows by scores in a specific column. Requires structured cell content (e.g., numerical scores).
+
+2. **Conditional formatting** - Highlight cells based on content (e.g., "good" = green, "poor" = red). Requires content analysis or structured output.
+
+3. **Multi-dimensional matrices** - More than 2 axes (e.g., 3D cube). Current 2D design would need significant extension.
+
+4. **Bulk row/column fill** - Fill entire row or column with one click. UI exists for single cell and "Fill All" - intermediate option.
+
+5. **Cell formulas** - Simple computed cells (e.g., average of other cells). Current implementation is pure LLM output.
+
+6. **Offline caching of web results** - Currently web results persist in session. Could persist across sessions in IndexedDB for offline access.
+
+## References
+
+### High-Level Design
+
+- `/docs/high-level-design.md` - Core canvas-chat architecture, node types, plugin system
+
+### Explanation Documents
+
+- `/docs/explanation/matrix-evaluation.md` - Design decision rationale for matrix feature
+- `/docs/explanation/matrix-resize-behavior.md` - Detailed CSS approach for dynamic cell sizing
+
+### User Guides
+
+- `/docs/how-to/use-matrix-evaluation.md` - End-user documentation for matrix feature
+
+### Implementation
+
+**Frontend:**
+
+- `src/canvas_chat/static/js/plugins/matrix.js` - Complete implementation (MatrixNode protocol + MatrixFeature)
+- `src/canvas_chat/static/js/graph-types.js` - `createMatrixNode()`, `createCellNode()`, `createRowNode()`, `createColumnNode()` factory functions
+- `src/canvas_chat/static/js/node-protocols.js` - `BaseNode` protocol class
+- `src/canvas_chat/static/css/matrix.css` - Matrix-specific styles
+
+**Backend:**
+
+- `src/canvas_chat/plugins/matrix_handler.py` - `/api/parse-two-lists` and `/api/matrix/fill` endpoints
+
+**Tests:**
+
+- `tests/test_matrix.js` - Matrix rendering and state tests
+- `tests/test_matrix_plugin.js` - MatrixFeature plugin tests
+- `cypress/e2e/matrix.cy.js` - E2E matrix creation and interaction tests
+- `cypress/e2e/matrix_fill_all_spinners.cy.js` - Fill All with mocked streaming
+- `cypress/e2e/matrix_row_column_click.cy.js` - Row/column extraction modal tests
+
+### Related Features
+
+- Web grounding: `src/canvas_chat/static/js/web-grounding.js`
+- Streaming: `src/canvas_chat/static/js/streaming-manager.js`
+- Undo/Redo: `src/canvas_chat/static/js/undo-manager.js`

--- a/docs/llds/modal-system.md
+++ b/docs/llds/modal-system.md
@@ -1,0 +1,127 @@
+# Modal System
+
+**Created**: 2026-03-16
+**Status**: Design Phase
+
+## Context and Design Philosophy
+
+The Modal system provides a unified mechanism for displaying dialogs and interactive overlays throughout Canvas-Chat. Rather than scattering modal implementations across the codebase with inconsistent patterns, the ModalManager centralizes all modal lifecycle management, ensuring a consistent user experience and reducing maintenance burden.
+
+Modal dialogs serve several distinct purposes within the application: configuration (Settings), navigation (Sessions), reference (Help), and inline editing (Content, Title, Code). Each category has different interaction patterns and lifecycle requirements. The ModalManager accommodates these variations through a combination of core modals defined in HTML and plugin-modals registered dynamically by feature plugins.
+
+The design philosophy emphasizes simplicity and consistency. Modals are always single-instance per type, meaning only one Settings modal exists at a time. This contrasts with node-centric modals where multiple instances might conceptually exist (editing multiple nodes simultaneously), though the current implementation restricts editing to one node at a time through locking mechanisms.
+
+## Architecture Overview
+
+The ModalManager operates as a dependency injected into the App class, receiving a reference to the App instance for coordinating modal actions with other subsystems. It maintains two categories of modals: core modals defined statically in index.html and plugin modals registered dynamically at runtime.
+
+Core modals include Settings, Help, Sessions, Edit Content, Edit Title, and Code Editor. These are always present in the DOM and are shown or hidden by manipulating their display style. Plugin modals are created on-demand when feature plugins call `registerModal()` during their `onLoad()` lifecycle hook.
+
+The modal visibility state is managed through CSS display properties rather than adding or removing elements from the DOM. This approach preserves form state (such as partially filled inputs in the Settings modal) and simplifies the show/hide logic to a single property change.
+
+## Core Modal Types
+
+### Settings Modal
+
+The Settings modal provides a tabbed interface for configuring application behavior. It follows a sidebar-content pattern where clicking a category in the sidebar shows the corresponding panel on the right. The sidebar categories include LLM providers, Search, Custom models, Proxy, Shortcuts, Features, and Plugins.
+
+API keys entered in the Settings modal are stored in localStorage via the Storage module and are never sent to the backend. Instead, they are included in requests to LLM providers from the client-side, aligning with the bring-your-own-keys design principle documented in the HLD.
+
+The Shortcuts panel within Settings deserves special attention because it supports key capture. When a user clicks "Change" on a shortcut row, the next key combination pressed is recorded and stored as an override. The ModalManager handles this capture state, filtering out modifier-only keys to prevent accidental bindings.
+
+### Help Modal
+
+The Help modal displays keyboard shortcuts in a table format. The shortcuts table is dynamically rendered from the current keybinding configuration, ensuring that custom keybindings are reflected accurately. The modal opens via the keyboard shortcut (default: ?) and closes via the Escape key or close button.
+
+### Sessions Modal
+
+The Sessions modal manages conversation history. It loads the list of saved sessions from IndexedDB via the Storage module and displays them in a scrollable list. Each session shows its name, creation date, and a delete button. Clicking a session loads it into the canvas, replacing the current session.
+
+Sessions are stored with unique identifiers and include the full graph state serialized as JSON. The modal handles session deletion without confirmation since users can easily create new sessions, and the cost of accidental deletion is low.
+
+### Edit Content Modal
+
+The Edit Content modal provides a split-pane interface for modifying node content. The left pane contains editable text areas while the right pane shows a live preview of how the content will appear on the canvas. This design allows users to see formatting and structure changes in real-time.
+
+The modal supports dynamic fields through the node protocol system. Different node types can expose different edit fields beyond just "content." For example, flashcard nodes expose both front and back fields, while standard message nodes have only a content field. The ModalManager queries the node's protocol class to determine which fields to render and how to handle the save operation.
+
+When the modal opens, it attempts to acquire a lock on the node for multiplayer scenarios. If the node is locked by another user, the modal shows a toast notification instead of opening. The lock is released when the modal closes, whether through save, cancel, or explicit close.
+
+Version history is maintained for edited content. Before applying changes, the current state is saved as a version with a timestamp. This enables future features around content history and rollback, though the current implementation only stores versions without a UI for browsing them.
+
+### Edit Title Modal
+
+The Edit Title modal is a simple single-input dialog for changing a node's title. Like the Edit Content modal, it supports locking for multiplayer and pushes an undo action when the title changes. The title field is optional; if left empty, the node's summary or truncated content is displayed instead.
+
+### Code Editor Modal
+
+The Code Editor modal provides syntax-highlighted editing for Python code nodes. It uses highlight.js for preview rendering and includes a split-pane layout with the code editor on the left and syntax-highlighted preview on the right.
+
+When code is saved, the modal emits a `nodeCodeChange` event via the canvas event system rather than directly updating the node. This allows the CodeFeature plugin to handle the code change appropriately, clearing any previous execution state and potentially triggering re-execution.
+
+## Plugin Modal Registration
+
+Feature plugins can register their own modals through the ModalManager's registration API. This enables plugins to present complex configuration interfaces without modifying the core HTML.
+
+The registration process follows a specific pattern. During the plugin's `onLoad()` method, it constructs an HTML template string containing the modal markup and calls `this.modalManager.registerModal(pluginId, modalId, htmlTemplate)`. The pluginId should match the plugin's identifier, and modalId should describe the specific modal within that plugin.
+
+After registration, the modal element can be retrieved via `getPluginModal(pluginId, modalId)` for adding event listeners or manipulating its contents. The modal is shown and hidden using `showPluginModal(pluginId, modalId)` and `hidePluginModal(pluginId, modalId)`.
+
+The registration enforces a naming convention where the modal's id attribute should follow the pattern `{pluginId}-{modalId}-modal`. If the provided HTML lacks an id attribute, the ModalManager assigns one automatically. This convention ensures consistent DOM traversal patterns throughout the codebase.
+
+Several plugins already use this pattern. The Committee plugin registers a main modal for configuring multi-LLM consultations. The Matrix plugin registers four modals: create (new matrix), edit (matrix properties), cell (individual cell editing), and slice (row/column configuration). Flashcards registers generation and review modals. Factcheck registers a main modal for claim verification workflows.
+
+## Event Handling
+
+The ModalManager participates in the canvas event system through several mechanisms. It registers canvas event listeners for modal-triggering events, such as the `nodeEditCode` event that opens the code editor modal when users click edit on a code node.
+
+Global keyboard shortcuts also route through the ModalManager. The Escape key triggers `closeAnyOpenModal()`, which checks modals in a priority order: plugin modals first (since they are most specific), then core app modals. This ordering ensures that if multiple modals are somehow open simultaneously, the most specific one closes first.
+
+The shortcut capture feature in the Settings modal requires dedicated keyboard event handling. When capturing a new keybinding, the ModalManager intercepts keydown events and records the key combination, filtering out modifier-only presses to prevent incomplete bindings.
+
+Modal close handlers also coordinate with the graph's locking mechanism. When closing edit modals (content or title), the ModalManager releases any node lock held by the current session, ensuring other users can edit the node afterward.
+
+## Technical Implementation Details
+
+The ModalManager maintains a Map data structure for plugin modals, keyed by a compound string combining pluginId and modalId. This allows O(1) lookup when showing or hiding plugin modals. Core modals are retrieved via `document.getElementById()` since they have fixed IDs in the HTML.
+
+The edit content modal's dynamic field rendering builds DOM elements programmatically based on the protocol's `getEditFields()` method. Each field consists of a label and textarea pair. The first field with id "content" reuses the existing textarea from the HTML template to maintain any user input already entered.
+
+Preview rendering delegates to the node protocol's `renderEditPreview()` method, which returns HTML strings. For flashcard nodes, the preview supports flip animation by updating CSS classes rather than replacing the DOM, preserving transition state during live editing.
+
+The code editor modal uses highlight.js for syntax highlighting. When the textarea content changes, the preview updates by replacing the code element's text content and re-running highlight.js. This provides real-time syntax highlighting without the overhead of a full code editor component.
+
+## Dependency Injection
+
+The ModalManager receives the App instance through its constructor, enabling it to coordinate with other subsystems. It accesses the graph (for node locking and updates), canvas (for rendering and event emission), storage (for persisting settings), and feature registry (for plugin access).
+
+This design allows the ModalManager to remain focused on modal lifecycle while delegating domain-specific operations to appropriate modules. For example, when saving edited content, the ModalManager uses the graph's `updateNode()` method to persist changes, which triggers CRDT synchronization for multiplayer scenarios.
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. Modal single-instance per type: The current design enforces one modal instance per type, simplifying state management and ensuring consistent behavior.
+
+2. Dynamic fields for edit modal: Node protocols determine which fields to display, enabling flexibility without ModalManager knowing specific node type details.
+
+3. Plugin modal registration timing: Registration must occur during `onLoad()` to ensure modals exist before slash commands or other triggers attempt to show them.
+
+### Deferred
+
+1. Modal stacking: Currently, only one modal displays at a time. Future enhancements could allow multiple modals to stack with proper z-index management.
+
+2. Modal resize: The current modal sizes are fixed. Future iterations could support drag-to-resize for modals like the Edit Content modal where variable heights are useful.
+
+3. Modal keyboard navigation: While Escape closes modals, full keyboard navigation (Tab through form fields, Enter to submit) could improve accessibility.
+
+4. Version history UI: The version history stored during content edits currently has no user-facing interface. A future enhancement could display a version list allowing users to browse and restore previous content.
+
+## References
+
+- HLD: `/docs/high-level-design.md`
+- Implementation: `src/canvas_chat/static/js/modal-manager.js`
+- HTML Templates: `src/canvas_chat/static/index.html`
+- Plugin Usage: `src/canvas_chat/static/js/plugins/committee.js`, `src/canvas_chat/static/js/plugins/matrix.js`
+- Node Protocols: `src/canvas_chat/static/js/node-protocols.js`
+- Keybindings: `src/canvas_chat/static/js/keybindings.js`

--- a/docs/llds/model-loading.md
+++ b/docs/llds/model-loading.md
@@ -1,0 +1,172 @@
+# Model Loading and Selection
+
+**Created**: 2026-03-18
+**Status**: Complete
+**Component**: Frontend (App, Chat, Storage)
+**Supersedes**: N/A
+
+## Context and Design Philosophy
+
+The model loading system provides a seamless experience where users set their API key once, and models automatically appear in the model picker. This "magic" behavior is achieved through dynamic fetching from providers on startup and whenever API keys change.
+
+### Design Goals
+
+1. **Zero-configuration defaults**: Default models should work out of the box if possible
+2. **Just-in-time loading**: Models load when needed, not all at once
+3. **Graceful degradation**: If one provider fails, others continue working
+4. **Fast startup**: Parallel fetching from all providers simultaneously
+
+## Technical Design
+
+### Provider Model Fetching
+
+The `loadModels()` function orchestrates parallel fetching:
+
+```javascript
+async loadModels() {
+    const keys = storage.getApiKeys();
+
+    // Build provider list from configured keys
+    const providers = [
+        { name: 'openai', key: keys.openai },
+        { name: 'anthropic', key: keys.anthropic },
+        { name: 'google', key: keys.google },
+        { name: 'groq', key: keys.groq },
+        { name: 'github', key: keys.github },
+    ];
+
+    // Parallel fetch from all providers with keys
+    const fetchPromises = providers
+        .filter((p) => p.key) // Skip providers without keys
+        .map((p) => chat.fetchProviderModels(p.name, p.key));
+
+    const results = await Promise.all(fetchPromises);
+}
+```
+
+### Model Picker Population
+
+After fetching, models are sorted and added to the picker:
+
+```javascript
+// Sort models: user-defined > provider-recommended > alphabetically
+allModels.sort((a, b) => {
+    if (a.isUserDefined && !b.isUserDefined) return -1;
+    if (!a.isUserDefined && b.isUserDefined) return 1;
+    return a.name.localeCompare(b.name);
+});
+
+// Add to picker
+this.modelPicker.innerHTML = '';
+for (const model of allModels) {
+    const option = document.createElement('option');
+    option.value = model.id;
+    option.textContent = `${model.name} (${model.provider})`;
+    this.modelPicker.appendChild(option);
+}
+
+// Restore last selection
+const savedModel = storage.getCurrentModel();
+if (savedModel && allModels.find((m) => m.id === savedModel)) {
+    this.modelPicker.value = savedModel;
+}
+```
+
+### Dynamic Reload Triggers
+
+Models are reloaded in these scenarios:
+
+| Trigger              | Location                                | Behavior             |
+| -------------------- | --------------------------------------- | -------------------- |
+| API key saved        | `modal-manager.js:saveSettings()`       | Calls `loadModels()` |
+| Custom model added   | `modal-manager.js:addCustomModel()`     | Calls `loadModels()` |
+| Custom model deleted | `modal-manager.js:deleteCustomModel()`  | Calls `loadModels()` |
+| Copilot auth refresh | `modal-manager.js:refreshCopilotAuth()` | Calls `loadModels()` |
+| App startup          | `app.js:init()`                         | Calls `loadModels()` |
+
+### Model ID Convention
+
+Models follow the `provider/model-id` convention:
+
+| Provider       | Example Model ID               |
+| -------------- | ------------------------------ |
+| OpenAI         | `openai/gpt-4o`                |
+| Anthropic      | `anthropic/claude-sonnet-4-5`  |
+| Google         | `google/gemini-1.5-pro`        |
+| Groq           | `groq/llama-3.1-70b-versatile` |
+| GitHub Copilot | `github_copilot/gpt-4o`        |
+| Ollama         | `ollama/llama3`                |
+
+### Custom Models
+
+Users can define custom models via Settings:
+
+```javascript
+// Custom model structure
+{
+    id: 'custom/my-model',
+    name: 'My Custom Model',
+    provider: 'Custom',
+    baseUrl: 'https://api.example.com/v1',
+    isUserDefined: true
+}
+```
+
+Custom models appear in the picker alongside dynamically fetched models.
+
+### Model Picker States
+
+The model picker displays different states based on configuration:
+
+| State         | Condition                | Display                                        |
+| ------------- | ------------------------ | ---------------------------------------------- |
+| No keys       | `allModels.length === 0` | "Configure API keys in Settings ⚙️" (disabled) |
+| Models loaded | Normal operation         | List of available models                       |
+| Loading       | During fetch             | (No explicit loading state; fetch is fast)     |
+
+## API Key Retrieval
+
+When sending a message, the system retrieves the API key for the selected model:
+
+```javascript
+getApiKeyForModel(model) {
+    if (!model) return null;
+
+    // Special case: DALL-E uses OpenAI key
+    if (model.startsWith('dall-e')) {
+        return storage.getApiKeyForProvider('openai');
+    }
+
+    const provider = model.split('/')[0].toLowerCase();
+    return storage.getApiKeyForProvider(provider);
+}
+```
+
+## OpenRouter Support
+
+OpenRouter uses a single API key for multiple providers. The system supports OpenRouter models with:
+
+- Custom model definition with OpenRouter base URL
+- Single key for all OpenRouter models
+- Provider field shows "OpenRouter"
+
+## Admin Mode
+
+In admin mode, models are loaded from server configuration instead of dynamically fetching:
+
+```javascript
+async loadModelsAdminMode() {
+    const allModels = this.adminModels;
+    // Populate picker with admin-configured models
+    // No API key validation needed
+}
+```
+
+Admin mode hides API key settings in the frontend since keys are managed server-side.
+
+## References
+
+- **Specs**: `docs/specs/core-specs.md` (CHAT-REQ-006 through CHAT-REQ-008g)
+- **Storage**: `docs/llds/storage-persistence.md`
+- **Chat Module**: `docs/llds/chat-module.md`
+- **Implementation**: `app.js:loadModels()`, `chat.js:fetchProviderModels()`

--- a/docs/llds/pdf-node.md
+++ b/docs/llds/pdf-node.md
@@ -1,0 +1,377 @@
+# PdfNode: PDF Viewer Node
+
+**Created**: 2026-03-16
+**Status**: Implementation
+**Related HLD**: [High-Level Design](../high-level-design.md)
+
+## Context and Design Philosophy
+
+The PdfNode provides a visual interface for viewing PDF documents directly on the canvas. It addresses a core need identified in the HLD: enabling users to work with diverse content types beyond plain text, including documents, data, and multimedia.
+
+### Why This Node Type Exists
+
+PDF viewing capability was added to support several user workflows:
+
+- **Research workflows**: Importing research papers, reports, and technical documents for discussion with LLMs
+- **Reference materials**: Keeping relevant PDFs accessible within the conversation canvas
+- **Multi-document comparison**: Using matrix nodes to compare content across multiple PDFs
+- **Text extraction for search**: Making PDF content searchable and selectable within the canvas
+
+The design philosophy emphasizes **lazy rendering** and **progressive enhancement**. The PDF is not fully rendered until the user interacts with the node. This keeps initial canvas load times fast while still providing a rich viewing experience.
+
+### Design Decisions
+
+1. **Unified with FetchResultNode**: PDF nodes share the same underlying node type as URL-fetched content (`fetch_result`). This reduces code duplication and ensures consistent behavior across different content types.
+
+2. **Dual storage approach**: Uploaded PDFs are stored in IndexedDB for fast local access, while text is extracted via the backend and stored in the graph for searchability.
+
+3. **Output panel for text**: Extracted text appears in the collapsible output panel below the PDF viewer, enabling text selection, search, and highlight creation.
+
+4. **Client-side rendering**: PDF.js runs entirely in the browser, avoiding server costs and providing instant feedback.
+
+## Technical Details
+
+### Architecture Overview
+
+The PDF viewing system spans three main modules:
+
+| Module                 | Location                       | Responsibility                                         |
+| ---------------------- | ------------------------------ | ------------------------------------------------------ |
+| `pdf-node.js`          | `plugins/pdf-node.js`          | Node protocol, file upload handler registration        |
+| `pdf-viewer.js`        | `plugins/pdf-viewer.js`        | PDF.js integration, IndexedDB storage, text extraction |
+| `fetch-result-node.js` | `plugins/fetch-result-node.js` | Node rendering, pagination UI, keyboard shortcuts      |
+
+### PDF.js Integration
+
+PDF rendering uses PDF.js (version 5.4.624) loaded from jsDelivr CDN:
+
+```javascript
+const PDFJS_CDN_VERSION = '5.4.624';
+const PDFJS_BASE = `https://cdn.jsdelivr.net/npm/pdfjs-dist@${PDFJS_CDN_VERSION}/build`;
+```
+
+The library is lazily loaded when first needed:
+
+```javascript
+export async function getPdfJs() {
+    if (pdfjsLibPromise === null) {
+        pdfjsLibPromise = (async () => {
+            const pdfjs = await import(/* webpackIgnore: true */ `${PDFJS_BASE}/pdf.mjs`);
+            const lib = pdfjs.default ?? pdfjs;
+            if (lib.GlobalWorkerOptions && !lib.GlobalWorkerOptions.workerSrc) {
+                lib.GlobalWorkerOptions.workerSrc = `${PDFJS_BASE}/pdf.worker.mjs`;
+            }
+            return lib;
+        })();
+    }
+    return pdfjsLibPromise;
+}
+```
+
+### Loading and Rendering
+
+PDFs can be loaded from two sources:
+
+1. **Uploaded files**: Retrieved from IndexedDB using `getPdfForNode(nodeId)`
+2. **URLs**: Loaded directly from the URL via the `pdf_url` metadata field
+
+The rendering pipeline:
+
+```javascript
+async function hydratePdfViewer(wrapper, node) {
+    // 1. Determine source (URL or IndexedDB)
+    const source = pdfUrl || (await getPdfForNode(nodeId));
+
+    // 2. Load PDF document
+    const pdfDoc = await loadDocument(source);
+
+    // 3. Render first page to canvas
+    await renderPageToCanvas(pdfDoc, 1, canvasEl, scale);
+
+    // 4. Extract text from all pages
+    const text = await extractTextFromDocument(pdfDoc);
+
+    // 5. Update graph with extracted text
+    this.graph.updateNode(nodeId, { content: newContent });
+}
+```
+
+### IndexedDB Storage
+
+Uploaded PDFs are stored in a dedicated IndexedDB database to avoid the limitations of localStorage (size limits, synchronous API):
+
+```javascript
+const DB_NAME = 'canvas-chat-pdf-db';
+const PDF_STORE_NAME = 'canvas-chat-pdf';
+
+export async function setPdfForNode(nodeId, arrayBuffer) {
+    const db = await openPdfDb();
+    // Store as { nodeId, arrayBuffer }
+    tx.objectStore(PDF_STORE_NAME).put({ nodeId, arrayBuffer });
+}
+
+export async function getPdfForNode(nodeId) {
+    const db = await openPdfDb();
+    // Retrieve ArrayBuffer for PDF.js
+    return req.result ? req.result.arrayBuffer : null;
+}
+```
+
+### Node Rendering
+
+PDF nodes are rendered using the `FetchResultNode` protocol class. The rendering logic checks for PDF-specific metadata:
+
+```javascript
+// In fetch-result-node.js renderContent()
+const pdfUrl = metadata.pdf_url;
+const pdfSource = metadata.pdf_source;
+if (contentType === 'pdf' && (pdfUrl || pdfSource === 'upload')) {
+    return `
+        <div class="pdf-viewer-container"
+             data-node-id="${nodeId}"
+             ${pdfUrl ? `data-pdf-url="${safeUrl}"` : 'data-pdf-source="upload"'}
+             data-pdf-hydrated="false">
+            <div class="pdf-viewer-page-info">Page 1 of 1</div>
+            <div class="pdf-viewer-loading">Loading PDF...</div>
+            <div class="pdf-viewer-page" style="display:none;">
+                <canvas class="pdf-viewer-canvas"></canvas>
+            </div>
+        </div>
+    `;
+}
+```
+
+The `data-pdf-hydrated="false"` attribute signals to the canvas that hydration is needed. The canvas delegates to the URL fetch plugin's `hydratePdfViewer()` method.
+
+### CSS Styling
+
+PDF viewer styling is defined in `nodes.css`:
+
+```css
+.pdf-viewer-container {
+    width: 100%;
+    min-height: 200px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background: var(--node-pdf, #e8f4f8);
+    border-radius: 4px;
+}
+
+.pdf-viewer-canvas {
+    display: block;
+    vertical-align: top;
+}
+```
+
+## Pagination and Text Extraction
+
+### Pagination Controls
+
+PDF nodes include pagination buttons in the action bar, implemented in `fetch-result-node.js`:
+
+```javascript
+// Action bar shows Prev/Next buttons for PDFs
+getAdditionalActions() {
+    const isPdf = metadata.content_type === 'pdf' &&
+                  (metadata.pdf_url || metadata.pdf_source === 'upload');
+    const pdfActions = isPdf ? [PDF_PREV_PAGE, PDF_NEXT_PAGE] : [];
+    return [...pdfActions, Actions.SUMMARIZE, Actions.CREATE_FLASHCARDS];
+}
+```
+
+Keyboard shortcuts are also bound for PDF pagination:
+
+```javascript
+getKeyboardShortcuts() {
+    const base = super.getKeyboardShortcuts();
+    if (isPdf) {
+        base.ArrowLeft = { action: 'pdf-prev-page', handler: 'pdf-prev-page' };
+        base.ArrowRight = { action: 'pdf-next-page', handler: 'pdf-next-page' };
+    }
+    return base;
+}
+```
+
+### Page State Management
+
+Page state is stored on the DOM element for quick access:
+
+```javascript
+const state = { currentPage: 1, numPages };
+state.showPage = showPage;
+container._pdfState = state;
+
+async function showPage(pageNum) {
+    state.currentPage = pageNum;
+    await renderPageToCanvas(pdfDoc, pageNum, canvasEl, scale);
+    pageInfo.textContent = `Page ${pageNum} of ${numPages}`;
+}
+```
+
+### Text Extraction
+
+Text extraction runs after the first page renders. The process iterates through all pages:
+
+```javascript
+export async function extractTextFromDocument(pdfDoc) {
+    const numPages = pdfDoc.numPages;
+    const parts = [];
+    for (let i = 1; i <= numPages; i++) {
+        const page = await pdfDoc.getPage(i);
+        const textContent = await page.getTextContent();
+        const text = textContent.items.map((item) => item.str).join(' ');
+        if (text.trim()) {
+            parts.push(`## Page ${i}\n\n${text.trim()}`);
+        }
+    }
+    const full = parts.length ? parts.join('\n\n') : '(No extractable text)';
+    return full;
+}
+```
+
+The extracted text is stored in the node's content with page markers (`## Page N`) that serve two purposes:
+
+1. **Structure**: Visual separation of pages in the output panel
+2. **Navigation targets**: Each heading gets an ID for scroll targeting (`id="pdf-page-N"`)
+
+### Output Panel Integration
+
+The output panel displays extracted text with page headings:
+
+```javascript
+// In fetch-result-node.js renderOutputPanel()
+if (metadata.content_type === 'pdf' && this.node.content) {
+    const html = canvas.renderMarkdown(this.node.content);
+    // Add IDs to page headings for scroll targeting
+    return html.replace(
+        /<h2([^>]*)>(Page (\d+))<\/h2>/gi,
+        (match, attrs, inner, pageNum) => `<h2 id="pdf-page-${pageNum}"${attrs}>${inner}</h2>`
+    );
+}
+```
+
+This enables the scroll-to-page feature:
+
+```javascript
+scrollOutputPanelToPage(nodeId, pageNum) {
+    const heading = panelBody.querySelector(`#pdf-page-${pageNum}`);
+    if (heading) {
+        heading.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }
+}
+```
+
+## File Upload Handler
+
+The PDF file upload handler (`PdfFileUploadHandler`) extends `FileUploadHandlerPlugin` and integrates with the file upload registry:
+
+```javascript
+class PdfFileUploadHandler extends FileUploadHandlerPlugin {
+    async handleUpload(file, position = null, _context = {}) {
+        // Validate file type and size (25 MB limit)
+        this.validateFile(file, MAX_SIZE, 'PDF');
+
+        // Create placeholder node
+        const pdfNode = createNode(NodeType.FETCH_RESULT, `Processing PDF: ${file.name}...`, { position });
+
+        // Store PDF in IndexedDB
+        const arrayBuffer = await file.arrayBuffer();
+        await setPdfForNode(pdfNode.id, arrayBuffer);
+
+        // Upload to backend for text extraction
+        const response = await fetch(apiUrl('/api/upload-file'), {
+            method: 'POST',
+            body: formData,
+        });
+
+        // Update node with extracted content and metadata
+        this.graph.updateNode(pdfNode.id, {
+            content: data.content,
+            title: data.title || file.name,
+            metadata: {
+                content_type: 'pdf',
+                pdf_source: 'upload',
+                page_count: data.page_count,
+            },
+        });
+    }
+}
+
+// Registration
+FileUploadRegistry.register({
+    id: 'pdf',
+    mimeTypes: ['application/pdf'],
+    extensions: ['.pdf'],
+    handler: PdfFileUploadHandler,
+    priority: PRIORITY.BUILTIN,
+});
+```
+
+### Backend Text Extraction
+
+The backend endpoint (`/api/upload-file`) uses PyMuPDF (fitz) to extract text from uploaded PDFs:
+
+```python
+# In app.py or file upload handler
+import fitz  # PyMuPDF
+
+def extract_text_from_pdf(file_bytes):
+    doc = fitz.open(stream=file_bytes, filetype="pdf")
+    text_parts = []
+    for page_num, page in enumerate(doc, start=1):
+        text = page.get_text()
+        if text.strip():
+            text_parts.append(f"## Page {page_num}\n\n{text.strip()}")
+    return "\n\n".join(text_parts), doc.page_count
+```
+
+## Open Questions and Future Decisions
+
+### Resolved
+
+1. ✅ PDF.js for client-side rendering
+2. ✅ PyMuPDF for backend text extraction
+
+### Deferred
+
+1. Text layer for selection - add overlay for direct selection
+2. Thumbnail navigation - sidebar with page previews
+3. Annotation support - highlight, annotate on PDF pages
+4. Search within PDF - dedicated search UI
+5. Render scale optimization - quality/performance setting
+6. Scanned PDF handling - OCR integration
+
+**Trade-off**: OCR is computationally expensive and would require backend processing. Tesseract.js could run client-side but with significant performance impact.
+
+## References to HLD
+
+This design implements several principles from the [High-Level Design](../high-level-design.md):
+
+### Node Types (Section 6)
+
+PDF nodes fall under the "Documents" category in the HLD's node type taxonomy:
+
+| Category  | Node Types                            |
+| --------- | ------------------------------------- |
+| Documents | PDFs, PowerPoint, YouTube transcripts |
+
+### Plugin-Extensible (Section 4.3)
+
+The PDF node follows the three-level plugin architecture:
+
+1. **Level 1**: Custom node type (`PdfNode` protocol class)
+2. **Level 2**: Feature integration (file upload handler)
+3. **Level 3**: Canvas hydration hook (lazy loading)
+
+### Local-First (Section 4.1)
+
+PDF storage uses IndexedDB, keeping all user data in the browser. No server-side storage of PDF files.
+
+### Streaming-First (Section 4.5)
+
+While PDF viewing isn't streaming, the progressive rendering (placeholder -> loading -> first page) follows the same philosophy of showing feedback immediately rather than waiting for complete operations.
+
+### Vanilla JavaScript (Section 8.1)
+
+The PDF implementation uses plain JavaScript with PDF.js, avoiding framework dependencies.

--- a/docs/llds/plugin-system.md
+++ b/docs/llds/plugin-system.md
@@ -1,0 +1,182 @@
+# Plugin System
+
+**Created**: 2026-03-16
+**Status**: Design Phase
+
+## Context and Design Philosophy
+
+Canvas-Chat is extensible through plugins. The plugin system lets developers add new features without modifying core code. Three levels of extensibility allow incremental addition of functionality.
+
+## Three-Level Architecture
+
+### Level 1: Custom Node Types
+
+Custom visual representations for nodes:
+
+- **What**: New node rendering, actions, keyboard shortcuts
+- **Example**: MatrixNode with table UI, CodeNode with output panel
+- **Registration**: `NodeRegistry.register({ type, protocol, defaultSize, css })`
+
+### Level 2: Feature Plugins
+
+Complex workflows with slash commands:
+
+- **What**: Multi-step LLM operations, stateful features
+- **Example**: Committee (multiple LLMs), Research (web search + LLM)
+- **Registration**: `FeatureRegistry.register({ id, feature, slashCommands })`
+
+### Level 3: Extension Hooks
+
+Hook into existing features:
+
+- **What**: Modify or augment behavior
+- **Example**: Logging, validation, analytics
+- **Mechanism**: Event subscriptions
+
+## FeaturePlugin Base Class
+
+All feature plugins extend `FeaturePlugin`:
+
+```javascript
+class MyFeature extends FeaturePlugin {
+    // Slash commands this feature handles
+    getSlashCommands() { return [{ command: '/mycmd', ... }] }
+
+    // Handle the command
+    async handleCommand(command, args, context) { ... }
+
+    // Subscribe to app events
+    getEventSubscriptions() { return { 'nodeAdded': this.onNodeAdded } }
+
+    // Handle canvas events from custom nodes
+    getCanvasEventHandlers() { return { 'myEvent': this.handleMyEvent } }
+
+    // Called when plugin loads
+    async onLoad() { ... }
+}
+```
+
+### AppContext
+
+Plugins receive `AppContext` for dependency injection:
+
+```javascript
+constructor(context) {
+    this.graph = context.graph;
+    this.canvas = context.canvas;
+    this.chat = context.chat;
+    this.storage = context.storage;
+    this.modalManager = context.modalManager;
+    this.undoManager = context.undoManager;
+}
+```
+
+## Node Protocols
+
+Custom node types implement the `BaseNode` protocol:
+
+```javascript
+class MyNode extends BaseNode {
+    getTypeLabel() {
+        return 'My Node';
+    }
+    getTypeIcon() {
+        return '📦';
+    }
+    getSummaryText() {
+        return 'Short summary';
+    }
+    renderContent() {
+        return '<div>...</div>';
+    }
+    getActions() {
+        return [Actions.COPY, Actions.EDIT];
+    }
+    isContentEditable() {
+        return true;
+    }
+}
+```
+
+## Slash Command Routing
+
+When user types `/command`:
+
+1. App checks `NodeRegistry` for custom node creation commands
+2. App checks `FeatureRegistry` for feature commands
+3. First match wins (based on priority)
+
+### Priority Levels
+
+| Priority | Level     | Use                      |
+| -------- | --------- | ------------------------ |
+| 2000     | OVERRIDE  | Force a specific handler |
+| 1000     | BUILTIN   | Core features            |
+| 500      | OFFICIAL  | First-party plugins      |
+| 100      | COMMUNITY | Third-party extensions   |
+
+## Event System
+
+### Event Bus
+
+`FeatureRegistry` maintains an internal event bus:
+
+```javascript
+// Subscribe
+featureRegistry.on('eventName', handler);
+
+// Emit
+featureRegistry.emit('eventName', { data });
+```
+
+### Cancellable Events
+
+Some events can be cancelled:
+
+```javascript
+// Command before event - can prevent execution
+getEventSubscriptions() {
+    return {
+        'command:before': (event) => {
+            if (shouldBlock) {
+                event.preventDefault();
+            }
+        }
+    }
+}
+```
+
+## File Upload Handlers
+
+Separate registry for file type handlers:
+
+```javascript
+FileUploadRegistry.register({
+    id: 'pdf',
+    extensions: ['.pdf'],
+    handler: PdfHandler,
+});
+```
+
+Priority: BUILTIN (100) > OFFICIAL (50) > COMMUNITY (10)
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. ✅ Three-level system - allows both simple and complex extensions
+2. ✅ Priority system - resolves conflicts predictably
+
+### Deferred
+
+1. Plugin marketplace? Sharing mechanism?
+2. Plugin versioning and updates?
+
+## References
+
+- HLD: `/docs/high-level-design.md`
+- Implementation:
+  - `src/canvas_chat/static/js/feature-plugin.js`
+  - `src/canvas_chat/static/js/feature-registry.js`
+  - `src/canvas_chat/static/js/node-registry.js`
+  - `src/canvas_chat/static/js/node-protocols.js`

--- a/docs/llds/powerpoint-node.md
+++ b/docs/llds/powerpoint-node.md
@@ -1,0 +1,129 @@
+# PowerPointNode Low-Level Design
+
+**Created**: 2026-03-16
+**Status**: Implementation
+**Related HLD**: [High-Level Design](../high-level-design.md)
+
+## Context and Design Philosophy
+
+The PowerPointNode enables users to upload PowerPoint (.pptx) files directly onto the canvas, transforming static presentations into interactive, navigable objects. This node type exists because LLM workflows often involve analyzing or presenting slide decks, and users need a way to visually explore, annotate, and extract insights from presentations without leaving the canvas environment.
+
+The design philosophy centers on three principles. First, progressive enhancement ensures the node remains usable even when backend dependencies like LibreOffice are unavailable by generating placeholder renderings. Second, rich interactivity distinguishes this from a simple image viewer by providing per-slide navigation, title editing, caption generation, and narrative weaving capabilities. Third, seamless integration with the broader canvas ecosystem allows slide images to be extracted as separate Image nodes, creating connections that maintain conversation context.
+
+## Technical Details
+
+### Architecture Overview
+
+The PowerPoint implementation spans three primary modules. The frontend `powerpoint-node.js` defines both the node protocol and the feature plugin, handling rendering, user interactions, and LLM orchestration. The backend `pptx_handler.py` manages file processing, converting PPTX files into structured slide data with rendered images. The API endpoints in `pptx_endpoints.py` expose LLM-powered features for caption generation and narrative weaving.
+
+```text
+PowerPoint Upload Flow:
+┌─────────────────┐     ┌──────────────────┐     ┌─────────────────┐
+│  File Drop      │────▶│  Backend Handler │────▶│  SSE Stream     │
+│  (Frontend)     │     │  (pptx_handler)  │     │  (pptx_endpoints)│
+└─────────────────┘     └──────────────────┘     └─────────────────┘
+                                │                         │
+                                ▼                         ▼
+                        ┌──────────────────┐     ┌─────────────────┐
+                        │ LibreOffice       │     │ Frontend Node   │
+                        │ python-pptx       │     │ Rendering       │
+                        └──────────────────┘     └─────────────────┘
+```
+
+### LibreOffice Rendering Pipeline
+
+The backend uses LibreOffice in headless mode to convert PPTX slides into PNG images. This approach ensures accurate rendering that matches what users see in PowerPoint, including fonts, layouts, and embedded media. The conversion process follows these steps:
+
+First, the uploaded file is saved to a temporary directory. Then LibreOffice is invoked with specific flags for headless operation, including `--headless`, `--nologo`, `--nolockcheck`, `--nodefault`, and `--nofirststartwizard`. The conversion target uses the Impress PNG export filter (`png:impress_png_Export`) for best results.
+
+A robust fallback mechanism exists for environments without LibreOffice. When the command is not found, the handler generates placeholder images using PIL that display the slide title and text content in a simple layout. This allows the UI to function even in minimal deployments, with a note indicating that LibreOffice is required for accurate rendering.
+
+The PNG output undergoes several transformations before reaching the frontend. Images are resized to a standard width of 1024 pixels for storage and 240 pixels for thumbnails. PNG files are transcoded to WebP format for reduced bandwidth, with quality settings of 90 for full images and 70 for thumbnails. If WebP encoding fails, the system gracefully falls back to PNG.
+
+Some LibreOffice builds only render the first slide when using plain PNG conversion. To handle this, the pipeline detects when fewer images are produced than expected slides and automatically falls back to PDF export followed by PyMuPDF rasterization. This two-stage approach ensures reliable multi-slide output across different LibreOffice versions and platforms.
+
+### python-pptx Text Extraction
+
+Text content extraction uses the python-pptx library to extract per-slide information before image rendering begins. This enables immediate display of slide metadata in the UI while images render in the background.
+
+Slide titles are extracted using a two-phase approach. The system first attempts to retrieve the title placeholder shape that PowerPoint designates as the title. If that fails (common with certain templates), a heuristic identifies the first non-empty text line from any shape on the slide, truncated to 120 characters.
+
+Text content is collected from all shapes with text frames on each slide, joined with newlines. This provides the raw material for LLM-powered caption generation.
+
+### Streaming Upload Architecture
+
+The upload process uses Server-Sent Events (SSE) to stream results to the frontend, providing progressive feedback during the potentially lengthy conversion process. The stream emits four event types.
+
+The `metadata` event fires first, containing slide count, titles, and text content extracted via python-pptx. This allows the UI to display the slide structure immediately. The `progress` event periodically indicates rendering status. Individual `slide` events deliver each rendered image as it completes, enabling incremental display. Finally, the `done` event signals completion and includes the rendering mode indicator.
+
+This architecture ensures the user sees meaningful content within seconds of upload while full rendering continues in the background.
+
+### Slide Navigation Drawer
+
+The slide drawer (output panel) provides a thumbnail-based navigation interface. Each row displays a 64x48 pixel thumbnail, slide number, editable title input, caption preview, and action buttons. The current slide is highlighted with an accent border and background color.
+
+Navigation supports multiple interaction modes. Arrow key shortcuts (Left/Right) navigate between slides when the node is selected. Clicking thumbnails in the drawer jumps directly to any slide. The node body displays the current slide with previous/next buttons and a counter showing position.
+
+The drawer implements in-place DOM patching to avoid full node re-renders during navigation. This prevents focus loss from input fields and eliminates visual flashing. The `_patchPowerPointDomInPlace` method selectively updates only the changed elements within both the node body and drawer.
+
+### Caption and Title Generation
+
+The LLM-powered caption feature generates one-paragraph descriptions and optional titles for individual slides or entire decks. Three API endpoints support this functionality.
+
+The single-slide endpoint (`/api/pptx/caption-title-slide`) accepts slide text, optional existing title, and filename, returning a structured title and caption. The deck endpoint (`/api/pptx/caption-title-deck`) processes all slides in a single LLM call for consistency across the presentation. The suggestions endpoint (`/api/pptx/narrative-style-suggestions`) generates AI-powered presets for the weave narrative feature.
+
+All endpoints support structured output when the model permits, falling back to JSON parsing from text responses when necessary. The system normalizes output to ensure captions are single paragraphs without newlines or bullet points.
+
+Frontend state tracks enrichment status per slide using `slideEnrichStatuses` (values: idle, queued, running, done, error) and stores generated content in `slideTitles` and `slideCaptions` objects keyed by slide index.
+
+### Slide Extraction
+
+Users can extract the current slide as a separate Image node by clicking the slide image. This mirrors the PDF viewer behavior, showing a tooltip with an "Extract" action that creates a new node containing only that slide's image. The new node connects to the PowerPoint node via a HIGHLIGHT edge, preserving the relationship between the source presentation and extracted content.
+
+## Weave Narrative Mode
+
+The weave narrative feature transforms a deck's titles and captions into a cohesive written output. It supports multiple output structures including continuous narrative, executive summary with bullet points, and speaker notes format.
+
+### Preset System
+
+When users open the weave modal, the system automatically requests narrative style suggestions from the LLM. These suggestions are represented as presets with properties including label, description, voice/persona guidance, audience hint, desired length (short/medium/long), output structure, and slide inclusion mode (all slides or only those with captions).
+
+If the suggestion endpoint fails, three fallback presets are available: Story Arc (coherent narrative), Executive Summary (high-level bullets with next steps), and Speaker Notes (slide-by-slide talking points).
+
+### Modal Workflow
+
+The weave modal presents AI-suggested presets as radio card selections. Selecting a preset auto-fills the voice, audience, length, structure, and inclusion controls. Users can customize these settings or create their own by modifying any field. The Generate button creates a new AI node connected to the PowerPoint node and streams the generated narrative into it.
+
+The generation prompt incorporates the selected voice and audience rules, the length guidelines (paragraph count targets), and the structure rules (narrative flow versus bullet points versus speaker notes format). Only slides matching the inclusion criteria (all or only captioned) are included in the prompt.
+
+## File Upload Handler
+
+The file upload system uses a two-layer registration mechanism. Backend registration in `pptx_handler.py` uses the FileUploadRegistry to declare supported MIME types and extensions. Frontend registration in `powerpoint-node.js` provides the PowerPointFileUploadHandler class that implements the actual upload logic.
+
+The frontend handler validates file type by both extension (.pptx, .ppt) and MIME type, rejecting invalid files with a clear error message. File size is validated against a 50 MB maximum. Upon valid upload, a placeholder node is created immediately with processing state, then updated progressively as SSE events arrive.
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. ✅ LibreOffice for server-side rendering
+2. ✅ python-pptx for text extraction
+
+### Deferred
+
+1. Rendering performance - lazy loading for large decks
+2. Collaborative editing - conflict resolution for multiplayer
+3. Template support - preserve theme colors/fonts
+4. Export capabilities - create PPTX from content
+
+## References to HLD
+
+This implementation supports the following HLD principles:
+
+- **Plugin-Extensible** (Section 4.3): PowerPointNode demonstrates Level 1 (custom node type) and Level 2 (feature plugin) extensibility. The NodeRegistry handles rendering while FeatureRegistry manages slash commands and canvas event handlers.
+
+- **Documents Node Category** (Section 6): The PowerPointNode belongs to the Documents category alongside PDF and YouTube transcript nodes, sharing common patterns for file upload, content extraction, and navigation.
+
+- **Streaming-First** (Section 4.4): SSE streaming provides progressive feedback during upload, and the streaming infrastructure supports weave narrative generation.
+
+- **Local-First** (Section 4.1): All slide data, titles, and captions persist in the browser via CRDT, requiring no server-side storage.

--- a/docs/llds/research-feature.md
+++ b/docs/llds/research-feature.md
@@ -1,0 +1,439 @@
+# Low-Level Design: ResearchFeature
+
+**Created**: 2026-03-16
+**Status**: Implementation
+**Module**: ResearchFeature (deep research and web search)
+
+## Context and Design Philosophy
+
+The ResearchFeature provides two related but distinct capabilities within Canvas-Chat. The `/search` command performs lightweight web searches and displays results as reference nodes. The `/research` command performs deep research, synthesizing information from multiple sources into a comprehensive report. Both commands support context-aware refinement, where selected text or nodes are used to clarify vague queries.
+
+The design philosophy centers on three principles. First, progressive disclosure recognizes that not all research needs are equal; `/search` is fast and lets users explore manually, while `/research` provides comprehensive synthesis for complex topics. Second, dual-provider architecture prioritizes Exa for quality but gracefully falls back to DuckDuckGo when no API key is available, ensuring the feature works for all users. Third, streaming-first experience provides real-time feedback during research, showing status updates and progressive content so users understand what's happening.
+
+## Technical Overview
+
+### Slash Command Entry Points
+
+The feature is accessed via two slash commands registered in the FeatureRegistry:
+
+- `/search` - Lightweight web search returning reference nodes
+- `/research` - Deep research with synthesized report
+
+```text
+/search latest advances in mRNA vaccines
+/research comprehensive analysis of mRNA vaccine technology and its clinical applications
+```
+
+#### Command Routing
+
+Both commands route to the same `ResearchFeature` class but use different handlers:
+
+- `/search` routes to `handleSearch(command, args, contextObj)`
+- `/research` routes to `handleResearch(param1, param2, param3)`
+
+The `handleResearch` method supports two calling patterns:
+
+1. Slash command: `handleResearch(command, args, contextObj)` - when invoked via `/research`
+2. Internal continue: `handleResearch(instructions, context, existingNodeId)` - when continuing a stopped research
+
+### Provider Detection
+
+The feature detects the search provider at runtime:
+
+```javascript
+const hasExa = storage.hasExaApiKey();
+const exaKey = hasExa ? storage.getExaApiKey() : null;
+const provider = hasExa ? 'Exa' : 'DuckDuckGo';
+```
+
+Provider detection happens in both `handleSearch` and `handleResearch`. The selected provider determines:
+
+- Which API endpoint to call (`/api/exa/search` vs `/api/ddg/search`)
+- Whether to use Exa-specific models (`exa-research`)
+- How to parse the response (streaming vs batch)
+
+## Query Refinement
+
+Both commands support context-aware query refinement. When users have text or nodes selected, the feature calls the `/api/refine-query` endpoint to generate a more effective search query.
+
+### Refinement Process
+
+1. User provides vague query with context (selected text/nodes)
+2. Frontend sends `{ user_query, context, command_type }` to `/api/refine-query`
+3. Backend uses LLM to generate a refined query that incorporates context
+4. Frontend updates the node to show both original and refined queries
+5. The refined query is used for the actual search/research
+
+### Example Transformation
+
+**User input**: Selected node mentions "Toffoli gates", query is "how does this work?"
+
+**Refined query**: "how Toffoli gate CCNOT quantum computing works"
+
+This allows conversational queries that would otherwise fail in web search.
+
+## /search Command Flow
+
+### Frontend: handleSearch Method
+
+The `handleSearch` method in `ResearchFeature` implements the following flow:
+
+1. **Provider Detection**: Check for Exa API key in storage
+2. **Node Creation**: Create a SEARCH node with placeholder content
+3. **Positioning**: Use `graph.autoPosition()` to place node relative to selected parents
+4. **Edge Creation**: Connect to parent nodes with `EdgeType.REFERENCE`
+5. **Query Refinement**: If context provided, call `/api/refine-query` and update display
+6. **Search Execution**: Call appropriate endpoint based on provider
+7. **Result Processing**: Parse response and update node content
+8. **Reference Node Creation**: Create REFERENCE nodes for each result, positioned to the right
+
+### Backend: /api/exa/search Endpoint
+
+Located in `app.py` at line 1822:
+
+```python
+@app.post("/api/exa/search")
+async def exa_search(request: ExaSearchRequest):
+```
+
+The endpoint:
+
+1. Creates an Exa client with the provided API key
+2. Calls `exa.search_and_contents()` with the query
+3. Requests `text={"max_characters": 1500}` for content extraction
+4. Returns formatted results with title, URL, snippet, published_date, author
+
+### Backend: /api/ddg/search Endpoint
+
+Located in `ddg_endpoints.py` at line 159:
+
+```python
+@app.post("/api/ddg/search")
+async def ddg_search(request: DDGSearchRequest):
+```
+
+The endpoint:
+
+1. Uses the `ddgs` library to perform DuckDuckGo search
+2. Returns results in the same format as Exa for frontend compatibility
+3. Falls back gracefully when Exa is not available
+
+### Search Node Structure
+
+Created using `createNode(NodeType.SEARCH, content, options)`:
+
+- **Width**: 420px
+- **Height**: 200px
+- **Edge Type**: `EdgeType.REFERENCE` from parent nodes
+- **Content**: Markdown with query, provider info, and result count
+
+### Reference Node Structure
+
+Created for each search result using `createNode(NodeType.REFERENCE, content, options)`:
+
+- **Position**: Offset 400px right of search node, with 200px vertical spacing
+- **Edge Type**: `EdgeType.SEARCH_RESULT` from search node
+- **Content**: Title (as link), URL, snippet, published date
+
+## /research Command Flow
+
+### Frontend: handleResearch Method
+
+The `handleResearch` method implements a more complex flow than search:
+
+1. **Provider Detection**: Check for Exa API key
+2. **Node Creation**: Create RESEARCH node with placeholder (500px wide for reports)
+3. **Streaming Registration**: Register with `StreamingManager` for stop/continue support
+4. **Query Refinement**: Same refinement process as search
+5. **Research Execution**: Call appropriate endpoint based on provider
+6. **SSE Processing**: Handle streaming events (status, content, sources)
+7. **Completion**: Clean up streaming state, generate summary
+
+### Streaming Integration
+
+Research integrates with the `StreamingManager` for unified stop/continue handling:
+
+```javascript
+this.streamingManager.register(nodeId, {
+    abortController,
+    featureId: 'research',
+    context: {
+        type: 'research',
+        originalInstructions: instructions,
+        originalContext: selectedContext,
+    },
+    onContinue: async (nodeId, state, _newAbortController) => {
+        // Continue research from where it left off
+        await this.handleResearch(state.context.originalInstructions, state.context.originalContext, nodeId);
+    },
+});
+```
+
+This integration provides:
+
+- Stop button in node header during streaming
+- Continue button to resume stopped research
+- Proper cleanup on completion or error
+
+### Backend: /api/exa/research Endpoint
+
+Located in `app.py` at line 2016:
+
+```python
+@app.post("/api/exa/research")
+async def exa_research(request: ExaResearchRequest):
+```
+
+The endpoint:
+
+1. Creates an Exa research task via `exa.research.create()`
+2. Streams results using `EventSourceResponse`
+3. Emits SSE events: `status`, `content`, `sources`, `done`, `error`
+
+#### SSE Event Types
+
+| Event     | Payload       | Description             |
+| --------- | ------------- | ----------------------- |
+| `status`  | string        | Current research phase  |
+| `content` | markdown      | Report content (chunks) |
+| `sources` | JSON array    | `[{title, url}, ...]`   |
+| `done`    | empty         | Research completed      |
+| `error`   | error message | Failure occurred        |
+
+#### Output Formatting
+
+The `format_research_output()` function (line 1973) transforms Exa output objects:
+
+- `output_type: "tasks"` - Planning phase: reasoning + task list
+- `output_type: "completed"` - Final report with optional cost
+- `output_type: "stop"` - Research stopped by user
+
+### Backend: /api/ddg/research Endpoint
+
+Located in `ddg_endpoints.py` at line 203:
+
+This is a fallback implementation that uses DuckDuckGo + user's LLM. It implements iterative research:
+
+1. **Query Generation**: LLM generates initial search queries from instructions
+2. **Iteration Loop**: 3-5 iterations (configurable)
+3. **Search**: DuckDuckGo search for each query
+4. **Relevance Filtering**: Filter results based on query keywords
+5. **Content Fetching**: Fetch page content via Jina or direct HTTP
+6. **Summarization**: LLM summarizes each page
+7. **Query Expansion**: Generate new queries based on learned information
+8. **Synthesis**: Combine all summaries into final report
+
+#### SSE Event Types (DDG Fallback)
+
+| Event     | Payload  | Description                                                  |
+| --------- | -------- | ------------------------------------------------------------ |
+| `status`  | string   | Current phase ("Generating initial search queries...", etc.) |
+| `source`  | JSON     | Individual source as it's processed                          |
+| `content` | markdown | Final report (sent once at end)                              |
+
+### Research Node Structure
+
+Created using `createNode(NodeType.RESEARCH, content, options)`:
+
+- **Width**: 500px (wider for markdown reports)
+- **Height**: 480px (default, resizable)
+- **Model Metadata**: Stores model used for research (`model` field)
+- **Edge Type**: `EdgeType.REFERENCE` from parent nodes
+
+### Research Node Protocol
+
+Defined in `plugins/research-node.js`:
+
+- **Type Label**: "Research"
+- **Type Icon**: "📚"
+- **Header Buttons**: Nav Parent, Nav Child, Collapse, Stop, Continue, Reset Size, Fit Viewport, Delete
+- **Actions**: Reply, Create Flashcards, Copy
+
+## Streaming Results Processing
+
+### Exa Streaming (Real-time Chunks)
+
+For Exa research, content arrives in chunks:
+
+```javascript
+onEvent: (eventType, data) => {
+    if (eventType === 'content') {
+        // Append chunk to existing content
+        if (reportContent.length > reportHeader.length) {
+            reportContent += '\n\n---\n\n';
+        }
+        reportContent += data;
+        this.canvas.updateNodeContent(nodeId, reportContent, true);
+        this.graph.updateNode(nodeId, { content: reportContent });
+    }
+};
+```
+
+The `true` parameter indicates streaming mode (appending vs replacing).
+
+### DDG Streaming (Source-by-Source)
+
+For DDG research, sources arrive individually:
+
+```javascript
+if (eventType === 'source') {
+    const source = JSON.parse(data);
+    ddgSourceCount += 1;
+
+    // Build markdown for this source
+    ddgSourcesMd += `### [${title}](${url})...\n\n${summary}\n\n---\n\n`;
+
+    // Update display with growing sources list
+    const sourcesBlock = `## Sources (${ddgSourceCount})\n\n${ddgSourcesMd}`;
+    this.canvas.updateNodeContent(nodeId, content, true);
+}
+```
+
+### Completion Handling
+
+```javascript
+onDone: () => {
+    this.streamingManager.unregister(nodeId);
+
+    // Normalize content
+    reportContent = normalizeText(reportContent);
+
+    // Add sources section if available
+    if (sources.length > 0) {
+        reportContent += '\n\n---\n**Sources:**\n';
+        for (const source of sources) {
+            reportContent += `- [${source.title}](${source.url})\n`;
+        }
+    }
+
+    this.canvas.updateNodeContent(nodeId, reportContent, false);
+    this.graph.updateNode(nodeId, { content: reportContent });
+
+    // Generate async summary
+    this.generateNodeSummary(nodeId);
+};
+```
+
+## Stop and Continue
+
+### Stop Mechanism
+
+1. User clicks Stop button in research node header
+2. `StreamingManager.unregister(nodeId)` is called
+3. `abortController.abort()` cancels the in-flight request
+4. Current content is preserved in the node
+5. Continue button appears in node header
+
+### Continue Mechanism
+
+1. User clicks Continue button
+2. `onContinue` callback is invoked with stored state
+3. `handleResearch` is called with `existingNodeId` parameter
+4. Node content shows "Restarting research..."
+5. New research begins, updating the same node
+
+## Node Positioning
+
+### Search Positioning
+
+- Search node: `graph.autoPosition(parentIds)` relative to selected parents
+- Reference nodes: Offset 400px right, 200px vertical spacing between each
+
+### Research Positioning
+
+- Research node: `graph.autoPosition(parentIds)` relative to selected parents
+- 500px width for better markdown report display
+
+## Data Flow Summary
+
+```text
+User Input (/research topic)
+        |
+        v
+ResearchFeature.handleResearch()
+        |
+        v
+Provider Detection (Exa vs DDG)
+        |
+        v
+Query Refinement (if context) --> /api/refine-query
+        |
+        v
+Create RESEARCH Node + StreamingManager.register()
+        |
+        v
+Backend API Call
+  - Exa: /api/exa/research (streaming SSE)
+  - DDG: /api/ddg/research (streaming SSE)
+        |
+        v
+SSE Stream Processing
+  - status events: Update with progress
+  - content events: Append to report
+  - sources events: Store for final section
+        |
+        v
+Completion: normalize + add sources + generate summary
+```
+
+## File Structure
+
+| File                       | Purpose                                                |
+| -------------------------- | ------------------------------------------------------ |
+| `plugins/research.js`      | ResearchFeature class with handleSearch/handleResearch |
+| `plugins/research-node.js` | ResearchNode protocol definition                       |
+| `plugins/search-node.js`   | SearchNode protocol definition                         |
+| `app.py`                   | Exa API endpoints (lines 1822-2066)                    |
+| `plugins/ddg_endpoints.py` | DuckDuckGo fallback endpoints                          |
+
+## Dependencies
+
+### Frontend Dependencies (injected via AppContext)
+
+- `this.graph` - CRDT graph for node/edge operations
+- `this.canvas` - SVG canvas for rendering
+- `this.chat` - LLM API integration
+- `this.storage` - localStorage for API keys
+- `this.streamingManager` - Concurrent streaming state
+- `this.modalManager` - Modal display
+- `this.buildLLMRequest()` - Request builder helper
+
+### External APIs
+
+- **Exa API** (`/api/exa/*`) - Neural search and research
+- **DuckDuckGo** (`/api/ddg/*`) - Free fallback search
+- **Jina AI** - URL content extraction (used by DDG fallback)
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. ✅ Dual provider (Exa + DuckDuckGo fallback)
+2. ✅ Automatic query refinement when context selected
+
+### Deferred
+
+1. Query refinement - skippable option for advanced users
+2. Research continuation state - preserve intermediate results
+3. Exa Pro model access - UI for model selection
+4. Maximum results configuration - user-configurable limits
+5. Multi-source synthesis - parallel provider searches
+
+## References to HLD
+
+This LLD supports the following HLD components:
+
+- **Section 5.2: Backend LLM Proxy** - Research endpoints are part of the FastAPI backend
+- **Section 5.1: Frontend The Canvas** - Research nodes render on the SVG canvas
+- **Section 4.4: Streaming-First** - All research results stream in real-time
+- **Section 4.3: Plugin-Extensible** - ResearchFeature is a Level 2 feature plugin
+- **Section 6: Node Types** - RESEARCH and SEARCH are documented node types
+- **Section 7: Edge Types** - EdgeType.REFERENCE and SEARCH_RESULT connect research graphs
+
+## Related Documentation
+
+- [How to conduct deep research](../how-to/deep-research.md) - User guide for /research
+- [How to search the web](../how-to/web-search.md) - User guide for /search
+- [High-Level Design](../high-level-design.md) - System overview
+- [Feature Plugin API](../reference/feature-plugin-api.md) - Plugin base class reference
+- [AppContext API](../reference/app-context-api.md) - Available Canvas-Chat APIs

--- a/docs/llds/search-module.md
+++ b/docs/llds/search-module.md
@@ -1,0 +1,290 @@
+# Search Module: Low-Level Design
+
+**Created**: 2026-03-16
+**Status**: Design Phase
+**Parent**: [High-Level Design](../high-level-design.md)
+
+## Context and Design Philosophy
+
+The Search module provides BM25-based keyword search across all nodes in the canvas. As a local-first application, Canvas-Chat stores all conversation data in the browser, and users need an efficient way to find relevant content within their growing collection of nodes.
+
+### Why BM25?
+
+The BM25 (Best Matching 25) algorithm is chosen over simpler approaches like raw term frequency for several reasons. First, BM25 naturally handles term frequency saturation through the K1 parameter, meaning that repeating a term many times does not linearly increase relevance. Second, BM25 incorporates document length normalization via the B parameter, ensuring that longer documents are not artificially penalized or boosted simply due to their size. Third, BM25 uses Inverse Document Frequency (IDF) weighting, which gives higher scores to rare terms that are more likely to distinguish relevant documents from irrelevant ones.
+
+### Design Goals
+
+The search module prioritizes three characteristics. Responsiveness is achieved by keeping the entire search index in memory for instant query results. Simplicity means the index is rebuilt on-demand when the search overlay opens, avoiding complex incremental update logic. Finally, UX familiarity is maintained by using the Ctrl+K keyboard shortcut and a modal overlay pattern that users recognize from modern applications like VS Code and Slack.
+
+## Technical Details
+
+### BM25 Algorithm
+
+The BM25 ranking function scores documents based on query term frequency and inverse document frequency, with length normalization applied. The implementation uses the standard BM25 formula:
+
+```text
+score(Q, D) = sum over q in Q of:
+    IDF(q) * (f(q, D) * (k1 + 1)) / (f(q, D) + k1 * (1 - b + b * |D| / avgdl))
+```
+
+#### Parameters
+
+| Parameter | Value | Purpose                             |
+| --------- | ----- | ----------------------------------- |
+| K1        | 1.2   | Term frequency saturation threshold |
+| B         | 0.75  | Length normalization strength       |
+
+The K1 parameter controls how quickly term frequency contributions saturate. A value of 1.2 means that after a term appears roughly once or twice in a document, additional occurrences contribute diminishing returns. This prevents single documents with excessively repeated terms from dominating results.
+
+The B parameter controls the degree of length normalization. At 0.75, documents are moderately normalized for length. A value of 0 would ignore document length entirely, while a value of 1 would fully normalize by relative length.
+
+#### IDF Calculation
+
+The implementation uses a smoothed IDF formula that avoids zero values for rare terms:
+
+```text
+IDF(N, df) = log((N - df + 0.5) / (df + 0.5) + 1)
+```
+
+This formula ensures that terms appearing in all documents receive a score approaching zero rather than exactly zero, which provides more stable ranking behavior.
+
+### Index Structure
+
+The SearchIndex class maintains three primary data structures:
+
+```javascript
+documents: Map<nodeId, { tokens: string[], length: number, content: string, type: string, ... }>
+termFrequencies: Map<nodeId, Map<term, count>>
+documentFrequencies: Map<term, count>
+```
+
+The documents map stores tokenized content and metadata for each indexed node. The termFrequencies map tracks how many times each term appears in each document, enabling efficient score calculation. The documentFrequencies map tracks how many documents contain each term, enabling IDF calculation.
+
+### Index Building
+
+The buildFromNodes method reconstructs the entire search index from the current graph state:
+
+```javascript
+buildFromNodes(nodes) {
+    this.clear();
+    for (const node of nodes) {
+        let textToIndex = node.content || '';
+
+        // Matrix nodes: include row/col items
+        if (node.type === 'matrix') {
+            textToIndex = [node.context || '', ...(node.rowItems || []), ...(node.colItems || [])].join(' ');
+        }
+
+        // Cell nodes: include row/col labels
+        if (node.type === 'cell') {
+            textToIndex = [node.content || '', node.rowItem || '', node.colItem || ''].join(' ');
+        }
+
+        // Include title and summary
+        if (node.title) textToIndex += ' ' + node.title;
+        if (node.summary) textToIndex += ' ' + node.summary;
+
+        if (textToIndex.trim()) {
+            this.addDocument(node.id, textToIndex, { type: node.type });
+        }
+    }
+}
+```
+
+The index rebuilds from scratch each time because the codebase lacks a mechanism for detecting which nodes have changed since the last index build. Given that most sessions contain fewer than a few hundred nodes, the full rebuild completes in milliseconds, making this approach acceptable.
+
+### Query Execution
+
+The search method executes as follows:
+
+1. Tokenize the query using the same tokenize function used during indexing
+2. Iterate over all indexed documents
+3. Calculate BM25 score for each document against query tokens
+4. Filter documents with score > 0
+5. Sort by score descending
+6. Return top N results (default 10)
+
+```javascript
+search(query, limit = 10) {
+    const queryTokens = tokenize(query);
+    if (queryTokens.length === 0) return [];
+
+    const results = [];
+    for (const [nodeId, doc] of this.documents) {
+        const score = this._scoreBM25(nodeId, queryTokens);
+        if (score > 0) {
+            results.push({
+                nodeId,
+                score,
+                content: doc.content,
+                snippet: this._generateSnippet(doc.content, queryTokens),
+                type: doc.type,
+                metadata: doc,
+            });
+        }
+    }
+
+    results.sort((a, b) => b.score - a.score);
+    return results.slice(0, limit);
+}
+```
+
+### Snippet Generation
+
+Search results include snippets that show context around the first matching term. The algorithm finds the earliest occurrence of any query term, then extracts a window of characters centered on that match:
+
+```javascript
+_generateSnippet(content, queryTokens) {
+    const SNIPPET_LENGTH = 100;
+    const CONTEXT_BEFORE = 30;
+
+    // Find earliest match
+    let firstMatchIndex = content.length;
+    for (const token of queryTokens) {
+        const idx = content.toLowerCase().indexOf(token);
+        if (idx !== -1 && idx < firstMatchIndex) {
+            firstMatchIndex = idx;
+        }
+    }
+
+    // Extract window, adjust to word boundaries
+    let start = Math.max(0, firstMatchIndex - CONTEXT_BEFORE);
+    let end = Math.min(content.length, start + SNIPPET_LENGTH);
+
+    // Trim to word boundaries
+    if (start > 0) {
+        const spaceIdx = content.indexOf(' ', start);
+        if (spaceIdx !== -1 && spaceIdx < firstMatchIndex) {
+            start = spaceIdx + 1;
+        }
+    }
+
+    // Add ellipsis
+    let snippet = content.slice(start, end);
+    if (start > 0) snippet = '...' + snippet;
+    if (end < content.length) snippet = snippet + '...';
+
+    return snippet;
+}
+```
+
+### Tokenization
+
+The tokenize function converts text into lowercase words suitable for indexing and matching:
+
+```javascript
+function tokenize(text) {
+    if (!text) return [];
+    return text
+        .toLowerCase()
+        .replace(/[^\w\s]/g, ' ')
+        .split(/\s+/)
+        .filter((token) => token.length > 0);
+}
+```
+
+This approach lowercases all text for case-insensitive matching, replaces punctuation with spaces (so "don't" becomes "don t"), splits on whitespace, and filters empty tokens.
+
+### UI Integration
+
+The search UI consists of an overlay modal triggered by the Ctrl+K keyboard shortcut or by clicking the search button in the toolbar. The implementation lives in app.js with the following flow:
+
+#### Opening Search
+
+When the user triggers search, the index is rebuilt to ensure freshness:
+
+```javascript
+openSearch() {
+    this.rebuildSearchIndex();
+    const overlay = document.getElementById('search-overlay');
+    overlay.style.display = 'flex';
+    document.getElementById('search-input').value = '';
+    setTimeout(() => input.focus(), 50);
+}
+```
+
+#### Handling Input
+
+Each keystroke triggers a search:
+
+```javascript
+handleSearchInput() {
+    const query = document.getElementById('search-input').value.trim();
+    if (!query) {
+        this.renderSearchResults([]);
+        return;
+    }
+    const results = this.searchIndex.search(query, 15);
+    this.renderSearchResults(results, query);
+}
+```
+
+#### Keyboard Navigation
+
+The search overlay supports Arrow Up, Arrow Down, Enter, and Escape for navigation:
+
+- Arrow keys cycle through results with visual selection
+- Enter navigates to the selected node and closes the overlay
+- Escape closes the overlay without navigation
+
+#### Result Rendering
+
+Results are rendered with the node type icon, type name, and a snippet with highlighted matching terms:
+
+```javascript
+renderSearchResults(results, query) {
+    const queryTokens = query.toLowerCase().split(/\s+/);
+
+    const html = results.map((result, idx) => {
+        const icon = getNodeTypeIcon(result.type);
+        let snippet = escapeHtmlText(result.snippet);
+
+        // Highlight matching terms
+        for (const token of queryTokens) {
+            const regex = new RegExp(`(${escapeRegex(token)})`, 'gi');
+            snippet = snippet.replace(regex, '<mark>$1</mark>');
+        }
+
+        return `<div class="search-result${idx === 0 ? ' selected' : ''}" data-node-id="${result.nodeId}">
+            <span class="search-result-icon">${icon}</span>
+            <div class="search-result-content">
+                <div class="search-result-type">${capitalize(result.type)}</div>
+                <div class="search-result-snippet">${snippet}</div>
+            </div>
+        </div>`;
+    }).join('');
+}
+```
+
+### Keyboard Shortcut
+
+The search action is registered in the keybindings system:
+
+```javascript
+// In keybindings.js
+{ action: 'search', keys: ['Ctrl', 'k'], description: 'Search nodes' }
+```
+
+The global keydown handler routes this action to openSearch().
+
+## Open Questions and Future Decisions
+
+### Resolved
+
+1. ✅ BM25 algorithm chosen - K1=1.2, B=0.75 standard values
+2. ✅ Full index rebuild on search open - ensures freshness for now
+
+### Deferred
+
+1. Incremental index updates - currently full rebuild, optimization for large graphs
+2. Fuzzy matching for typo tolerance
+3. Phrase search support
+4. Additional ranking factors (recency, node type weights)
+
+## References
+
+- **High-Level Design**: [../high-level-design.md](../high-level-design.md)
+- **Search Module Implementation**: [../../src/canvas_chat/static/js/search.js](../../src/canvas_chat/static/js/search.js)
+- **Search UI Integration**: [../../src/canvas_chat/static/js/app.js](../../src/canvas_chat/static/js/app.js) (lines 4460-4540)
+- **Search Tests**: [../../tests/test_search.js](../../tests/test_search.js)
+- **BM25 Algorithm**: Robertson and Zaragoza (2009), "The Probabilistic Relevance Framework: BM25 and Beyond"

--- a/docs/llds/storage-persistence.md
+++ b/docs/llds/storage-persistence.md
@@ -1,0 +1,116 @@
+# Storage and Persistence
+
+**Created**: 2026-03-16
+**Status**: Design Phase
+
+## Context and Design Philosophy
+
+Canvas-Chat is local-first. All user data stays in the browser. The storage system handles two types of data with appropriate storage mechanisms.
+
+## Dual Storage Strategy
+
+### IndexedDB (Sessions)
+
+For large, structured data:
+
+- **What**: Sessions (nodes, edges, tags, timestamps)
+- **Database**: `canvas-chat`
+- **Store**: `sessions`
+- **Why IndexedDB**: Supports large objects, better performance for complex queries
+
+### localStorage (Settings)
+
+For small key-value settings:
+
+- **What**: API keys, model preferences, keybindings
+- **Why localStorage**: Simple API, synchronous access, small data
+
+## Session Data Structure
+
+```javascript
+{
+  id: "uuid",
+  name: "My Conversation",
+  nodes: [...],
+  edges: [...],
+  tags: [{name: "Important", color: "#ff0000"}],
+  created_at: 1234567890,
+  updated_at: 1234567890
+}
+```
+
+## Settings Keys
+
+| Key                         | Purpose                          |
+| --------------------------- | -------------------------------- |
+| `canvas-chat-api-keys`      | Provider API keys (JSON)         |
+| `canvas-chat-model`         | Current selected model           |
+| `canvas-chat-last-session`  | ID of last used session          |
+| `canvas-chat-keybindings`   | User keyboard shortcut overrides |
+| `canvas-chat-custom-models` | User-defined model configs       |
+
+## Session Lifecycle
+
+### Create
+
+1. Generate UUID
+2. Create empty session object
+3. Store in IndexedDB
+4. Set as last session
+
+### Load
+
+1. Read last session ID from localStorage
+2. Fetch session from IndexedDB
+3. Initialize CRDTGraph with data
+4. Enable persistence
+
+### Save
+
+1. Debounce 500ms after changes
+2. Serialize graph to session object
+3. Update IndexedDB
+4. Also update CRDT IndexedDB (for real-time sync)
+
+### Export
+
+1. Serialize session to JSON
+2. Add version metadata
+3. Download as `.canvaschat` file
+
+### Import
+
+1. Parse JSON file
+2. Validate structure
+3. Generate new UUID (avoid conflicts)
+4. Store in IndexedDB
+
+## CRDT Persistence
+
+The CRDTGraph has its own persistence layer:
+
+```text
+Database: crdt-{sessionId}
+```
+
+This is separate from session JSON storage and enables:
+
+- Real-time sync overlay
+- Future multiplayer collaboration
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. ✅ Dual storage - appropriate mechanism for data type
+2. ✅ Debounced saves - balance responsiveness vs performance
+
+### Deferred
+
+1. Session versioning/migration for schema changes?
+2. Automatic cleanup of old sessions?
+
+## References
+
+- HLD: `/docs/high-level-design.md`
+- Implementation: `src/canvas_chat/static/js/storage.js`

--- a/docs/llds/url-fetch.md
+++ b/docs/llds/url-fetch.md
@@ -1,0 +1,351 @@
+# URL Fetch Feature
+
+**Created**: 2026-03-16
+**Status**: Implementation
+**Related HLD**: [High-Level Design](../high-level-design.md)
+**Related Design Doc**: [URL Fetching Architecture](../explanation/url-fetching.md)
+
+## Context and Design Philosophy
+
+The URL Fetch feature enables users to import web content directly onto the canvas as nodes. This addresses a fundamental need in the canvas-chat workflow: gathering external reference material from the web into conversations with LLMs.
+
+### Why This Feature Exists
+
+The URL Fetch feature supports several core user workflows:
+
+- **Research capture**: Fetching articles, documentation, and blog posts for analysis
+- **Reference gathering**: Pulling external content to cite in conversations
+- **PDF reading**: Viewing PDF documents directly on the canvas with pagination
+- **Multimodal content**: Supporting various content types (HTML, PDF, YouTube, GitHub)
+
+The design philosophy follows the principle of **progressive disclosure**. New users can immediately use `/fetch` without any configuration, while power users can leverage specialized commands like `/youtube` and `/git` for enhanced experiences with those content types.
+
+### Design Decisions
+
+1. **Generic `/fetch` as foundation**: The `/fetch` command provides basic URL fetching for any URL type. This ensures a working solution exists even when specialized handlers are unavailable.
+
+2. **Backend handler registry**: URL fetch handlers are registered via `UrlFetchRegistry`, allowing plugins to add specialized handling for specific URL patterns (YouTube, GitHub, etc.) without modifying core code.
+
+3. **Markdown-only output**: All fetched content is converted to markdown before reaching the frontend. This is a deliberate security measure to prevent malicious page styles from affecting the canvas UI.
+
+4. **Unified FetchResultNode**: All fetched content uses the `fetch_result` node type, with rendering adapted based on content type metadata. This reduces code duplication while enabling type-specific UX.
+
+5. **Client-side PDF hydration**: PDF rendering happens in the browser using PDF.js, with text extraction on the backend. This reduces server load and provides a responsive paginated viewing experience.
+
+## Technical Details
+
+### Architecture Overview
+
+The URL Fetch system spans multiple modules across frontend and backend:
+
+| Module                        | Location                                      | Responsibility                                        |
+| ----------------------------- | --------------------------------------------- | ----------------------------------------------------- |
+| `url-fetch.js`                | `static/js/plugins/url-fetch.js`              | Feature plugin, slash command handling, PDF hydration |
+| `fetch-result-node.js`        | `static/js/plugins/fetch-result-node.js`      | Node protocol, content rendering                      |
+| `pdf-viewer.js`               | `static/js/plugins/pdf-viewer.js`             | PDF.js integration, rendering, text extraction        |
+| `app.py`                      | `src/canvas_chat/app.py`                      | `/api/fetch-url` endpoint, fallback fetching          |
+| `url_fetch_registry.py`       | `src/canvas_chat/url_fetch_registry.py`       | Handler registration and routing                      |
+| `url_fetch_handler_plugin.py` | `src/canvas_chat/url_fetch_handler_plugin.py` | Base class for custom handlers                        |
+
+### The `/fetch` Slash Command
+
+The `/fetch` command is handled by the `UrlFetchFeature` class in `url-fetch.js`:
+
+```javascript
+getSlashCommands() {
+    return [
+        {
+            command: '/fetch',
+            description: 'Fetch content from URL (basic fetch, no special rendering)',
+            placeholder: 'https://...',
+        },
+    ];
+}
+```
+
+When the user enters `/fetch <url>`, the following flow occurs:
+
+1. **Command parsing**: The URL is extracted from command arguments
+2. **Validation**: The URL is validated using `isUrlContent()`
+3. **Placeholder node**: A placeholder node is created with "Fetching content from..." content
+4. **Parent edges**: Edges are created from any selected parent nodes
+5. **Backend fetch**: The URL is sent to `/api/fetch-url` for processing
+6. **Node update**: The node is updated with fetched content and metadata
+
+### Backend URL Fetching Flow
+
+The `/api/fetch-url` endpoint (`app.py`) implements a multi-stage fetching strategy:
+
+```text
+Request: POST /api/fetch-url { url: "https://..." }
+           │
+           ▼
+    ┌──────────────────┐
+    │ UrlFetchRegistry │◄── Check for specialized handlers
+    │   .find_handler  │    (YouTube, GitHub, etc.)
+    └────────┬─────────┘
+             │
+      ┌──────┴──────┐
+      │ Handler     │ Yes
+      │ found?      ├─────────────┐
+      └──────┬──────┘             │
+             │ No                  ▼
+             ▼              ┌──────────────┐
+    ┌─────────────────┐     │  Handler     │
+    │ GET url        │     │  .fetch_url()│
+    │ (single request)     └──────────────┘
+    └────────┬────────┘
+             │
+      ┌──────┴──────┐
+      │ Content-Type│
+      │ detection   │
+      └──────┬──────┘
+             │
+    ┌────────┼────────┬─────────────┐
+    │        │        │             │
+    ▼        ▼        ▼             ▼
+  PDF     HTML    text/*       Other
+```
+
+#### Stage 1: Handler Lookup
+
+The backend first checks `UrlFetchRegistry.find_handler(url)` to see if a specialized handler exists. Handlers are registered with URL patterns and priority levels:
+
+```python
+PRIORITY = {
+    "BUILTIN": 100,    # YouTube, GitHub handlers
+    "OFFICIAL": 50,
+    "COMMUNITY": 10,
+}
+```
+
+If a handler matches, it's used. If it throws an exception, the flow falls back to generic fetching.
+
+#### Stage 2: Content-Type Detection
+
+For non-specialized URLs, a single GET request determines the content type:
+
+```python
+response = await client.get(request.url, follow_redirects=True)
+content_type = response.headers.get("content-type", "").lower()
+```
+
+The content type drives the remaining flow:
+
+- **`application/pdf`**: Return PDF metadata; frontend handles rendering
+- **`text/html` or `text/*`**: Convert to markdown using html2text
+- **Other**: Fall back to Jina Reader API
+
+#### Stage 3: Markdown Conversion
+
+Two strategies exist for HTML-to-markdown conversion:
+
+**Strategy A: Direct fetch + html2text** (primary fallback)
+
+```python
+def _parse_html_response(response: httpx.Response) -> tuple[str, str]:
+    html = response.text
+    title = extract_title_from_html(html)
+    h2t = html2text.HTML2Text()
+    h2t.ignore_links = False
+    h2t.body_width = 0
+    content = h2t.handle(html)
+    return title, content
+```
+
+**Strategy B: Jina Reader API** (preferred when available)
+
+```python
+async def fetch_url_via_jina(url: str, client: httpx.AsyncClient) -> tuple[str, str]:
+    jina_url = f"https://r.jina.ai/{url}"
+    response = await client.get(jina_url, headers={"Accept": "text/markdown"})
+    # Jina returns markdown directly with title as first # heading
+    title, content = parse_jina_response(response)
+    return title, content
+```
+
+The Jina path is attempted first for "other" content types, with direct fetch as fallback.
+
+### Response Format
+
+All URL fetch responses follow a consistent schema:
+
+```python
+class FetchUrlResult(BaseModel):
+    url: str
+    title: str
+    content: str  # Markdown content
+    metadata: dict = {}  # Optional: content_type, pdf_url, video_id, etc.
+```
+
+For PDFs, the content is empty initially (text extracted client-side after rendering):
+
+```python
+{
+    "url": "https://example.com/doc.pdf",
+    "title": "document",
+    "content": "",  # Empty; extracted after PDF renders
+    "metadata": {
+        "content_type": "pdf",
+        "pdf_url": "https://example.com/doc.pdf",
+        "source": "url"
+    }
+}
+```
+
+### FetchResultNode Rendering
+
+The `FetchResultNode` protocol class handles rendering based on content type:
+
+```javascript
+renderContent(canvas) {
+    const metadata = this.node.metadata || {};
+    const contentType = metadata.content_type;
+
+    // YouTube: embedded video
+    if (contentType === 'youtube' && videoId) {
+        return `<iframe src="https://www.youtube.com/embed/${videoId}" ...>`;
+    }
+
+    // PDF: viewer container (lazy-loaded)
+    if (contentType === 'pdf' && pdfUrl) {
+        return `<div class="pdf-viewer-container" data-pdf-url="${pdfUrl}">...</div>`;
+    }
+
+    // Default: markdown content
+    return canvas.renderMarkdown(this.node.content || '');
+}
+```
+
+### PDF Viewer Hydration
+
+PDF viewing uses a lazy hydration pattern. When canvas renders a node with `.pdf-viewer-container[data-pdf-hydrated="false"]`, it calls the registered hydrator:
+
+```javascript
+// In url-fetch.js
+this.canvas.setPdfViewerHydrator(this.hydratePdfViewer.bind(this));
+
+// Hydration flow:
+// 1. Load PDF via PDF.js (lazy from CDN)
+// 2. Render first page to canvas
+// 3. Extract text from all pages
+// 4. Store text in node content
+// 5. Update UI with page info
+// 6. Set hydrated flag
+```
+
+PDF navigation is handled via canvas event handlers:
+
+- **Action bar buttons**: `pdf-prev-page`, `pdf-next-page`
+- **Keyboard shortcuts**: ArrowLeft, ArrowRight
+- **Scroll sync**: Page headings in extracted text enable scroll-to-page
+
+### Data Flow Diagram
+
+```text
+Frontend                              Backend
+    │                                     │
+    │  POST /api/fetch-url {url}         │
+    ├────────────────────────────────────►│
+    │                                     │
+    │  1. Find handler (URL pattern)     │
+    │  2. GET url → Content-Type         │
+    │  3. Convert to markdown            │
+    │                                     │
+    │  {title, content, metadata}        │
+    ◄─────────────────────────────────────┤
+    │                                     │
+    │  Create FETCH_RESULT node          │
+    │  ┌─────────────────────────────┐    │
+    │  │ title: "Article Title"      │    │
+    │  │ content: "**Title**\n\n..." │    │
+    │  │ metadata: {content_type}    │    │
+    │  └─────────────────────────────┘    │
+    │                                     │
+    │  Render via FetchResultNode         │
+    │  - PDF → viewer container          │
+    │  - YouTube → iframe embed           │
+    │  - Other → markdown HTML           │
+```
+
+## Markdown Extraction
+
+### Why Markdown, Not HTML
+
+The URL fetch system deliberately converts all content to markdown before sending to the frontend. This is a security measure:
+
+- **Style isolation**: Node content renders in the main document (not an iframe). Raw HTML with `<style>` tags could modify app styles, hide toolbars, or break layout.
+- **Consistency**: Markdown renders uniformly regardless of source page structure.
+- **LLM context**: Markdown is better structured for LLM analysis than raw HTML.
+
+### Conversion Strategies
+
+| Source      | Strategy               | Notes                                          |
+| ----------- | ---------------------- | ---------------------------------------------- |
+| Jina Reader | Native markdown        | `Accept: text/markdown` returns clean markdown |
+| Direct HTML | html2text              | Python library, configurable options           |
+| PDF         | PDF.js text extraction | Per-page extraction with "## Page N" markers   |
+| YouTube     | youtube-transcript-api | Server-side, language fallback                 |
+
+### Title Extraction
+
+Titles are extracted from different sources depending on the strategy:
+
+- **Jina**: First markdown heading (`# Title`)
+- **Direct fetch**: `<title>` tag via regex
+- **PDF**: Derived from URL filename (`/doc.pdf` → "doc")
+- **YouTube**: Video metadata from API
+
+## Open Questions & Future Decisions
+
+### Resolved
+
+1. ✅ Multi-stage fetch strategy - try handlers first, then generic
+2. ✅ Markdown-only output - security consideration
+
+### Deferred
+
+1. PDF text extraction reliability - scanned PDFs need OCR?
+2. Large PDF handling - pagination, compression, limits
+3. Jina API reliability - caching, user-configurable method
+4. Handler error handling - propagate or fallback silently?
+
+### Future Enhancements
+
+1. Summarize action on FetchResultNode - client-side option
+2. Image extraction - fetch and display
+3. Link scraping - extract links as reference nodes
+4. Caching layer - avoid redundant fetches
+5. Custom handler UI - beyond base protocol
+
+- **Caching layer**: Cache fetched content to avoid redundant requests.
+- **Custom handler UI**: Allow handlers to provide custom node rendering beyond the base protocol.
+
+## References
+
+### Related Documentation
+
+- [High-Level Design](../high-level-design.md) - Overall application architecture
+- [URL Fetching Architecture](../explanation/url-fetching.md) - Design rationale and trade-offs
+- [YouTubeNode LLD](youtube-node.md) - Specialized YouTube handling (uses same infrastructure)
+- [GitRepoNode LLD](git-repo-node.md) - Specialized GitHub handling (uses same infrastructure)
+- [PDF Node LLD](pdf-node.md) - PDF handling details
+- [Feature Plugin API](../reference/feature-plugin-api.md) - Plugin base class
+- [Plugin Architecture](../explanation/plugin-architecture.md) - Three-level plugin system
+
+### API Endpoints
+
+| Endpoint                     | Method | Purpose                              |
+| ---------------------------- | ------ | ------------------------------------ |
+| `/api/fetch-url`             | POST   | Fetch URL content (main entry point) |
+| `/api/url-fetch/list-files`  | POST   | GitHub: list repository files        |
+| `/api/url-fetch/fetch-files` | POST   | GitHub: fetch file contents          |
+
+### Key Files
+
+- Frontend: `src/canvas_chat/static/js/plugins/url-fetch.js`
+- Frontend: `src/canvas_chat/static/js/plugins/fetch-result-node.js`
+- Frontend: `src/canvas_chat/static/js/plugins/pdf-viewer.js`
+- Backend: `src/canvas_chat/app.py` (lines ~2169-2337)
+- Backend: `src/canvas_chat/url_fetch_registry.py`
+- Backend: `src/canvas_chat/url_fetch_handler_plugin.py`

--- a/docs/llds/youtube-node.md
+++ b/docs/llds/youtube-node.md
@@ -1,0 +1,330 @@
+# YouTubeNode: YouTube Video Transcript Node
+
+**Created**: 2026-03-16
+**Status**: Implementation
+**Related HLD**: [High-Level Design](../high-level-design.md)
+
+## Context and Design Philosophy
+
+The YouTubeNode provides a visual interface for embedding YouTube videos with their transcripts directly on the canvas. It addresses a core need for multimodal content integration, enabling users to discuss video content with LLMs.
+
+### Why This Node Type Exists
+
+YouTube video support was added to support several user workflows:
+
+- **Video research**: Importing talks, tutorials, and presentations for discussion with LLMs
+- **Content analysis**: Analyzing video transcripts for key points, quotes, and themes
+- **Multimodal learning**: Combining video viewing with AI-assisted note-taking and questioning
+- **Citation workflows**: Using video content as references in conversations
+
+The design philosophy emphasizes **seamless integration** between video playback and transcript access. Users should be able to watch the video while simultaneously interacting with its transcript for search, highlighting, and branching conversations.
+
+### Design Decisions
+
+1. **Unified with FetchResultNode**: YouTube nodes share the same underlying node type (`fetch_result`) as URL-fetched content. This ensures consistent behavior and reduces code duplication.
+
+2. **Transcript-first approach**: The transcript is stored as node content (for LLM context and searchability), while the video embed is rendered in the main content area. This separates the "what" (transcript) from the "how" (video playback).
+
+3. **Output panel for transcript**: The transcript appears in a collapsible output panel below the video embed. This keeps the main content area clean while providing easy access to searchable, selectable text.
+
+4. **Backend transcript fetching**: Transcript extraction happens server-side using `youtube-transcript-api`. This handles authentication, rate limiting, and transcript availability checks that would be difficult or unreliable client-side.
+
+5. **Video ID stored in metadata**: The YouTube video ID is stored in the node's metadata, not embedded in the content. This allows the video embed to be rendered independently of the transcript text.
+
+## Technical Details
+
+### Architecture Overview
+
+The YouTube video system spans three main modules:
+
+| Module               | Location                     | Responsibility                         |
+| -------------------- | ---------------------------- | -------------------------------------- |
+| `youtube.js`         | `plugins/youtube.js`         | Feature plugin, slash command handling |
+| `youtube-node.js`    | `plugins/youtube-node.js`    | Node protocol, video embed rendering   |
+| `youtube_handler.py` | `plugins/youtube_handler.py` | Backend transcript fetching            |
+
+### The `/youtube` Slash Command
+
+The `/youtube` slash command is handled by the `YouTubeFeature` class in `youtube.js`:
+
+```javascript
+getSlashCommands() {
+    return [
+        {
+            command: '/youtube',
+            description: 'Fetch YouTube video with transcript',
+            placeholder: 'https://youtube.com/watch?v=...',
+        },
+    ];
+}
+```
+
+When the user enters `/youtube <url>`, the following flow occurs:
+
+1. **Command parsing**: The URL is extracted from the command arguments
+2. **Validation**: The URL is validated as a proper URL format
+3. **Placeholder node**: A placeholder node is created with "Fetching YouTube video..." content
+4. **Parent edges**: Edges are created from any selected parent nodes
+5. **Backend fetch**: The URL is sent to `/api/fetch-url` for processing
+6. **Node update**: The node is updated with the transcript content and video metadata
+
+### YouTube Transcript Fetching
+
+The backend `YouTubeHandler` class (`youtube_handler.py`) handles transcript extraction:
+
+```python
+class YouTubeHandler(UrlFetchHandlerPlugin):
+    async def fetch_url(self, url: str) -> dict[str, Any]:
+        video_id = self._extract_video_id(url)
+        api = YouTubeTranscriptApi()
+        transcript_list = api.list(video_id)
+        transcript = transcript_list.find_transcript(["en"])
+        fetched_transcript = transcript.fetch()
+```
+
+**Supported URL patterns:**
+
+```python
+url_patterns=[
+    r"^https?://(www\.)?youtube\.com/watch\?v=[\w-]+",
+    r"^https?://(www\.)?youtube\.com/embed/[\w-]+",
+    r"^https?://youtu\.be/[\w-]+",
+    r"^https?://(www\.)?youtube\.com/watch\?.*v=[\w-]+",
+]
+```
+
+**Transcript extraction strategy:**
+
+1. **Primary**: Try to fetch English transcript (`find_transcript(["en"])`)
+2. **Fallback**: If English unavailable, try any available language
+3. **Manual preference**: Prefer manually-created transcripts over auto-generated ones
+4. **Error handling**: Raise descriptive errors if transcripts are disabled or unavailable
+
+The handler returns:
+
+```python
+{
+    "title": "YouTube Video: {video_id}",
+    "content": "# YouTube Video Transcript\n\n**Video ID:** `{video_id}`\n\n**URL:** {url}\n\n**Language:** {lang}\n\n---\n\n**[{timestamp}]** {transcript_text}\n...",
+    "metadata": {
+        "content_type": "youtube",
+        "video_id": video_id,
+        "language": language_code,
+        "is_generated": is_generated,
+    },
+}
+```
+
+### Video Player Embed
+
+The `YouTubeNode` protocol class (`youtube-node.js`) renders the video embed:
+
+```javascript
+renderContent() {
+    const videoId = this.node.metadata?.video_id || this.node.youtubeVideoId;
+    const embedUrl = `https://www.youtube.com/embed/${videoId}`;
+    return `
+        <div class="youtube-embed-container youtube-embed-main">
+            <iframe
+                src="${embedUrl}"
+                frameborder="0"
+                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                allowfullscreen
+                class="youtube-embed-iframe"
+            ></iframe>
+        </div>
+    `;
+}
+```
+
+**Embed URL format:** `https://www.youtube.com/embed/{video_id}`
+
+**Iframe permissions:**
+
+- `accelerometer`: Device orientation (rarely needed)
+- `autoplay`: Allow auto-play (user may need to unmute)
+- `clipboard-write`: Clipboard access
+- `encrypted-media`: DRM content
+- `gyroscope`: Device orientation
+- `picture-in-picture`: PiP mode
+- `allowfullscreen`: Fullscreen mode
+
+### Transcript Panel Rendering
+
+The transcript is rendered in the output panel:
+
+```javascript
+hasOutput() {
+    return true; // Always show transcript in drawer
+}
+
+renderOutputPanel() {
+    return `
+        <div class="youtube-transcript-content">
+            ${this.renderMarkdown(this.node.content)}
+        </div>
+    `;
+}
+```
+
+The transcript is stored in `node.content` and formatted as markdown with timestamps:
+
+```text
+**[{timestamp}]** {text}
+**[{timestamp}]** {text}
+...
+```
+
+### CSS Styling
+
+YouTube-specific styles in `nodes.css`:
+
+```css
+.youtube-embed-container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #000;
+}
+
+.youtube-embed-main {
+    min-height: 400px;
+    max-height: 100%;
+}
+
+.youtube-embed-iframe {
+    width: 100%;
+    height: 100%;
+    max-width: 100%;
+    max-height: 100%;
+    aspect-ratio: 16 / 9;
+}
+```
+
+### Data Flow Diagram
+
+```text
+User enters: /youtube https://youtube.com/watch?v=xxx
+        |
+        v
+YouTubeFeature.handleCommand()
+        |
+        |-- Creates placeholder node
+        |-- POST /api/fetch-url {url}
+        |
+        v
+app.py /api/fetch-url
+        |
+        |-- Finds YouTubeHandler via UrlFetchRegistry
+        |
+        v
+YouTubeHandler.fetch_url()
+        |
+        |-- Extracts video_id from URL
+        |-- Calls YouTubeTranscriptApi
+        |-- Formats transcript as markdown
+        |
+        v
+Returns: {title, content, metadata}
+        |
+        v
+YouTubeFeature updates node:
+        - content = transcript
+        - metadata = {content_type, video_id, language, is_generated}
+        - outputExpanded = true (open drawer)
+        |
+        v
+YouTubeNode renders:
+        - renderContent() = YouTube iframe
+        - renderOutputPanel() = transcript markdown
+```
+
+### Node Properties
+
+| Property                | Source             | Purpose                           |
+| ----------------------- | ------------------ | --------------------------------- |
+| `type`                  | `NodeType.YOUTUBE` | Node type identifier              |
+| `content`               | Backend response   | Transcript text (markdown)        |
+| `metadata.video_id`     | Backend response   | YouTube video ID for embed        |
+| `metadata.content_type` | Backend response   | Always "youtube"                  |
+| `metadata.language`     | Backend response   | Transcript language code          |
+| `metadata.is_generated` | Backend response   | Whether auto-generated            |
+| `outputExpanded`        | Feature plugin     | Show transcript drawer by default |
+
+## Open Questions and Future Decisions
+
+### Resolved
+
+1. ✅ youtube-transcript-api for fetching
+2. ✅ Prefer English, fallback to any available
+
+### Deferred
+
+1. Video title fetching - use oEmbed endpoint (no API key)
+2. Transcript language selection - user-specified preference
+3. Video chapter navigation - parse timestamps from transcript
+4. Playback synchronization - click timestamp to seek
+5. Caption download capability
+6. Handle videos without transcripts
+
+**Trade-off**: Requires parsing chapter markers from video description or transcript. Additional complexity for marginal benefit.
+
+### Playback Synchronization
+
+Currently, the video and transcript are independent. Clicking a transcript timestamp could seek the video to that position.
+
+**Trade-off**: Requires iframe API integration (YouTube IFrame API). Significant complexity for a niche use case.
+
+### Caption Download
+
+Users might want to download the transcript as a file (SRT, VTT, or plain text) for offline use.
+
+**Trade-off**: Requires export functionality. Lower priority than core viewing.
+
+### Handling Videos Without Transcripts
+
+Some videos have captions disabled or no captions available. The current error message is descriptive but doesn't offer alternatives.
+
+**Future**: Could suggest using YouTube's auto-translate feature or provide a manual transcription workflow.
+
+## References to HLD
+
+This design implements several principles from the [High-Level Design](../high-level-design.md):
+
+### Node Types (Section 6)
+
+YouTube nodes fall under the "Documents" category in the HLD's node type taxonomy:
+
+| Category  | Node Types                            |
+| --------- | ------------------------------------- |
+| Documents | PDFs, PowerPoint, YouTube transcripts |
+
+### Plugin-Extensible (Section 4.3)
+
+The YouTube node follows the three-level plugin architecture:
+
+1. **Level 1**: Custom node type (`YouTubeNode` protocol class)
+2. **Level 2**: Feature plugin (`YouTubeFeature` with `/youtube` slash command)
+3. **Level 3**: URL fetch handler backend (`YouTubeHandler`)
+
+### Local-First (Section 4.1)
+
+Video and transcript data are stored in the browser's IndexedDB (for the graph). No server-side storage of video content.
+
+### Streaming-First (Section 4.5)
+
+While not streaming in the LLM sense, the progressive loading (placeholder -> loading -> video + transcript) follows the same philosophy of showing feedback immediately.
+
+### Vanilla JavaScript (Section 8.1)
+
+The YouTube node implementation uses plain JavaScript with no framework dependencies. Backend handling uses the existing `youtube-transcript-api` library.
+
+### URL Fetching Design (from docs)
+
+The YouTube handler follows the URL fetching design documented in [url-fetching.md](../explanation/url-fetching.md):
+
+- Uses URL pattern matching to route YouTube URLs to a specialized handler
+- Falls back to generic fetching if the handler fails
+- Returns structured metadata for the frontend to render appropriately

--- a/docs/planning/svelte-flow-migration.2026-03-17.md
+++ b/docs/planning/svelte-flow-migration.2026-03-17.md
@@ -1,0 +1,819 @@
+# Svelte Flow Migration Implementation Plan
+
+**Created**: 2026-03-17
+**Issue**: #247
+**Status**: Planning
+**HLD**: `/docs/high-level-design.md`
+**LLDs**: `/docs/llds/` (26 LLDs covering all current components + build/deployment)
+**EARS Specs**: `/docs/specs/` (137 requirements across 4 spec files)
+
+**Current State**: The application uses vanilla JavaScript with:
+
+- `index.html` containing all UI (toolbar, chat input, 9+ modal templates, canvas container, search overlay)
+- `app.js` (~4,700 lines) orchestrating all DOM manipulation
+- Custom SVG canvas (`canvas.js`) for rendering nodes and edges
+- Vanilla JS ES modules for plugins
+
+**Goal**: Migrate to Svelte + Svelte Flow to fix Safari compatibility, add MiniMap, improve touch support, and reduce maintenance burden. The backend (FastAPI) and data model (CRDTGraph) remain unchanged. All 138 EARS requirements must continue to be satisfied after migration.
+
+**Critical constraints**: The app must deploy to Modal and distribute via `pip install canvas-chat`. Users must NOT need Node.js. The Vite build runs in CI/maintainer machines only; built assets are included in the wheel and Modal image.
+
+## Success Criteria
+
+1. Safari renders and interacts with all node types (0% → 80%+ functionality)
+2. MiniMap component available for canvas navigation
+3. All 138 EARS requirements verified passing on new implementation
+4. All existing Cypress E2E tests pass with updated selectors
+5. `canvas.js` removed from codebase
+6. No regression in plugin system functionality
+7. Modal deployment serves the complete Svelte Flow app
+8. `pip install canvas-chat && canvas-chat launch` works without Node.js
+
+## Current Architecture
+
+The application runs on vanilla JavaScript with these components:
+
+- **`index.html`** (~720 lines): All UI HTML — toolbar, chat input, 9+ modal templates, canvas container, search overlay, node templates
+- **`app.js`** (~4,700 lines): Main orchestrator with 99+ `getElementById` calls, handles chat, canvas, modals, plugins
+- **`canvas.js`** (~2,500 lines): Custom SVG canvas with pan/zoom, node/edge rendering
+- **`modal-manager.js`** (~1,300 lines): Manages modal state and HTML template swapping
+- **`js/` directory**: ES modules (chat.js, storage.js, crdt-graph.js, streaming-manager.js, feature plugins)
+
+## Migration Strategy: Full Page Takeover, Phased Execution
+
+**Core principles**:
+
+- The backend and CRDT data model are frozen
+- After migration: Svelte owns the entire page — `index.html` becomes a minimal `<div id="app">` shell
+- Existing vanilla JS modules are already ESM — Svelte imports them directly (no global scope bridge)
+- Window globals preserved during transition, removed progressively
+- The `app.js` App class (~4,700 lines, 99 `getElementById` calls) is decomposed as sections move to Svelte
+
+**Why full takeover, not canvas-only mount**: The App class is the bottleneck, not `canvas.js`. Canvas-only mount leaves the App class intact — you swap one canvas for another without fixing the architecture. Full takeover lets you decompose the App class naturally as you migrate each section.
+
+**Progressive page takeover order**:
+
+```text
+Phases 1-2:  Svelte app shell renders (empty page, no visible UI)
+Phase 3:     Canvas rendering → Svelte Flow replaces SVG canvas
+Phases 4-5:  Node components → all 25+ node types as Svelte
+Phase 6:     Feature plugin nodes → committee, research, factcheck, etc.
+Phase 7a:    Chat input + toolbar → Svelte components, App class chat methods decomposed
+Phase 7b:    Modals (9 total) → Svelte components replace HTML templates + modal-manager.js
+Phase 7c:    Search overlay + keybindings → Svelte components
+Phase 8:     Remove old App class, canvas.js, modal-manager.js
+```
+
+**Layer cake** (bottom to top, each layer built before the one above):
+
+```text
+Layer 0: Build infrastructure (Vite + npm + CI pipeline)
+Layer 1: Svelte + Vite scaffold
+Layer 2: Graph store (CRDT bridge)
+Layer 3: Canvas rendering (Svelte Flow)
+Layer 4: Node components (25+ types)
+Layer 5: Plugin adapter + integration
+Layer 6: UI chrome (modals, search, settings)
+Layer 7: Testing
+Layer 8: Deploy (Modal + pip)
+```
+
+---
+
+## Phase 0: Build Infrastructure
+
+**Goal**: Vite build pipeline works, CI can build Svelte, and built assets integrate with FastAPI StaticFiles.
+
+### Phase 0 Deliverables
+
+1. **npm project setup**
+    - `package.json` with `svelte`, `@xyflow/svelte`, `vite`, and dev dependencies
+    - `vite.config.js` with root, build output, and dev server proxy
+    - Build output: `src/canvas_chat/static/svelte-dist/` with `base: './'`
+    - **Specs**: BLD-REQ-001, BLD-REQ-003
+
+2. **FastAPI integration with built assets**
+    - `index.html` references `/static/svelte-dist/assets/index-[hash].js`
+    - Existing `StaticFiles` mount at `/static` serves built assets (no code change needed)
+    - **Specs**: BLD-REQ-002
+
+3. **CI build pipeline**
+    - GitHub Actions runs `npm install && npm run build` before Modal deploy
+    - `.github/workflows/modal-deploy.yaml` updated with Node.js setup step
+    - Trigger paths include `src/canvas_chat/static/svelte/` for Svelte source changes
+    - **Specs**: DEP-REQ-001
+
+4. **pip packaging verification**
+    - `pyproject.toml` hatchling config includes `svelte-dist/` in wheel
+    - `pip install -e .` works and serves the built app at `localhost:7865`
+    - **Specs**: DEP-REQ-002, DEP-REQ-003
+
+### Phase 0 Testing Requirements
+
+- **Manual**: `npm run build` produces output in `svelte-dist/`
+- **Manual**: FastAPI serves the built assets at `/static/svelte-dist/`
+- **Manual**: `canvas-chat launch` works after `pip install -e .`
+- **CI**: GitHub Actions build step succeeds
+
+### Phase 0 Definition of Done
+
+- [ ] `npm run build` compiles Svelte to `svelte-dist/`
+- [ ] FastAPI serves built assets at correct URL
+- [ ] GitHub Actions CI runs build before Modal deploy
+- [ ] `canvas-chat launch` serves complete app
+- [ ] `@spec` annotations on build-related code
+
+---
+
+## Phase 1: Svelte Foundation
+
+**Goal**: Blank Svelte Flow canvas renders in the browser alongside existing vanilla JS app.
+
+### Phase 1 Deliverables
+
+1. **Svelte + Vite scaffold**
+    - Install `svelte`, `@xyflow/svelte`, `vite`
+    - Create `src/canvas_chat/static/svelte/` directory
+    - Vite dev server serves Svelte app
+    - Build outputs to `static/svelte/dist/` for production
+    - **Specs**: None (infrastructure)
+
+2. **Svelte app entry point**
+    - `svelte/App.svelte` — root component
+    - Mount point in `index.html` (alongside existing vanilla JS mount)
+    - **Specs**: None (infrastructure)
+
+3. **Blank Svelte Flow canvas**
+    - `svelte/CanvasFlow.svelte` — wraps `@xyflow/svelte` `SvelteFlow`
+    - Renders with no nodes, no edges
+    - Pan and zoom work
+    - **Specs**: CANV-REQ-002, CANV-REQ-003
+
+### Phase 1 Testing Requirements
+
+- **Manual**: Verify blank Svelte Flow canvas renders at `http://localhost:5173`
+- **Manual**: Pan with mouse drag, zoom with scroll wheel
+
+### Phase 1 Definition of Done
+
+- [ ] Svelte app renders blank canvas
+- [ ] Vite dev server starts without errors
+- [ ] Pan and zoom work on blank canvas
+- [ ] Existing vanilla JS app still works (no breakage)
+
+---
+
+## Phase 2: Graph Store — Direct ESM Imports
+
+**Goal**: Svelte app imports `CRDTGraph`, `storage`, and related modules directly. No adapter — just `import { CRDTGraph } from '../js/crdt-graph.js'`.
+
+### Phase 2 Deliverables
+
+1. **Graph store module**
+    - `svelte/stores/graphStore.js`
+    - Imports `CRDTGraph` directly from `../js/crdt-graph.js` (ESM)
+    - Converts CRDT nodes/edges into Svelte Flow `nodes` and `edges` arrays
+    - Subscribes to Yjs `observe()` events, updates Svelte state reactively
+    - Exposes `addNode()`, `removeNode()`, `addEdge()`, `updateNodePosition()` etc.
+    - **Specs**: GRPH-REQ-001, GRPH-REQ-002, GRPH-REQ-003, GRPH-REQ-004, GRPH-REQ-005, BLD-REQ-004
+
+2. **Session persistence bridge**
+    - Imports `storage` directly from `../js/storage.js` (ESM)
+    - Reuses existing IndexedDB logic (no rewrite)
+    - On Svelte app mount, load last session from IndexedDB
+    - Auto-save with 500ms debounce
+    - **Specs**: STOR-REQ-001, STOR-REQ-003, STOR-REQ-004
+
+3. **Window globals preserved (transition)**
+    - Existing `window.X = X` assignments in source modules remain untouched
+    - Plugins continue to work via globals during migration
+    - **Specs**: BLD-REQ-004
+
+### Phase 2 Testing Requirements
+
+- **Unit**: Graph store correctly converts Yjs Map to Svelte Flow nodes array
+- **Unit**: Yjs observe events trigger Svelte state updates
+- **Unit**: `resolveContext()` traversal works through store
+- **Manual**: Load existing session (nodes appear on canvas)
+
+### Phase 2 Definition of Done
+
+- [ ] Graph store converts CRDT → Svelte Flow format
+- [ ] Yjs changes propagate to Svelte reactively
+- [ ] Session loads from IndexedDB on mount
+- [ ] `@spec` annotations link to GRPH-REQ and STOR-REQ IDs
+
+---
+
+## Phase 3: Core Canvas — Rendering + Interaction
+
+**Goal**: All canvas rendering and interaction specs pass on Svelte Flow.
+
+### Phase 3 Deliverables
+
+1. **Node rendering**
+    - Svelte Flow renders all nodes from graph store
+    - Default node component with header, content, actions
+    - Type-specific icons and labels
+    - **Specs**: CANV-REQ-001, NODE-REQ-001, NODE-REQ-002
+
+2. **Edge rendering**
+    - Bezier curve edges for reply, branch, reference, generates types
+    - Edge types registered with Svelte Flow
+    - **Specs**: CANV-REQ-005, EDGE-REQ-001, EDGE-REQ-002, EDGE-REQ-003, EDGE-REQ-004
+
+3. **Node interaction**
+    - Click to select (visual highlight)
+    - Drag to reposition (updates CRDT)
+    - At zoom > 0.6: drag via handle only
+    - At zoom <= 0.6: drag from anywhere
+    - **Specs**: CANV-REQ-006, CANV-REQ-007
+
+4. **Semantic zoom**
+    - CSS class changes based on zoom level (zoom-full, zoom-summary, zoom-mini)
+    - Classes applied to node wrapper elements
+    - **Specs**: CANV-REQ-004
+
+5. **Viewport focus**
+    - `addUserNode()` triggers `zoomToSelectionAnimated()` with scale 0.8
+    - No auto-pan on programmatic node addition
+    - **Specs**: CANV-REQ-008
+
+6. **MiniMap component**
+    - `@xyflow/svelte` `MiniMap` added to canvas
+    - Configurable node colors by type
+    - **Specs**: None new (enhancement from #247)
+
+### Phase 3 Testing Requirements
+
+- **Unit**: Node rendering with correct type icon/label
+- **Unit**: Edge Bezier curves connect correct ports
+- **Unit**: Semantic zoom classes applied at correct thresholds
+- **E2E**: Click selects node, drag repositions node
+- **E2E**: Pan canvas, zoom with scroll wheel
+- **Manual**: MiniMap shows node positions and allows click navigation
+
+### Phase 3 Definition of Done
+
+- [ ] All CANV-REQ specs pass on Svelte Flow
+- [ ] Pan, zoom, select, drag all work
+- [ ] Semantic zoom classes applied correctly
+- [ ] MiniMap renders and is interactive
+- [ ] All `@spec` annotations present
+
+---
+
+## Phase 4: Simple Node Types
+
+**Goal**: All non-complex node types render correctly as Svelte components.
+
+### Phase 4 Deliverables
+
+1. **Message nodes**
+    - `svelte/components/nodes/HumanNode.svelte`
+    - `svelte/components/nodes/AiNode.svelte`
+    - Streaming content update (token-by-token via store)
+    - Model name display, stop/continue buttons in header
+    - **Specs**: NODE-REQ-001, NODE-REQ-002, CHAT-REQ-004, CHAT-REQ-005
+
+2. **Content nodes**
+    - `svelte/components/nodes/NoteNode.svelte` — editable markdown
+    - `svelte/components/nodes/ReferenceNode.svelte` — URL link
+    - `svelte/components/nodes/SearchNode.svelte` — search results list
+    - `svelte/components/nodes/ImageNode.svelte` — image display
+    - `svelte/components/nodes/SummaryNode.svelte` — summary text
+    - **Specs**: NODE-REQ-003, NODE-REQ-004, NODE-REQ-005, NODE-REQ-009
+
+3. **Highlight/Branch nodes**
+    - `svelte/components/nodes/HighlightNode.svelte` — excerpt from source
+    - **Specs**: NODE-REQ-003 (partial, branch behavior)
+
+4. **Node protocol bridge**
+    - Map existing `node-protocols.js` `wrapNode()` to Svelte component selection
+    - Svelte Flow `nodeTypes` registry maps node type → Svelte component
+    - **Specs**: PROT-REQ-001 through PROT-REQ-006
+
+### Phase 4 Testing Requirements
+
+- **Unit**: Each node component renders correct content
+- **Unit**: Node type registry maps to correct Svelte component
+- **E2E**: Human message creates HumanNode on canvas
+- **E2E**: AI response creates AiNode with streaming
+
+### Phase 4 Definition of Done
+
+- [ ] All simple node types render on canvas
+- [ ] Node type registry maps correctly
+- [ ] Streaming content updates work for AI nodes
+- [ ] Node protocols (getSummaryText, getActions, etc.) bridged
+- [ ] `@spec` annotations on all node components
+
+---
+
+## Phase 5: Complex Node Types
+
+**Goal**: Nodes with interactive internals (drawers, viewers, tables) render correctly.
+
+### Phase 5 Deliverables
+
+1. **CodeNode with output panel**
+    - `svelte/components/nodes/CodeNode.svelte`
+    - Code editor (Monaco/CodeMirror) + output panel
+    - Run button triggers Pyodide execution
+    - Self-healing loop (up to 3 attempts)
+    - Code generation via LLM
+    - **Specs**: NODE-REQ-007, CODE-REQ-001, CODE-REQ-002, CODE-REQ-003, CODE-REQ-004, CODE-REQ-005
+
+2. **MatrixNode with interactive cells**
+    - `svelte/components/nodes/MatrixNode.svelte`
+    - Table with editable cells
+    - Click cell to fill via LLM
+    - Fill All with parallel streaming
+    - Row/column extraction
+    - **Specs**: NODE-REQ-006, MAT-REQ-001, MAT-REQ-002, MAT-REQ-003, MAT-REQ-004
+
+3. **PDFNode with pagination**
+    - `svelte/components/nodes/PdfNode.svelte`
+    - PDF.js rendering in Svelte context
+    - Prev/Next page navigation
+    - **Specs**: NODE-REQ-008, UP-REQ-001
+
+4. **PowerPointNode with slide navigation**
+    - `svelte/components/nodes/PowerPointNode.svelte`
+    - Slide images with drawer
+    - Per-slide captioning
+    - **Specs**: NODE-REQ-014
+
+5. **HtmlSlidesNode with embed**
+    - `svelte/components/nodes/HtmlSlidesNode.svelte`
+    - Blob URL iframe embed
+    - Prev/Next navigation
+    - **Specs**: NODE-REQ-017, SLID-REQ-001, SLID-REQ-002, SLID-REQ-003
+
+6. **Data import nodes**
+    - `svelte/components/nodes/CsvNode.svelte`
+    - `svelte/components/nodes/ExcelNode.svelte`
+    - `svelte/components/nodes/PrismNode.svelte`
+    - Each provides csvData for /code integration
+    - **Specs**: NODE-REQ-016, UP-REQ-003
+
+### Phase 5 Testing Requirements
+
+- **Unit**: CodeNode renders editor + output panel
+- **Unit**: MatrixNode renders table with correct dimensions
+- **Unit**: PDFNode renders PDF.js viewer
+- **E2E**: Code execution produces output
+- **E2E**: Matrix cell fill works
+- **E2E**: PDF page navigation works
+
+### Phase 5 Definition of Done
+
+- [ ] All complex node types render and interact correctly
+- [ ] Code execution works via Pyodide
+- [ ] Self-healing code works (3 retries)
+- [ ] Matrix fill cell + fill all work
+- [ ] PDF pagination works
+- [ ] `@spec` annotations on all complex node components
+
+---
+
+## Phase 6: Multi-LLM and Feature Plugin Nodes
+
+**Goal**: Committee, research, factcheck, flashcard, and image generation nodes work.
+
+### Phase 6 Deliverables
+
+1. **Committee nodes**
+    - `svelte/components/nodes/OpinionNode.svelte`
+    - `svelte/components/nodes/ReviewNode.svelte`
+    - `svelte/components/nodes/SynthesisNode.svelte`
+    - Parallel streaming per opinion node
+    - **Specs**: NODE-REQ-012, COMM-REQ-001 through COMM-REQ-005
+
+2. **Research node**
+    - `svelte/components/nodes/ResearchNode.svelte`
+    - Synthesized findings + sources display
+    - **Specs**: NODE-REQ-018, RSCH-REQ-001 through RSCH-REQ-004
+
+3. **Factcheck node**
+    - `svelte/components/nodes/FactcheckNode.svelte`
+    - Claims, verdicts, source links
+    - Read-only (not editable)
+    - **Specs**: NODE-REQ-013, FACT-REQ-001 through FACT-REQ-004
+
+4. **Flashcard node**
+    - `svelte/components/nodes/FlashcardNode.svelte`
+    - Question/answer with flip interaction
+    - **Specs**: NODE-REQ-011, FLAS-REQ-001, FLAS-REQ-004
+
+5. **Image generation node**
+    - `svelte/components/nodes/ImageNode.svelte` (reuse, add generation support)
+    - Generated image display with prompt reference
+    - **Specs**: IMG-REQ-001 through IMG-REQ-003
+
+6. **YouTube and GitRepo nodes**
+    - `svelte/components/nodes/YouTubeNode.svelte`
+    - `svelte/components/nodes/GitRepoNode.svelte`
+    - **Specs**: NODE-REQ-010, NODE-REQ-015
+
+### Phase 6 Testing Requirements
+
+- **E2E**: `/committee` creates opinion + synthesis nodes with streaming
+- **E2E**: `/research` creates research node with sources
+- **E2E**: `/factcheck` creates factcheck node with verdicts
+- **E2E**: Flashcard flip interaction works
+
+### Phase 6 Definition of Done
+
+- [ ] All multi-LLM nodes render correctly
+- [ ] `/committee` command works end-to-end
+- [ ] `/research` command works end-to-end
+- [ ] `/factcheck` command works end-to-end
+- [ ] Flashcard flip works
+- [ ] `/image` command works end-to-end
+
+---
+
+## Phase 7: UI Chrome — Progressive Page Takeover
+
+**Goal**: Svelte takes over chat input, toolbar, modals, search, and keybindings. The App class is decomposed. `modal-manager.js` and `app.js` DOM manipulation is replaced by Svelte components.
+
+### Phase 7a: Plugin Integration + Chat Input + Toolbar
+
+**Goal**: Plugins register and work. Chat input and toolbar become Svelte components. The App class's chat methods decompose into Svelte state.
+
+### Phase 7a Deliverables
+
+1. **Plugin registration entry point**
+    - `svelte/imports/plugins.js` — side-effect imports of all plugins
+    - Replicates the import chain from `app.js` (each plugin registers itself on import)
+    - `App.svelte` imports this entry point to trigger registration
+    - **Specs**: PLUG-REQ-001, PLUG-REQ-002, PLUG-REQ-003, PLUG-REQ-004, BLD-REQ-004
+
+2. **AppContext for plugins**
+    - `svelte/stores/appContext.js` wraps Svelte graph store, canvas API, chat, storage into an `AppContext` object
+    - Feature plugins receive this context (same shape as current `AppContext`)
+    - Plugin methods call through to Svelte reactive state
+    - **Specs**: PLUG-REQ-004
+
+3. **ChatInput.svelte + Toolbar.svelte**
+    - Chat input sends messages, creates human + AI nodes
+    - Streaming updates AI node content via graph store
+    - Toolbar: model picker, action buttons, tag drawer
+    - Slash command menu (`SlashCommandMenu.svelte`)
+    - Model selection + API key management (via `storage` import)
+    - **Specs**: CHAT-REQ-001 through CHAT-REQ-011
+
+4. **Remove App class chat methods**
+    - `handleSend()`, `streamWithAbort()`, `addUserNode()` decomposed into Svelte components
+    - Remaining App class methods reduced (only non-chat methods survive until Phase 8)
+    - Window globals for chat removed
+
+### Phase 7a Testing Requirements
+
+- **Unit**: Plugin adapter provides correct context to plugins
+- **Unit**: Slash commands route to correct handlers
+- **E2E**: Send chat message → human node + AI node created
+- **E2E**: Model selection changes persisted
+
+### Phase 7a Definition of Done
+
+- [ ] All plugins register via side-effect imports
+- [ ] Chat send → stream → node creation works via Svelte
+- [ ] Toolbar renders in Svelte with model picker
+- [ ] All slash commands functional
+- [ ] App class chat methods removed
+
+---
+
+### Phase 7b: Modals (9 total)
+
+**Goal**: All 9 modal HTML templates move from `index.html` into Svelte components. `modal-manager.js` is replaced.
+
+### Phase 7b Deliverables
+
+1. **SettingsModal.svelte**
+    - API key entry per provider
+    - Model selection dropdown
+    - Keybinding overrides
+    - Search provider config
+    - Sidebar categories (LLM, Search, Custom models, Proxy, Features, Plugins)
+    - **Specs**: MOD-REQ-001, CHAT-REQ-006, CHAT-REQ-007, CHAT-REQ-008
+
+2. **HelpModal.svelte**
+    - Keyboard shortcuts display
+    - **Specs**: MOD-REQ-002
+
+3. **SessionsModal.svelte**
+    - Load, save, delete sessions
+    - Export/import
+    - **Specs**: MOD-REQ-003, STOR-REQ-002, STOR-REQ-003, STOR-REQ-004
+
+4. **EditContentModal.svelte + EditTitleModal.svelte**
+    - Markdown editor with live preview
+    - Respects `isContentEditable()` protocol
+    - **Specs**: MOD-REQ-004, PROT-REQ-006
+
+5. **CodeEditorModal.svelte**
+    - Code editor with syntax highlighting
+    - **Specs**: CODE-REQ-002
+
+6. **CopilotAuthModal.svelte**
+    - GitHub Copilot authentication
+    - **Specs**: CANV-CHAT-ENABLE-GITHUB-COPILOT (config.py)
+
+7. **SearchOverlay.svelte + FlashcardToast.svelte**
+    - Search results overlay with BM25 snippets
+    - Flashcard due notification toast
+    - **Specs**: SCH-REQ-001, SCH-REQ-002, FLAS-REQ-003
+
+8. **Remove modal-manager.js and modal HTML templates**
+    - `modal-manager.js` (52 `getElementById` calls) deleted
+    - All 9 modal `<div>` blocks removed from `index.html`
+    - App class modal-related methods removed
+
+### Phase 7b Testing Requirements
+
+- **E2E**: Settings modal opens, API key saved, persists on reload
+- **E2E**: Help modal displays keyboard shortcuts
+- **E2E**: Sessions modal saves/loads/deletes sessions
+- **E2E**: Edit content modal opens for editable node types
+- **Cypress**: `settings_modal.cy.js`, `help_modal.cy.js` pass
+
+### Phase 7b Definition of Done
+
+- [ ] All 9 modals render as Svelte components
+- [ ] `modal-manager.js` deleted
+- [ ] Modal HTML templates removed from `index.html`
+- [ ] All modal-related Cypress tests pass
+
+---
+
+### Phase 7c: Search + Keybindings
+
+**Goal**: BM25 search and keyboard shortcuts become Svelte-managed.
+
+### Phase 7c Deliverables
+
+1. **SearchOverlay.svelte integration**
+    - BM25 search with K1=1.2, B=0.75 (import `SearchIndex` from `../js/search.js`)
+    - Results with highlighted snippets
+    - Keyboard arrow navigation
+    - **Specs**: SCH-REQ-001, SCH-REQ-002
+
+2. **Keybinding management in Svelte**
+    - Default shortcuts (Ctrl+K, Ctrl+Z, Delete, E, R)
+    - User overrides from localStorage (import from `../js/storage.js`)
+    - Cross-platform Cmd/Ctrl normalization (import from `../js/keybindings.js`)
+    - **Specs**: KEY-REQ-001, KEY-REQ-002, KEY-REQ-003
+
+3. **Remove App class search + keyboard methods**
+    - Search-related methods removed from App class
+    - Keybinding event listeners moved to Svelte `onMount`
+
+### Phase 7c Testing Requirements
+
+- **E2E**: Ctrl+K opens search, results display, arrow keys navigate
+- **E2E**: Keyboard shortcuts work (Ctrl+Z undo, Delete node, E edit, R reply)
+- **Cypress**: `search.cy.js`, `keyboard_interactions.cy.js`, `slash_command_menu.cy.js` pass
+
+### Phase 7c Definition of Done
+
+- [ ] Search works with BM25 via Svelte component
+- [ ] All keybindings functional
+- [ ] App class search/keyboard methods removed
+
+---
+
+## Phase 8: Testing + Cutover
+
+**Goal**: Full test coverage, Safari verification, and removal of all legacy code.
+
+### Phase 8 Deliverables
+
+1. **Cypress test updates**
+    - Update selectors for Svelte-rendered nodes (SVG → HTML elements)
+    - All existing E2E tests pass
+    - New tests for MiniMap, Safari-specific behavior
+    - **Specs**: All 139 EARS requirements
+
+2. **Safari verification**
+    - Test all node types render on Safari
+    - Test pan/zoom/interact on Safari
+    - Test streaming on Safari
+    - Document any remaining issues
+
+3. **Performance testing**
+    - Compare render performance: old canvas.js vs Svelte Flow
+    - Measure with 100+ nodes on canvas
+    - Verify no memory leaks with session load/save cycles
+
+4. **Feature flag cutover**
+    - Add feature flag to switch between old UI and Svelte
+    - Test both paths work during transition
+    - Remove flag, delete legacy code
+
+5. **Remove legacy code**
+    - Delete `app.js` (~4,700 lines) — fully decomposed into Svelte components
+    - Delete `modal-manager.js` — replaced by Svelte modal components
+    - Delete `canvas.js` (~4,700 lines) — replaced by Svelte Flow
+    - Delete `slash-command-menu.js` — replaced by `SlashCommandMenu.svelte`
+    - Remove modal HTML templates from `index.html` (9 modals, ~460 lines)
+    - Remove toolbar HTML from `index.html` (~110 lines)
+    - Remove chat input HTML from `index.html` (~28 lines)
+    - `index.html` is now the minimal `<div id="app">` shell
+    - Remove window global assignments from consumed modules
+    - Update AGENTS.md with new file map
+
+### Phase 8 Testing Requirements
+
+- **E2E**: All 17 existing Cypress test files pass
+- **Manual**: Safari smoke test (all node types, pan/zoom, streaming)
+- **Performance**: 100-node canvas renders in < 2s
+- **Performance**: No memory leak over 10 session load/save cycles
+
+### Phase 8 Definition of Done
+
+- [ ] All Cypress tests pass with updated selectors
+- [ ] Safari renders all node types
+- [ ] Performance benchmarks acceptable
+- [ ] `canvas.js` removed from codebase
+- [ ] AGENTS.md updated with new architecture
+- [ ] Feature flag removed
+- [ ] All 138 EARS requirements verified passing
+
+---
+
+## Phase 9: Deploy + Distribution
+
+**Goal**: Modal deployment and pip distribution work correctly with the Svelte Flow app.
+
+### Phase 9 Deliverables
+
+1. **Modal deployment update**
+    - `modal_app.py` — verify `.add_local_dir("src/canvas_chat")` includes `svelte-dist/`
+    - Modal image size acceptable (built assets should be small — tree-shaken)
+    - **Specs**: DEP-REQ-001
+
+2. **CI/CD pipeline update**
+    - GitHub Actions runs `npm install && npm run build` before `modal deploy`
+    - Modal deploy succeeds on push to `main`
+    - Test deployments work on PRs
+    - Health check passes after deploy
+    - **Specs**: DEP-REQ-001
+
+3. **pip wheel packaging**
+    - `python -m build` produces wheel with `svelte-dist/` included
+    - `pip install dist/canvas-chat-*.whl` installs successfully
+    - `canvas-chat launch` starts and serves complete app
+    - No Node.js required at install or runtime
+    - **Specs**: DEP-REQ-002, DEP-REQ-003
+
+4. **Release process documentation**
+    - Document the release workflow: build → test → bump version → publish to PyPI → deploy to Modal
+    - Update AGENTS.md with deployment sections
+
+### Phase 9 Testing Requirements
+
+- **CI**: Full GitHub Actions pipeline passes (build + deploy + health check)
+- **Manual**: Fresh `pip install` in a clean environment works
+- **Manual**: Modal deployment serves complete app at production URL
+- **Manual**: `canvas-chat launch --admin-mode --config config.yaml` works
+
+### Phase 9 Definition of Done
+
+- [ ] Modal deployment serves Svelte Flow app
+- [ ] CI/CD pipeline builds Svelte before deploy
+- [ ] `pip install canvas-chat` includes built assets
+- [ ] `canvas-chat launch` works without Node.js
+- [ ] Release process documented
+
+---
+
+## Requirements Traceability
+
+### Phase 0 (Build Infrastructure)
+
+- Build: BLD-REQ-001, BLD-REQ-002, BLD-REQ-003, BLD-REQ-004, BLD-REQ-005
+- Deploy: DEP-REQ-002, DEP-REQ-003
+
+### Phase 1 (Foundation)
+
+- Canvas: CANV-REQ-002, CANV-REQ-003
+
+### Phase 2 (Graph Store + Canvas Adapter)
+
+- Graph: GRPH-REQ-001 through GRPH-REQ-005
+- Storage: STOR-REQ-001, STOR-REQ-003, STOR-REQ-004
+- Build: BLD-REQ-004, BLD-REQ-005
+
+### Phase 3 (Core Canvas)
+
+- Canvas: CANV-REQ-001, CANV-REQ-004, CANV-REQ-005, CANV-REQ-006, CANV-REQ-007, CANV-REQ-008
+
+### Phase 4 (Simple Nodes)
+
+- Chat: CHAT-REQ-004, CHAT-REQ-005
+- Nodes: NODE-REQ-001 through NODE-REQ-005, NODE-REQ-009
+- Protocols: PROT-REQ-001 through PROT-REQ-006
+
+### Phase 5 (Complex Nodes)
+
+- Nodes: NODE-REQ-006 through NODE-REQ-008, NODE-REQ-014, NODE-REQ-016, NODE-REQ-017
+- Code: CODE-REQ-001 through CODE-REQ-005
+- Matrix: MAT-REQ-001 through MAT-REQ-004
+- Uploads: UP-REQ-001, UP-REQ-003
+- Slides: SLID-REQ-001 through SLID-REQ-003
+
+### Phase 6 (Multi-LLM + Feature Nodes)
+
+- Nodes: NODE-REQ-010 through NODE-REQ-013, NODE-REQ-015, NODE-REQ-018
+- Committee: COMM-REQ-001 through COMM-REQ-005
+- Research: RSCH-REQ-001 through RSCH-REQ-004
+- Factcheck: FACT-REQ-001 through FACT-REQ-004
+- Flashcards: FLAS-REQ-001, FLAS-REQ-004
+- Image: IMG-REQ-001 through IMG-REQ-003
+
+### Phase 7a (Plugin Integration + Chat + Toolbar)
+
+- Chat: CHAT-REQ-001 through CHAT-REQ-011
+- Plugin: PLUG-REQ-001 through PLUG-REQ-004
+- Build: BLD-REQ-004
+
+### Phase 7b (Modals)
+
+- Modal: MOD-REQ-001 through MOD-REQ-004
+- Storage: STOR-REQ-002 through STOR-REQ-004
+- Code: CODE-REQ-002
+- Flashcards: FLAS-REQ-003
+
+### Phase 7c (Search + Keybindings)
+
+- Search: SCH-REQ-001, SCH-REQ-002
+- Keybindings: KEY-REQ-001 through KEY-REQ-003
+
+### Phase 8 (Testing + Cutover)
+
+- All 139 requirements verified
+
+### Phase 9 (Deploy + Distribution)
+
+- Deploy: DEP-REQ-001, DEP-REQ-002, DEP-REQ-003
+
+**Total**: 138 EARS requirements across 10 phases (0-9)
+
+## Risk Assessment
+
+### High Risk
+
+1. **Plugin adapter complexity**
+    - Vanilla JS plugins expect DOM APIs, event emitters, global state
+    - Svelte's reactivity model may conflict with imperative plugin code
+    - **Mitigation**: Adapter pattern with thin wrapper; test each plugin individually in Phase 7
+
+2. **CRDT ↔ Svelte Flow synchronization**
+    - Yjs observe events must correctly map to Svelte state updates
+    - Bidirectional sync (user drags node → update CRDT → persist) is complex
+    - **Mitigation**: Unidirectional data flow (CRDT → Svelte state → Svelte Flow); writes go through CRDT API
+
+### Medium Risk
+
+1. **Safari partial compatibility**
+    - Svelte Flow uses CSS transforms (better than SVG foreignObject) but Safari may still have quirks
+    - **Mitigation**: Test early (Phase 1), document issues, plan workarounds
+
+2. **Performance with 100+ nodes**
+    - Svelte Flow is performant but rendering 25+ custom node types with complex internals may lag
+    - **Mitigation**: Svelte Flow's built-in viewport culling; semantic zoom already limits rendered content
+
+3. **Vite build integration with existing FastAPI**
+    - Current app serves static files directly from `src/canvas_chat/static/`
+    - Vite build output must integrate into existing static file serving
+    - **Mitigation**: Build to existing static directory; configure Vite output paths
+
+### Low Risk
+
+1. **MiniMap styling**
+    - MiniMap node colors may need customization per node type
+    - **Mitigation**: Svelte Flow MiniMap supports custom node color function
+
+2. **Existing tests break during migration**
+    - Cypress selectors will change as DOM structure changes
+    - **Mitigation**: Phase 8 dedicated to test updates; run tests after each phase
+
+## References
+
+- Issue: `#247` (Migrate to Svelte Flow)
+- HLD: `/docs/high-level-design.md` (Section 9: Build, Deploy, and Distribution)
+- Build & Deploy LLD: `/docs/llds/build-deployment.md`
+- Canvas LLD: `/docs/llds/canvas-rendering.md`
+- Plugin System LLD: `/docs/llds/plugin-system.md`
+- App Orchestrator LLD: `/docs/llds/app-orchestrator.md`
+- CRDT Graph LLD: `/docs/llds/crdt-graph.md`
+- Modal deployment: `modal_app.py`
+- CI workflow: `.github/workflows/modal-deploy.yaml`
+- Package config: `pyproject.toml`
+- Core Specs: `/docs/specs/core-specs.md`
+- Node Type Specs: `/docs/specs/node-types-specs.md`
+- Feature Plugin Specs: `/docs/specs/feature-plugins-specs.md`
+- Backend API Specs: `/docs/specs/backend-api-specs.md`

--- a/docs/specs/backend-api-specs.md
+++ b/docs/specs/backend-api-specs.md
@@ -1,0 +1,160 @@
+# Backend API Specifications
+
+**Created**: 2026-03-16
+**Status**: Active
+**HLD**: [High-Level Design](../high-level-design.md)
+
+## Chat API
+
+### [x] API-REQ-001: POST /api/chat
+
+**Location**: `app.py`
+
+The system MUST provide a `/api/chat` endpoint that accepts POST requests with messages, model, and API key. The endpoint MUST return an SSE stream of the LLM response.
+
+**Request:**
+
+```json
+{
+    "messages": [{ "role": "user", "content": "Hello" }],
+    "model": "openai/gpt-4o",
+    "api_key": "sk-...",
+    "temperature": 0.3
+}
+```
+
+**Response:** Server-Sent Events stream with `content` events.
+
+### [x] API-REQ-002: POST /api/summarize
+
+**Location**: `app.py`
+
+The system MUST provide a `/api/summarize` endpoint that accepts conversation messages and returns a summary.
+
+### [x] API-REQ-003: POST /api/committee
+
+**Location**: `app.py`
+
+The system MUST provide a `/api/committee` endpoint that accepts multiple model configurations and returns parallel responses from each model.
+
+## Search API
+
+### [x] API-REQ-004: POST /api/exa/search
+
+**Location**: `app.py`
+
+The system MUST provide an `/api/exa/search` endpoint that accepts a query and returns search results from Exa API.
+
+### [x] API-REQ-005: POST /api/exa/research
+
+**Location**: `app.py`
+
+The system MUST provide an `/api/exa/research` endpoint that performs deep research, streaming results as they are generated.
+
+### [x] API-REQ-006: POST /api/exa/get-contents
+
+**Location**: `app.py`
+
+The system MUST provide an `/api/exa/get-contents` endpoint that fetches and extracts content from URLs.
+
+### [x] API-REQ-007: POST /api/ddg/search
+
+**Location**: `ddg_endpoints.py`
+
+The system MUST provide a `/api/ddg/search` endpoint as a fallback when Exa is unavailable.
+
+### [x] API-REQ-008: POST /api/ddg/research
+
+**Location**: `ddg_endpoints.py`
+
+The system MUST provide a `/api/ddg/research` endpoint as a fallback for deep research.
+
+## File Processing API
+
+### [x] API-REQ-009: POST /api/upload-file
+
+**Location**: `app.py`
+
+The system MUST provide an `/api/upload-file` endpoint that accepts file uploads and routes to appropriate handlers based on file type.
+
+### [x] API-REQ-010: POST /api/pptx/upload
+
+**Location**: `pptx_endpoints.py`
+
+The system MUST provide an `/api/pptx/upload` endpoint for PowerPoint file processing with slide-by-slide streaming.
+
+### [x] API-REQ-011: POST /api/pptx/caption
+
+**Location**: `pptx_endpoints.py`
+
+The system MUST provide an `/api/pptx/caption` endpoint to generate captions for slides using the LLM.
+
+### [x] API-REQ-012: POST /api/pptx/narrate
+
+**Location**: `pptx_endpoints.py`
+
+The system MUST provide an `/api/pptx/narrate` endpoint to generate narrative summaries for presentations.
+
+## Code Generation API
+
+### [x] API-REQ-013: POST /api/generate-code
+
+**Location**: `code_handler.py`
+
+The system MUST provide a `/api/generate-code` endpoint that generates Python code based on user prompt and context.
+
+### [x] API-REQ-014: POST /api/matrix/fill
+
+**Location**: `matrix_handler.py`
+
+The system MUST provide an `/api/matrix/fill` endpoint to fill matrix cells using the LLM with provided context.
+
+## Image Generation API
+
+### [x] API-REQ-015: POST /api/generate-image
+
+**Location**: `app.py`
+
+The system MUST provide a `/api/generate-image` endpoint that generates images using DALL-E, Gemini, or Ollama.
+
+## Utility API
+
+### [x] API-REQ-016: POST /api/refine-query
+
+**Location**: `app.py`
+
+The system MUST provide a `/api/refine-query` endpoint that refines ambiguous queries using context from the graph.
+
+### [x] API-REQ-017: GET /api/models
+
+**Location**: `app.py`
+
+The system MUST provide an `/api/models` endpoint that returns available models from configured providers.
+
+## WebSocket API
+
+### [x] API-REQ-018: WS /signal
+
+**Location**: `app.py`
+
+The system MUST provide a WebSocket `/signal` endpoint for WebRTC peer connection signaling (optional multiplayer).
+
+## Admin Mode
+
+### [x] API-REQ-019: Server-Side Keys
+
+**Location**: `config.py`
+
+When admin mode is enabled, the system MUST use API keys from the config file instead of requiring keys from the client.
+
+### [x] API-REQ-020: Hide Settings
+
+**Location**: `app.py`, `index.html`
+
+When admin mode is enabled, the system MUST hide API key settings in the frontend.
+
+## Status Key
+
+- `[ ]` Active requirement
+- `[x]` Implemented requirement
+- `[D]` Deferred requirement

--- a/docs/specs/core-specs.md
+++ b/docs/specs/core-specs.md
@@ -1,0 +1,448 @@
+# Canvas-Chat Core Specifications
+
+**Created**: 2026-03-16
+**Status**: Active
+**HLD**: [High-Level Design](../high-level-design.md)
+
+## Core Chat Specifications
+
+### [x] CHAT-REQ-001: Send Message to LLM
+
+**Location**: `app.js:handleSend()`
+
+The system MUST allow users to type a message in the chat input and send it to an LLM provider. The message MUST be sent as a POST request to `/api/chat` with the message content, model selection, and API key.
+
+### [x] CHAT-REQ-002: Stream LLM Response
+
+**Location**: `chat.js`, `sse.js`
+
+The system MUST stream LLM responses token-by-token using Server-Sent Events (SSE). The stream MUST update the AI node content in real-time as tokens are received.
+
+### [x] CHAT-REQ-003: Stop/Continue Generation
+
+**Location**: `streaming-manager.js`
+
+The system MUST allow users to stop an in-progress LLM response mid-stream. The system MUST allow users to continue a stopped response from where it left off.
+
+### [x] CHAT-REQ-004: Create Human Node
+
+**Location**: `app.js:addUserNode()`
+
+When a user sends a message, the system MUST create a `human` node containing the message content. The node MUST be persisted to the graph and rendered on the canvas.
+
+### [x] CHAT-REQ-005: Create AI Node
+
+**Location**: `app.js:handleSend()`
+
+When a user sends a message, the system MUST immediately create an `ai` node (see CHAT-REQ-012). The node MUST be connected to the parent human node via a `reply` edge. The node content is populated as the LLM response streams in (see CHAT-REQ-014).
+
+### [x] CHAT-REQ-006: Model Selection
+
+**Location**: `app.js`, `storage.js`
+
+The system MUST allow users to select which LLM model to use. The selected model MUST be persisted in localStorage and used for subsequent requests.
+
+### [x] CHAT-REQ-007: API Key Management
+
+**Location**: `storage.js`, `modal-manager.js`
+
+The system MUST allow users to enter and store API keys for LLM providers. Keys MUST be stored in localStorage and sent with requests. Keys MUST NOT be stored on the backend. The system MUST support API keys for: OpenAI, Anthropic, Google, Groq, GitHub, and OpenRouter.
+
+### [x] CHAT-REQ-008: Load Available Models
+
+**Location**: `app.js:loadModels()`, `chat.js:fetchProviderModels()`
+
+The system MUST dynamically fetch available models from configured LLM providers on startup. The system MUST populate the model picker dropdown with available models and MUST persist the user's selected model in localStorage.
+
+### [x] CHAT-REQ-009: Slash Command Routing
+
+**Location**: `app.js:tryHandleSlashCommand()`, `feature-registry.js`
+
+The system MUST route slash commands (e.g., /research, /committee, /code) to registered feature plugins. Commands MUST be matched by priority (BUILTIN > OFFICIAL > COMMUNITY).
+
+### [x] CHAT-REQ-010: Context Resolution
+
+**Location**: `app.js:handleSend()`, `crdt-graph.js:resolveContext()`
+
+The system MUST build conversation context by traversing parent nodes in the graph. Context MUST be formatted as an array of {role, content} messages for the LLM API.
+
+### [x] CHAT-REQ-011: Error Display with Retry
+
+**Location**: `app.js:showNodeError()`, `app.js:handleNodeRetry()`
+
+The system MUST display user-friendly error messages on AI nodes. The system MUST provide retry functionality that re-executes the failed request with the same parameters.
+
+### [x] CHAT-REQ-012: Immediate Node Appearance on Send
+
+**Location**: `app.js:handleSend()`
+
+When a user sends a message, the system MUST immediately create and render BOTH the human node AND the AI node on the canvas before the LLM response is received. The human node MUST contain the user's message content. The AI node MUST appear immediately with empty content.
+
+### [x] CHAT-REQ-013: Immediate Edge Creation
+
+**Location**: `app.js:handleSend()`
+
+When a user sends a message, the system MUST immediately create a reply edge connecting the human node to the AI node. This edge MUST be created and rendered before streaming begins.
+
+### [x] CHAT-REQ-014: Real-time AI Node Updates
+
+**Location**: `app.js:handleSend()`, `canvas.js:updateNodeContent()`
+
+As tokens are received from the LLM stream, the system MUST update the AI node content in real-time. The node MUST display partial content as it streams, allowing users to see the response forming.
+
+### [x] CHAT-REQ-015: API Key Validation Before Send
+
+**Location**: `app.js:handleSend()`
+
+When a user sends a message, the system MUST validate that an API key is configured for the selected model before creating nodes. If no API key is found, the system MUST display a toast notification directing the user to Settings and MUST NOT create nodes.
+
+### [x] CHAT-REQ-016: Streaming State Management
+
+**Location**: `app.js:handleSend()`, `streaming-manager.js`
+
+When streaming begins, the system MUST register the stream with the StreamingManager. The StreamingManager MUST show a stop button in the AI node header. When streaming completes, the system MUST unregister the stream and hide the stop button.
+
+### [x] CHAT-REQ-017: Automatic Summary Generation
+
+**Location**: `app.js:generateNodeSummary()`
+
+When an AI response completes streaming, the system MUST automatically generate a summary of the node content. The summary MUST be stored on the node for use in semantic zoom and search.
+
+### [x] CHAT-REQ-018: Per-Provider API Key Storage
+
+**Location**: `storage.js`
+
+The system MUST store API keys individually per provider in localStorage under the key `canvas-chat-api-keys`. The storage format MUST be JSON with provider names as keys.
+
+### [x] CHAT-REQ-019: Provider Detection from Model ID
+
+**Location**: `chat.js:getApiKeyForModel()`
+
+The system MUST extract the provider name from the model ID (e.g., `openai/gpt-4o` → `openai`) and retrieve the corresponding API key from storage.
+
+### [x] CHAT-REQ-020: Dynamic Model Reload on API Key Save
+
+**Location**: `modal-manager.js:saveSettings()`, `app.js:loadModels()`
+
+When a user saves an API key in Settings, the system MUST immediately reload available models. The model picker dropdown MUST be updated to include models from the newly configured provider.
+
+### [x] CHAT-REQ-021: Filter Models by Available API Keys
+
+**Location**: `app.js:loadModels()`
+
+The system MUST only display models for LLM providers that have a configured API key. Providers without keys MUST NOT appear in the model picker.
+
+### [x] CHAT-REQ-022: Parallel Provider Model Fetching
+
+**Location**: `app.js:loadModels()`
+
+The system MUST fetch models from multiple providers in parallel. Each provider with a configured API key MUST have its models fetched independently. Failed provider fetches MUST NOT block other providers from loading.
+
+### [x] CHAT-REQ-023: Model Picker UI States
+
+**Location**: `app.js:loadModels()`
+
+The system MUST display appropriate UI states in the model picker:
+
+- When no API keys are configured: Show "Configure API keys in Settings ⚙️" as a disabled option
+- When models are loaded: Show the list of available models
+
+### [x] CHAT-REQ-024: Restore Last Selected Model
+
+**Location**: `app.js:loadModels()`
+
+When models are reloaded, the system MUST attempt to restore the user's previously selected model. If the previously selected model is still available, it MUST be selected.
+
+### [x] CHAT-REQ-025: Custom Model Support
+
+**Location**: `app.js:loadModels()`, `storage.js`
+
+The system MUST allow users to define custom model endpoints. Custom models MUST be added to the model picker alongside dynamically fetched models.
+
+## Canvas Specifications
+
+### [x] CANV-REQ-001: Render Nodes
+
+**Location**: `canvas.js`
+
+The system MUST render all nodes from the graph on the SVG canvas. Each node MUST display its content, type icon, and action buttons.
+
+### [x] CANV-REQ-002: Pan Canvas
+
+**Location**: `canvas.js`
+
+The system MUST allow users to pan the canvas by dragging on empty space. Panning MUST work with mouse drag and touch gestures.
+
+### [x] CANV-REQ-003: Zoom Canvas
+
+**Location**: `canvas.js`
+
+The system MUST allow users to zoom the canvas using scroll wheel (with Ctrl), trackpad pinch, or touch gestures. Zoom MUST be constrained between 0.1 and 3.0.
+
+### [x] CANV-REQ-004: Semantic Zoom
+
+**Location**: `canvas.js`, `nodes.css`
+
+The system MUST show full node content at zoom > 0.6, summary text at zoom 0.35-0.6, and minimal view at zoom <= 0.35. This MUST be implemented via CSS classes on the canvas container.
+
+### [x] CANV-REQ-005: Render Edges
+
+**Location**: `canvas.js`
+
+The system MUST render edges connecting related nodes. Edges MUST be Bezier curves. Edges MUST be rendered after nodes to avoid z-order issues.
+
+### [x] CANV-REQ-006: Node Selection
+
+**Location**: `canvas.js`
+
+The system MUST allow users to select a node by clicking. Selected nodes MUST show a visual indicator (border highlight).
+
+### [x] CANV-REQ-007: Node Dragging
+
+**Location**: `canvas.js`
+
+The system MUST allow users to drag nodes to reposition them. At zoom > 0.6, dragging MUST use a handle. At zoom <= 0.6, dragging MUST work from anywhere on the node.
+
+### [x] CANV-REQ-008: Viewport Focus
+
+**Location**: `app.js:addUserNode()`
+
+When a new node is added via chat, the system MUST focus the viewport to show the node. This MUST use `zoomToSelectionAnimated()` with scale 0.8.
+
+## Graph Specifications
+
+### [x] GRPH-REQ-001: Store Nodes
+
+**Location**: `crdt-graph.js`
+
+The system MUST store all nodes in a Yjs CRDT Map. Each node MUST have id, type, content, position, and metadata properties.
+
+### [x] GRPH-REQ-002: Store Edges
+
+**Location**: `crdt-graph.js`
+
+The system MUST store all edges in a Yjs CRDT Array. Each edge MUST have id, source, target, and type properties.
+
+### [x] GRPH-REQ-003: Persist to IndexedDB
+
+**Location**: `crdt-graph.js`, `storage.js`
+
+The system MUST persist graph data to IndexedDB. Changes MUST be auto-saved with a 500ms debounce.
+
+### [x] GRPH-REQ-004: Load from IndexedDB
+
+**Location**: `storage.js`
+
+On startup, the system MUST load the last session from IndexedDB. If no session exists, create a new empty session.
+
+### [x] GRPH-REQ-005: Graph Traversal
+
+**Location**: `crdt-graph.js:getParents()`, `getChildren()`
+
+The system MUST provide methods to traverse the graph: get parents (nodes that reply to), get children (nodes this node replies to), get root nodes, get leaf nodes.
+
+## Plugin Specifications
+
+### [x] PLUG-REQ-001: Register Feature Plugin
+
+**Location**: `feature-registry.js`
+
+The system MUST allow registering feature plugins via `FeatureRegistry.register()`. Plugins MUST have priority levels (OVERRIDE, BUILTIN, OFFICIAL, COMMUNITY).
+
+### [x] PLUG-REQ-002: Slash Commands
+
+**Location**: `feature-registry.js`, `app.js`
+
+The system MUST route slash commands to registered features. The first matching command (by priority) MUST handle the command.
+
+### [x] PLUG-REQ-003: Register Node Type
+
+**Location**: `node-registry.js`
+
+The system MUST allow registering custom node types. Each node type MUST provide a protocol with rendering, actions, and keyboard shortcuts.
+
+### [x] PLUG-REQ-004: AppContext Injection
+
+**Location**: `feature-plugin.js`
+
+Feature plugins MUST receive an AppContext with access to graph, canvas, chat, storage, and modalManager.
+
+## Storage Specifications
+
+### [x] STOR-REQ-001: Session Storage
+
+**Location**: `storage.js`
+
+Sessions MUST be stored in IndexedDB with nodes, edges, tags, created_at, and updated_at fields.
+
+### [x] STOR-REQ-002: Settings Storage
+
+**Location**: `storage.js`
+
+Settings (API keys, model selection, keybinding overrides) MUST be stored in localStorage.
+
+### [x] STOR-REQ-003: Export Session
+
+**Location**: `storage.js`
+
+The system MUST allow exporting a session as a `.canvaschat` JSON file containing all nodes, edges, and metadata.
+
+### [x] STOR-REQ-004: Import Session
+
+**Location**: `storage.js`
+
+The system MUST allow importing a session from a `.canvaschat` file. Imported sessions MUST get a new UUID.
+
+## Search Specifications
+
+### [x] SCH-REQ-001: BM25 Search
+
+**Location**: `search.js`
+
+The system MUST implement BM25 search with K1=1.2 and B=0.75. Search MUST index node content and be triggered via Ctrl+K.
+
+### [x] SCH-REQ-002: Search Results
+
+**Location**: `search.js`, `app.js`
+
+Search results MUST display top 15 matches with snippets containing highlighted terms. Users MUST be able to navigate results with keyboard arrows.
+
+## File Upload Specifications
+
+### [x] UP-REQ-001: PDF Upload
+
+**Location**: `file-upload-registry.js`
+
+The system MUST handle PDF file uploads. Uploaded PDFs MUST be stored in IndexedDB and rendered in a PdfNode with pagination.
+
+### [x] UP-REQ-002: Image Upload
+
+**Location**: `file-upload-registry.js`
+
+The system MUST handle image file uploads (png, jpg, gif, webp). Uploaded images MUST be stored as base64 and displayed in an ImageNode.
+
+### [x] UP-REQ-003: CSV Upload
+
+**Location**: `file-upload-registry.js`
+
+The system MUST handle CSV file uploads. CSV data MUST be parsed and stored as csvData on the node for use with /code.
+
+## Keybinding Specifications
+
+### [x] KEY-REQ-001: Default Shortcuts
+
+**Location**: `keybindings.js`
+
+The system MUST provide default keyboard shortcuts: Ctrl+k (search), Ctrl+z (undo), Ctrl+Shift+z (redo), Delete/Backspace (delete), e (edit), r (reply).
+
+### [x] KEY-REQ-002: Override Shortcuts
+
+**Location**: `keybindings.js`
+
+The system MUST allow users to override default shortcuts. Overrides MUST be stored in localStorage and merged with defaults at runtime.
+
+### [x] KEY-REQ-003: Cross-Platform Handling
+
+**Location**: `keybindings.js`
+
+The system MUST normalize Cmd (Mac) to Ctrl (Windows/Linux) for consistent shortcut behavior across platforms.
+
+## Modal Specifications
+
+### [x] MOD-REQ-001: Settings Modal
+
+**Location**: `modal-manager.js`
+
+The system MUST provide a Settings modal for configuring API keys, model selection, and keyboard shortcuts.
+
+### [x] MOD-REQ-002: Help Modal
+
+**Location**: `modal-manager.js`
+
+The system MUST provide a Help modal showing all keyboard shortcuts.
+
+### [x] MOD-REQ-003: Sessions Modal
+
+**Location**: `modal-manager.js`
+
+The system MUST provide a Sessions modal for loading, saving, and deleting sessions.
+
+### [x] MOD-REQ-004: Edit Content Modal
+
+**Location**: `modal-manager.js`
+
+The system MUST provide an Edit Content modal for editing node markdown content with live preview.
+
+## Build Specifications
+
+### [x] BLD-REQ-001: Build Produces Static Bundle
+
+**Location**: `vite.config.js`, `package.json`
+
+When `npm run build` is executed, the system MUST produce a JS bundle and a CSS file in `src/canvas_chat/static/svelte-dist/assets/`. The Vite config MUST set `base: './'` so that asset URLs in the built HTML are relative paths.
+
+**Test**: Run `npm run build`, assert `svelte-dist/assets/index-*.js` and `svelte-dist/assets/index-*.css` exist. Assert built JS contains no leading `/` in import paths.
+
+### [x] BLD-REQ-002: FastAPI Serves Built Bundle
+
+**Location**: `app.py` (StaticFiles mount), `index.html`
+
+When the FastAPI server is running, a GET request to `/static/svelte-dist/assets/index-[hash].js` MUST return HTTP 200 with JavaScript content. The HTML at `/` MUST contain a `<script>` tag referencing `/static/svelte-dist/assets/index-[hash].js`.
+
+**Test**: Start server, GET `/`, assert HTML contains `<script src="./static/svelte-dist/assets/index-` substring.
+
+### [ ] BLD-REQ-003: Dev Server Proxies API Requests
+
+**Location**: `vite.config.js` (server.proxy)
+
+When the Vite dev server is running, a GET request to `/health` MUST return HTTP 200. A GET request to `/static/js/crdt-graph.js` MUST return HTTP 200 with JavaScript content.
+
+**Test**: Start Vite dev server (`npm run dev`) with FastAPI backend running, GET `/health` returns 200, GET `/static/js/crdt-graph.js` returns 200.
+
+### [ ] BLD-REQ-004: Svelte App Loads Without Import Errors
+
+**Location**: `svelte/App.svelte`
+
+The Svelte app MUST import `CRDTGraph` from `../js/crdt-graph.js` and `storage` from `../js/storage.js` via ES module `import` statements. The app MUST load in the browser without import resolution errors.
+
+**Test**: Build and serve the app, open browser console, assert no `Failed to resolve module` or `Uncaught SyntaxError` errors.
+
+### [ ] BLD-REQ-005: Canvas Adapter Preserves App Class Interface
+
+**Location**: `svelte/CanvasFlow.svelte` (or canvas.js adapter)
+
+During the transition period, a canvas adapter MUST export a `Canvas` class with the same constructor signature (`new Canvas(containerId, svgId)`) and method interface as the current `canvas.js`. The App class MUST instantiate and call methods on this adapter without modification. `node --check` MUST pass on `app.js` without errors throughout the migration.
+
+**Test**: During Phases 3-6, `node --check src/canvas_chat/static/js/app.js` must pass. All existing plugin files must load without errors when the adapter is active.
+
+## Deployment Specifications
+
+### [ ] DEP-REQ-001: Deployed App Serves Svelte Bundle
+
+**Location**: `modal_app.py`, production URL
+
+When the app is deployed to the production Modal URL, a GET request to `/` MUST return HTML containing a `<script>` tag referencing `svelte-dist/assets/index-`. A GET request to `/health` MUST return HTTP 200.
+
+**Test**: Deploy to production, GET `/`, assert response HTML contains `svelte-dist/assets/index-`. GET `/health` returns 200.
+
+### [ ] DEP-REQ-002: pip Wheel Contains Built Assets
+
+**Location**: `pyproject.toml` (hatchling config)
+
+When the Python wheel is built (`python -m build`), the wheel MUST contain the directory `canvas_chat/static/svelte-dist/assets/` with at least one `.js` file. The wheel MUST NOT require Node.js as an install dependency.
+
+**Test**: Build wheel, extract it, assert `canvas_chat/static/svelte-dist/assets/index-*.js` exists. Assert `package.json` is not in the wheel's `requires-dist` metadata.
+
+### [ ] DEP-REQ-003: canvas-chat Launch Serves App
+
+**Location**: `__main__.py`
+
+When `canvas-chat launch` is executed, the CLI MUST start a server that responds to GET `/` with HTTP 200 and HTML content. The response MUST contain the string `svelte-dist`.
+
+**Test**: Run `canvas-chat launch --port 9876`, GET `http://localhost:9876/`, assert HTTP 200 and body contains `svelte-dist`.
+
+## Status Key
+
+- `[ ]` Active requirement
+- `[x]` Implemented requirement
+- `[D]` Deferred requirement

--- a/docs/specs/feature-plugins-specs.md
+++ b/docs/specs/feature-plugins-specs.md
@@ -1,0 +1,239 @@
+# Feature Plugins Specifications
+
+**Created**: 2026-03-16
+**Status**: Active
+**HLD**: [High-Level Design](../high-level-design.md)
+
+## Committee Feature
+
+### [x] COMM-REQ-001: Multi-LLM Query
+
+**Location**: `committee.js`
+
+The system MUST allow users to query multiple LLM models in parallel via the `/committee` command. Users MUST be able to select which models to include.
+
+### [x] COMM-REQ-002: Opinion Nodes
+
+**Location**: `committee.js`
+
+Each model response MUST be displayed as a separate `opinion` node. Opinion nodes MUST show which model generated the response.
+
+### [x] COMM-REQ-003: Optional Review
+
+**Location**: `committee.js`
+
+The system MAY generate `review` nodes where each model critiques the other models' responses.
+
+### [x] COMM-REQ-004: Synthesis Node
+
+**Location**: `committee.js`
+
+The system MUST generate a `synthesis` node containing a summary that combines insights from all models. A chairman model MUST be used for synthesis.
+
+### [x] COMM-REQ-005: Streaming
+
+**Location**: `committee.js`, `streaming-manager.js`
+
+All opinion, review, and synthesis responses MUST stream in real-time. The stop/continue button MUST work for each phase.
+
+## Research Feature
+
+### [x] RSCH-REQ-001: Web Search
+
+**Location**: `research.js`
+
+The system MUST provide `/search` command for quick web lookups. Search results MUST be displayed as reference nodes.
+
+### [x] RSCH-REQ-002: Deep Research
+
+**Location**: `research.js`
+
+The system MUST provide `/research` command for deep research. Research MUST iterate through sources and synthesize findings.
+
+### [x] RSCH-REQ-003: Dual Provider
+
+**Location**: `research.js`, `app.py`
+
+The system MUST use Exa API when available, falling back to DuckDuckGo when no Exa key is configured.
+
+### [x] RSCH-REQ-004: Query Refinement
+
+**Location**: `research.js`
+
+When context is selected, the system MUST refine the search query using the LLM before executing the search.
+
+## Code Feature
+
+### [x] CODE-REQ-001: Python Execution
+
+**Location**: `plugins/code.js`, `pyodide-runner.js`
+
+The system MUST execute Python code in the browser using Pyodide. Execution MUST capture stdout, return values, and matplotlib figures.
+
+### [x] CODE-REQ-002: Code Editor
+
+**Location**: `modal-manager.js`
+
+The system MUST provide a code editor modal with syntax highlighting for editing code nodes.
+
+### [x] CODE-REQ-003: Code Generation
+
+**Location**: `plugins/code.js`
+
+The system MUST generate Python code via LLM when user clicks "Generate". The generated code MUST be inserted into the editor.
+
+### [x] CODE-REQ-004: Self-Healing
+
+**Location**: `plugins/code.js`
+
+When code execution fails, the system MUST automatically attempt to fix the error up to 3 times using the LLM.
+
+### [x] CODE-REQ-005: DataFrame Integration
+
+**Location**: `plugins/code.js`
+
+When code nodes are created from CSV/Excel/Prism nodes, the csvData MUST be pre-loaded as a DataFrame variable.
+
+## Factcheck Feature
+
+### [x] FACT-REQ-001: Claim Extraction
+
+**Location**: `factcheck.js`
+
+The system MUST extract factual claims from selected text using the LLM. Extracted claims MUST be presented for user confirmation.
+
+### [x] FACT-REQ-002: Web Verification
+
+**Location**: `factcheck.js`
+
+For each confirmed claim, the system MUST search the web for verification. Results MUST be displayed as sources.
+
+### [x] FACT-REQ-003: Verdict
+
+**Location**: `factcheck.js`
+
+The system MUST generate a verdict (VERIFIED, PARTIALLY_TRUE, MISLEADING, FALSE, UNVERIFIABLE) for each claim with explanation and source citations.
+
+### [x] FACT-REQ-004: Fallback Search
+
+**Location**: `factcheck.js`
+
+When Exa is unavailable, the system MUST fall back to DuckDuckGo for web verification.
+
+## Flashcards Feature
+
+### [x] FLAS-REQ-001: Generate Flashcards
+
+**Location**: `flashcards.js`
+
+The system MUST generate flashcards from selected content using the LLM. Generated cards MUST be reviewable immediately.
+
+### [x] FLAS-REQ-002: SM-2 Algorithm
+
+**Location**: `utils.js`
+
+The system MUST implement the SM-2 spaced repetition algorithm for scheduling reviews. Quality ratings (0-5) MUST adjust review intervals.
+
+### [x] FLAS-REQ-003: Due Card Detection
+
+**Location**: `utils.js`
+
+On app load, the system MUST detect flashcards that are due for review and show a notification.
+
+### [x] FLAS-REQ-004: Review Modal
+
+**Location**: `flashcards.js`
+
+The system MUST provide a review modal showing the question, allowing the user to reveal the answer, and prompting for a quality rating.
+
+## Matrix Feature
+
+### [x] MAT-REQ-001: Create Matrix
+
+**Location**: `matrix.js`
+
+The system MUST allow users to create a matrix with specified rows and columns via `/matrix` command or modal.
+
+### [x] MAT-REQ-002: Fill Cell
+
+**Location**: `matrix.js`
+
+The system MUST allow users to fill individual cells using the LLM. The LLM MUST have context from related nodes.
+
+### [x] MAT-REQ-003: Fill All
+
+**Location**: `matrix.js`
+
+The system MUST allow users to fill all empty cells in parallel using the LLM.
+
+### [x] MAT-REQ-004: Extract Row/Column
+
+**Location**: `matrix.js`
+
+The system MUST allow users to extract a row or column as a new node on the canvas.
+
+## URL Fetch Feature
+
+### [x] URL-REQ-001: Fetch URL
+
+**Location**: `url-fetch.js`
+
+The system MUST provide `/fetch` command to fetch URL content. Fetched content MUST be converted to markdown.
+
+### [x] URL-REQ-002: Specialized Handlers
+
+**Location**: `url-fetch.js`
+
+The system MUST have specialized handlers for YouTube, GitHub, and PDF URLs with enhanced parsing.
+
+### [x] URL-REQ-003: Generic Fallback
+
+**Location**: `url-fetch.js`
+
+For URLs without specialized handlers, the system MUST use Jina Reader or direct fetch with html2text conversion.
+
+## Image Generation Feature
+
+### [x] IMG-REQ-001: Generate Image
+
+**Location**: `image-generation.js`
+
+The system MUST provide `/image` command to generate images via DALL-E, Gemini, or Ollama.
+
+### [x] IMG-REQ-002: Provider Selection
+
+**Location**: `image-generation.js`
+
+Users MUST be able to select which image generation provider to use in settings.
+
+### [x] IMG-REQ-003: Display Image
+
+**Location**: `image-generation.js`
+
+Generated images MUST be displayed in an ImageNode with the prompt stored for reference.
+
+## HTML Slides Feature
+
+### [x] SLID-REQ-001: Create Slides
+
+**Location**: `html-slides.js`
+
+The system MUST provide `/slides` command to create HTML slide presentations. Users MUST be able to paste HTML or generate from prompt.
+
+### [x] SLID-REQ-002: Slide Navigation
+
+**Location**: `html-slides.js`
+
+The system MUST provide Prev/Next buttons and keyboard navigation (Space, Arrow keys) for slides.
+
+### [x] SLID-REQ-003: Blob Embedding
+
+**Location**: `html-slides.js`
+
+HTML slides MUST be embedded via Blob URL for self-contained presentations without external dependencies.
+
+## Status Key
+
+- `[ ]` Active requirement
+- `[x]` Implemented requirement
+- `[D]` Deferred requirement

--- a/docs/specs/instant-ai-response-specs.md
+++ b/docs/specs/instant-ai-response-specs.md
@@ -1,0 +1,172 @@
+# Instant AI Response Specifications
+
+**Created**: 2026-03-18
+**Status**: Active
+**HLD**: [High-Level Design](../high-level-design.md) (Section 4.6)
+**LLD**: [Instant AI Response LLD](../llds/instant-ai-response.md)
+
+## Feature Overview
+
+Instant AI Response (also called "Copilot Mode") provides real-time AI suggestions as users type in the chat input. When enabled with valid API keys, the system displays a "ghost" AI node that streams suggestions, which users can accept with Tab or ignore by continuing to type.
+
+## Status Key
+
+- `[ ]` Active requirement
+- `[x]` Implemented requirement
+- `[D]` Deferred requirement
+
+---
+
+## Feature Toggle Specifications
+
+### [ ] INST-UI-001
+
+When the user navigates to Settings, the system SHALL display an "Instant AI Response" section with a toggle switch.
+
+### [ ] INST-UI-002
+
+When the user enables the toggle, the system SHALL save the preference to localStorage.
+
+### [ ] INST-UI-003
+
+When the user disables the toggle, the system SHALL immediately cancel any pending suggestion and reset to IDLE state.
+
+---
+
+## Debouncing Specifications
+
+### [ ] INST-CTL-001
+
+When the user types in the chat input, the system SHALL wait 500ms (debounce delay) after the last keystroke before triggering a suggestion request.
+
+### [ ] INST-CTL-002
+
+When the user types fewer than 10 characters, the system SHALL NOT trigger a suggestion request.
+
+### [ ] INST-CTL-003
+
+When the user continues typing while a suggestion is streaming, the system SHALL cancel the current streaming request and start a new debounce timer.
+
+### [ ] INST-CTL-004
+
+When the user clears the chat input completely, the system SHALL cancel any pending suggestion and reset to IDLE state.
+
+---
+
+## Ghost Node Specifications
+
+### [ ] INST-NODE-001
+
+When a suggestion request is triggered, the system SHALL create a ghost AI node on the canvas with 50% opacity and dashed border styling.
+
+### [ ] INST-NODE-002
+
+When the system receives streaming tokens from the LLM, the system SHALL update the ghost node content in real-time.
+
+### [ ] INST-NODE-003
+
+When the suggestion is accepted (Tab pressed), the system SHALL convert the ghost node to a regular AI node with full opacity and solid border.
+
+### [ ] INST-NODE-004
+
+When the suggestion is cancelled (Escape pressed), the system SHALL remove the ghost node from the canvas and cancel any ongoing streaming.
+
+### [ ] INST-NODE-005
+
+When the suggestion is superseded (user continues typing), the system SHALL finalize the ghost node as a real AI node and begin a new suggestion.
+
+---
+
+## Acceptance Interaction Specifications
+
+### [ ] INST-KEY-001
+
+When the user presses the Tab key while a ghost node is streaming, the system SHALL finalize the suggestion as a real AI node.
+
+### [ ] INST-KEY-002
+
+When the user presses the Escape key while a ghost node is streaming, the system SHALL cancel the suggestion and remove the ghost node.
+
+### [ ] INST-KEY-003
+
+When the user presses Enter before any suggestion is triggered, the system SHALL treat the input as a normal message send (existing behavior).
+
+### [ ] INST-KEY-004
+
+When the user presses Enter while a ghost node is streaming, the system SHALL accept the current suggestion and also finalize the human message.
+
+---
+
+## Context Building Specifications
+
+### [ ] INST-CTX-001
+
+When building context for a suggestion request, the system SHALL include the conversation history from selected parent nodes.
+
+### [ ] INST-CTX-002
+
+When building context for a suggestion request, the system SHALL include the user's current typed input as the final message.
+
+### [ ] INST-CTX-003
+
+When no parent nodes are selected, the system SHALL build context from the most recent conversation branch.
+
+---
+
+## Error Handling Specifications
+
+### [ ] INST-ERR-001
+
+When the suggestion request fails due to network error, the system SHALL remove the ghost node and show a subtle error indicator on the chat input.
+
+### [ ] INST-ERR-002
+
+When the suggestion request fails due to authentication error, the system SHALL remove the ghost node and show a toast notification directing user to Settings.
+
+### [ ] INST-ERR-003
+
+When the LLM response exceeds 2000 tokens, the system SHALL truncate the response at 2000 tokens and show "..." indicator.
+
+---
+
+## API Key Validation Specifications
+
+### [ ] INST-AUTH-001
+
+When Instant AI is enabled but no API keys are configured, the system SHALL show a toast notification on first typing attempt.
+
+### [ ] INST-AUTH-002
+
+When the configured API key becomes invalid, the system SHALL show an authentication error toast and fall back to traditional send mode.
+
+---
+
+## Slash Command Specifications
+
+### [ ] INST-SLASH-001
+
+When the user types `/instant`, the system SHALL toggle the Instant AI Response feature on/off.
+
+### [ ] INST-SLASH-002
+
+When the user types `/instant on`, the system SHALL enable Instant AI Response.
+
+### [ ] INST-SLASH-003
+
+When the user types `/instant off`, the system SHALL disable Instant AI Response.
+
+---
+
+## Settings Persistence Specifications
+
+### [ ] INST-PERSIST-001
+
+The system SHALL persist the Instant AI enabled/disabled state to localStorage.
+
+### [ ] INST-PERSIST-002
+
+The system SHALL persist the selected model for Instant AI to localStorage.
+
+### [ ] INST-PERSIST-003
+
+The system SHALL load the Instant AI preferences from localStorage on application startup.

--- a/docs/specs/node-types-specs.md
+++ b/docs/specs/node-types-specs.md
@@ -1,0 +1,185 @@
+# Node Types Specifications
+
+**Created**: 2026-03-16
+**Status**: Active
+**HLD**: [High-Level Design](../high-level-design.md)
+
+## Node Type Requirements
+
+### [x] NODE-REQ-001: Human Node
+
+**Location**: `graph-types.js`
+
+The system MUST provide a `human` node type for user messages. Human nodes MUST display the message content with a person icon.
+
+### [x] NODE-REQ-002: AI Node
+
+**Location**: `graph-types.js`
+
+The system MUST provide an `ai` node type for LLM responses. AI nodes MUST display the response content with a bot icon and model name.
+
+### [x] NODE-REQ-003: Note Node
+
+**Location**: `graph-types.js`
+
+The system MUST provide a `note` node type for static content. Note nodes MUST be editable and support markdown rendering.
+
+### [x] NODE-REQ-004: Reference Node
+
+**Location**: `graph-types.js`
+
+The system MUST provide a `reference` node type for external URLs. Reference nodes MUST display the URL title and a link.
+
+### [x] NODE-REQ-005: Search Node
+
+**Location**: `graph-types.js`
+
+The system MUST provide a `search` node type for search results. Search nodes MUST display the query and list of results with links.
+
+### [x] NODE-REQ-006: Matrix Node
+
+**Location**: `plugins/matrix.js`
+
+The system MUST provide a `matrix` node type for evaluation tables. Matrix nodes MUST display rows and columns with editable cells. Cells MUST be fillable via LLM.
+
+### [x] NODE-REQ-007: Code Node
+
+**Location**: `plugins/code.js`, `pyodide-runner.js`
+
+The system MUST provide a `code` node type for executable Python. Code nodes MUST include a code editor and output panel. Execution MUST use Pyodide in the browser.
+
+### [x] NODE-REQ-008: PDF Node
+
+**Location**: `plugins/pdf-node.js`
+
+The system MUST provide a `pdf` node type for PDF viewing. PDF nodes MUST render pages and support pagination (Prev/Next).
+
+### [x] NODE-REQ-009: Image Node
+
+**Location**: `graph-types.js`
+
+The system MUST provide an `image` node type for images. Image nodes MUST display the image at proper aspect ratio.
+
+### [x] NODE-REQ-010: YouTube Node
+
+**Location**: `plugins/youtube.js`
+
+The system MUST provide a `youtube` node type for YouTube videos. YouTube nodes MUST display the video player and transcript.
+
+### [x] NODE-REQ-011: Flashcard Node
+
+**Location**: `flashcards.js`
+
+The system MUST provide a `flashcard` node type for spaced repetition. Flashcard nodes MUST display question and answer with flip interaction.
+
+### [x] NODE-REQ-012: Committee Node
+
+**Location**: `plugins/committee.js`
+
+The system MUST provide `opinion`, `review`, and `synthesis` node types for multi-LLM consultation. These nodes MUST display responses from multiple models.
+
+### [x] NODE-REQ-013: Factcheck Node
+
+**Location**: `plugins/factcheck.js`
+
+The system MUST provide a `factcheck` node type for claim verification. Factcheck nodes MUST display claims, verdicts, and source links.
+
+### [x] NODE-REQ-014: PowerPoint Node
+
+**Location**: `powerpoint-node.js`
+
+The system MUST provide a `powerpoint` node type for presentations. PowerPoint nodes MUST display slides with navigation.
+
+### [x] NODE-REQ-015: GitHub Node
+
+**Location**: `plugins/git-repo.js`
+
+The system MUST provide a `git_repo` node type for GitHub repositories. GitHub nodes MUST display file tree and content.
+
+### [x] NODE-REQ-016: Data Import Nodes
+
+**Location**: `plugins/csv-node.js`, `plugins/excel-node.js`, `plugins/prism-node.js`
+
+The system MUST provide `csv`, `excel`, and `prism` node types for data import. These nodes MUST provide csvData for /code integration.
+
+### [x] NODE-REQ-017: HTML Slides Node
+
+**Location**: `html-slides.js`
+
+The system MUST provide an `html_slides` node type for HTML presentations. HTML slides nodes MUST support Prev/Next navigation.
+
+### [x] NODE-REQ-018: Research Node
+
+**Location**: `plugins/research.js`
+
+The system MUST provide a `research` node type for deep research. Research nodes MUST display synthesized findings and sources.
+
+## Edge Type Requirements
+
+### [x] EDGE-REQ-001: Reply Edge
+
+**Location**: `graph-types.js`
+
+The system MUST provide a `reply` edge type connecting AI responses to the human message they respond to.
+
+### [x] EDGE-REQ-002: Branch Edge
+
+**Location**: `graph-types.js`
+
+The system MUST provide a `branch` edge type connecting branched conversations to their origin text.
+
+### [x] EDGE-REQ-003: Reference Edge
+
+**Location**: `graph-types.js`
+
+The system MUST provide a `reference` edge type connecting reference nodes to their source content.
+
+### [x] EDGE-REQ-004: Generate Edge
+
+**Location**: `graph-types.js`
+
+The system MUST provide a `generates` edge type connecting source content to derived content (e.g., flashcards from notes).
+
+## Node Protocol Requirements
+
+### [x] PROT-REQ-001: getTypeLabel
+
+**Location**: `node-protocols.js`
+
+All node types MUST implement `getTypeLabel()` returning a human-readable type name.
+
+### [x] PROT-REQ-002: getTypeIcon
+
+**Location**: `node-protocols.js`
+
+All node types MUST implement `getTypeIcon()` returning an emoji or icon identifier.
+
+### [x] PROT-REQ-003: getSummaryText
+
+**Location**: `node-protocols.js`
+
+All node types MUST implement `getSummaryText()` returning text for semantic zoom summary view.
+
+### [x] PROT-REQ-004: renderContent
+
+**Location**: `node-protocols.js`
+
+All node types MUST implement `renderContent()` returning HTML string for node display.
+
+### [x] PROT-REQ-005: getActions
+
+**Location**: `node-protocols.js`
+
+All node types MUST implement `getActions()` returning array of available actions (copy, edit, delete, etc.).
+
+### [x] PROT-REQ-006: isContentEditable
+
+**Location**: `node-protocols.js`
+
+Node types MAY implement `isContentEditable()` returning false to disable editing. Default is true.
+
+## Status Key
+
+- `[ ]` Active requirement
+- `[x]` Implemented requirement
+- `[D]` Deferred requirement

--- a/src/canvas_chat/static/js/app.js
+++ b/src/canvas_chat/static/js/app.js
@@ -298,7 +298,7 @@ class App {
     }
 
     /**
-     *
+     * @spec CHAT-REQ-008
      */
     async loadModels() {
         // In admin mode, use admin-configured models
@@ -321,6 +321,7 @@ class App {
         ];
 
         // Fetch models from all providers in parallel
+        // @spec CHAT-REQ-021
         const fetchPromises = providers
             .filter((p) => p.key) // Only providers with keys
             .map((p) => chat.fetchProviderModels(p.name, p.key));
@@ -753,12 +754,15 @@ class App {
         document.getElementById('save-settings-btn').addEventListener('click', () => {
             this.saveSettings();
         });
-        document.getElementById('settings-modal')?.querySelector('.settings-sidebar')?.addEventListener('click', (e) => {
-            const item = e.target.closest('.settings-sidebar-item');
-            if (item && !item.classList.contains('admin-hidden')) {
-                this.modalManager.setSettingsCategory(item.dataset.category);
-            }
-        });
+        document
+            .getElementById('settings-modal')
+            ?.querySelector('.settings-sidebar')
+            ?.addEventListener('click', (e) => {
+                const item = e.target.closest('.settings-sidebar-item');
+                if (item && !item.classList.contains('admin-hidden')) {
+                    this.modalManager.setSettingsCategory(item.dataset.category);
+                }
+            });
 
         document.getElementById('copilot-auth-start').addEventListener('click', () => {
             this.modalManager.startCopilotAuth();
@@ -1278,7 +1282,7 @@ class App {
     }
 
     /**
-     *
+     * @spec CHAT-REQ-001
      */
     async handleSend() {
         const content = this.chatInput.value.trim();
@@ -1324,6 +1328,7 @@ class App {
         // Get selected nodes - if none selected, create a new root node
         let parentIds = this.canvas.getSelectedNodeIds();
 
+        // @spec CHAT-REQ-012
         // Create human node
         const humanNode = createNode(NodeType.HUMAN, content, {
             position: this.graph.autoPosition(parentIds.length > 0 ? parentIds : []),
@@ -1387,6 +1392,7 @@ class App {
             messages,
             model,
             // onChunk
+            // @spec CHAT-REQ-014
             (chunk, fullContent) => {
                 this.canvas.updateNodeContent(aiNode.id, fullContent, true);
                 this.graph.updateNode(aiNode.id, { content: fullContent });
@@ -1420,6 +1426,7 @@ class App {
      * Use this for "add one node and show it" flows (chat, summarize, image extract, etc.).
      * For multiple nodes or when focus is not needed, use graph.addNode() and call
      * canvas.zoomToSelectionAnimated(nodeIds) or canvas.panToNodeAnimated(nodeId) when you want focus.
+     * @spec CHAT-REQ-004
      * @param {Object} node - The node to add
      */
     addUserNode(node) {

--- a/src/canvas_chat/static/js/canvas.js
+++ b/src/canvas_chat/static/js/canvas.js
@@ -30,6 +30,7 @@ class Canvas {
         // Viewport state
         this.viewBox = { x: 0, y: 0, width: 1000, height: 800 };
         this.scale = 1;
+        // @spec CANV-REQ-003: Zoom MUST be constrained between 0.1 and 3.0
         this.minScale = 0.1;
         this.maxScale = 3;
 
@@ -723,8 +724,7 @@ class Canvas {
             return;
         }
 
-        const parentElement =
-            anchorNode.nodeType === Node.TEXT_NODE ? anchorNode.parentElement : anchorNode;
+        const parentElement = anchorNode.nodeType === Node.TEXT_NODE ? anchorNode.parentElement : anchorNode;
         let nodeContent = parentElement?.closest('.node-content');
         let nodeId = null;
 
@@ -753,7 +753,6 @@ class Canvas {
 
         this.showBranchTooltip(tooltipX, tooltipY);
     }
-
 
     // --- PDF Drag & Drop Handlers ---
 
@@ -1858,6 +1857,7 @@ class Canvas {
 
     /**
      * Render a node to the canvas
+     * @spec CANV-REQ-001
      * @param {Object} node
      * @returns {void}
      */
@@ -3214,6 +3214,7 @@ class Canvas {
     }
 
     /**
+     * @spec CHAT-REQ-014
      * Update node content (for streaming)
      * @param nodeId
      * @param content
@@ -3858,6 +3859,7 @@ class Canvas {
     // --- Edge Rendering ---
 
     /**
+     * @spec CANV-REQ-005
      * Render an edge as a bezier curve.
      * Supports two signatures:
      * 1. renderEdge(edge, graph) - Automatically fetches fresh positions (Recommended)

--- a/src/canvas_chat/static/js/crdt-graph.js
+++ b/src/canvas_chat/static/js/crdt-graph.js
@@ -118,6 +118,7 @@ class CRDTGraph extends EventEmitter {
      * Create a new CRDT-backed graph
      * @param {string} sessionId - Unique session identifier for persistence
      * @param {Object} legacyData - Legacy data to load (nodes, edges, tags)
+     * @spec GRPH-REQ-001
      */
     constructor(sessionId = null, legacyData = {}) {
         // Call EventEmitter constructor
@@ -562,17 +563,17 @@ class CRDTGraph extends EventEmitter {
                 const yTags = new Y.Array();
                 yTags.push(value);
                 yNode.set('tags', yTags);
-                } else if (key === 'cells' && value) {
-                    // Matrix cells - store as Y.Map
-                    const yCells = new Y.Map();
-                    for (const [cellKey, cellValue] of Object.entries(value)) {
-                        const yCell = new Y.Map();
-                        yCell.set('content', cellValue.content);
-                        yCell.set('filled', cellValue.filled || false);
-                        yCell.set('filling', cellValue.filling || false);
-                        yCells.set(cellKey, yCell);
-                    }
-                    yNode.set('cells', yCells);
+            } else if (key === 'cells' && value) {
+                // Matrix cells - store as Y.Map
+                const yCells = new Y.Map();
+                for (const [cellKey, cellValue] of Object.entries(value)) {
+                    const yCell = new Y.Map();
+                    yCell.set('content', cellValue.content);
+                    yCell.set('filled', cellValue.filled || false);
+                    yCell.set('filling', cellValue.filling || false);
+                    yCells.set(cellKey, yCell);
+                }
+                yNode.set('cells', yCells);
             } else if (key === 'metadata' && value && typeof value === 'object') {
                 // Metadata object - store as Y.Map to preserve nested properties
                 const yMetadata = new Y.Map();
@@ -1431,9 +1432,7 @@ class CRDTGraph extends EventEmitter {
         if (cellEntries.length) parts.push('Cells:\n' + cellEntries.join('\n'));
         const results = node.webSearchResults || [];
         if (results.length > 0) {
-            const sourceLines = results.map(
-                (r, i) => `[${i + 1}] ${r.title || ''} (${r.url || ''})`
-            );
+            const sourceLines = results.map((r, i) => `[${i + 1}] ${r.title || ''} (${r.url || ''})`);
             parts.push('Web sources:\n' + sourceLines.join('\n'));
         }
         return parts.join('\n\n').trim() || '';
@@ -1476,8 +1475,7 @@ class CRDTGraph extends EventEmitter {
             NodeType.GIT_REPO,
         ];
         return sorted.map((node) => {
-            const content =
-                node.type === NodeType.MATRIX ? this.getMatrixContextString(node) : node.content;
+            const content = node.type === NodeType.MATRIX ? this.getMatrixContextString(node) : node.content;
             const msg = {
                 role: userTypes.includes(node.type) ? 'user' : 'assistant',
                 content: content || '',

--- a/src/canvas_chat/static/js/feature-registry.js
+++ b/src/canvas_chat/static/js/feature-registry.js
@@ -229,6 +229,7 @@ class FeatureRegistry {
     }
 
     /**
+     * @spec PLUG-REQ-001
      * Register a feature plugin
      * @param {Object} config - Feature configuration
      * @param {string} config.id - Unique feature identifier

--- a/src/canvas_chat/static/js/sse.js
+++ b/src/canvas_chat/static/js/sse.js
@@ -31,6 +31,7 @@ function normalizeText(text) {
 }
 
 /**
+ * @spec CHAT-REQ-002
  * Create an SSE stream reader that handles buffering and parsing
  *
  * @param {Response} response - Fetch response with SSE body

--- a/src/canvas_chat/static/js/storage.js
+++ b/src/canvas_chat/static/js/storage.js
@@ -296,6 +296,7 @@ class Storage {
     /**
      * Save API keys to localStorage
      * @param keys
+     * @spec CHAT-REQ-007
      */
     saveApiKeys(keys) {
         localStorage.setItem('canvas-chat-api-keys', JSON.stringify(keys));
@@ -528,6 +529,7 @@ class Storage {
     /**
      * Save the currently selected model
      * @param model
+     * @spec CHAT-REQ-006
      */
     setCurrentModel(model) {
         localStorage.setItem('canvas-chat-model', model);

--- a/src/canvas_chat/static/js/streaming-manager.js
+++ b/src/canvas_chat/static/js/streaming-manager.js
@@ -207,6 +207,7 @@ class StreamingManager {
     /**
      * Stop streaming for a node.
      * Handles both individual nodes and grouped nodes (stops entire group).
+     * @spec CHAT-REQ-003
      *
      * @param {string} nodeId - The node to stop
      * @returns {boolean} True if stop was successful
@@ -299,6 +300,7 @@ class StreamingManager {
 
     /**
      * Continue streaming for a stopped node.
+     * @spec CHAT-REQ-003
      *
      * @param {string} nodeId - The node to continue
      * @returns {Promise<boolean>} True if continue was successful


### PR DESCRIPTION
## Summary

Comprehensive EARS specs and code annotations for core chat and model loading functionality.

## Changes Breakdown

### Specs Renumbering
- **core-specs.md**: CHAT specs now sequential (001-025)
- **backend-api-specs.md**: API specs now sequential (001-020)

### New/Updated Specs
- Added CHAT-REQ-018 through 025 for API key → model loading flow
- Added instant-ai-response specs and LLD (new feature)
- Added model-loading.md LLD documenting the magic model pop-in

### Code Annotations (@spec tags)
Added to 15 key implementation locations:
- CHAT-REQ-001: app.js:handleSend()
- CHAT-REQ-002: sse.js:readSSEStream()
- CHAT-REQ-003: streaming-manager.js:stop(), continue()
- CHAT-REQ-004: app.js:addUserNode()
- CHAT-REQ-006: storage.js:setCurrentModel()
- CHAT-REQ-007: storage.js:saveApiKeys()
- CHAT-REQ-008: app.js:loadModels()
- CHAT-REQ-012: app.js (node creation)
- CHAT-REQ-014: app.js + canvas.js (updateNodeContent)
- CHAT-REQ-021: app.js (provider filter)
- CANV-REQ-001: canvas.js (node rendering)
- CANV-REQ-003: canvas.js (zoom constraints)
- CANV-REQ-005: canvas.js:renderEdge()
- GRPH-REQ-001: crdt-graph.js (constructor)
- PLUG-REQ-001: feature-registry.js:register()

### Documentation Fixes
- Added EARS syncing workflow to AGENTS.md
- Fixed markdownlint errors across all LLD/spec/planning files

## Tests

```bash
pixi run test      # Python tests
pixi run test-js   # JavaScript tests
```
