### PR TITLE
chore(deps): cap litellm below 1.82.7

### DIFF
--- a/modal_app.py
+++ b/modal_app.py
@@ -28,7 +28,7 @@ image = (
     .pip_install(
         "fastapi[standard]>=0.115.0",
         "uvicorn>=0.32.0",
-        "litellm>=1.50.0",
+        "litellm>=1.50.0,<1.82.7",
         "sse-starlette>=2.0.0",
         "pydantic>=2.0.0",
         "exa-py>=1.0.0",

--- a/pixi.lock
+++ b/pixi.lock
@@ -2655,11 +2655,11 @@ packages:
 - pypi: ./
   name: canvas-chat
   version: 0.1.107
-  sha256: 50cbc52c7bdfe5cbe022359575099bcf9b1c1155bd404528ca2b44fa7d0afacb
+  sha256: 120bca4bdfe18ba193783498a2bb578198100dadd46c3cd0284e45eb53e3d6fa
   requires_dist:
   - fastapi>=0.115.0
   - uvicorn>=0.32.0
-  - litellm>=1.50.0
+  - litellm>=1.50.0,<1.82.7
   - llamabot>=0.17.0
   - pydantic>=2.0.0
   - sse-starlette>=2.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.11"
 dependencies = [
     "fastapi>=0.115.0",
     "uvicorn>=0.32.0",
-    "litellm>=1.50.0",
+    "litellm>=1.50.0,<1.82.7",
     "llamabot>=0.17.0",
     "pydantic>=2.0.0",
     "sse-starlette>=2.0.0", "exa-py>=2.0.2,<3", "modal>=1.3.0.post1,<2", "httpx>=0.28.1,<0.29", "pytest>=9.0.2,<10", "build>=1.3.0,<2", "html2text>=2025.4.15,<2026",

--- a/src/canvas_chat/app.py
+++ b/src/canvas_chat/app.py
@@ -2,7 +2,7 @@
 # dependencies = [
 #     "fastapi>=0.115.0",
 #     "uvicorn>=0.32.0",
-#     "litellm>=1.50.0",
+#     "litellm>=1.50.0,<1.82.7",
 #     "sse-starlette>=2.0.0",
 #     "pydantic>=2.0.0",
 #     "exa-py>=1.0.0",


### PR DESCRIPTION
## Summary

Caps **litellm** at **1.82.6** by requiring `>=1.50.0,<1.82.7` everywhere the project declares the dependency.

## Changes

- **`pyproject.toml`** — project dependency constraint
- **`modal_app.py`** — Modal image `pip_install` matches the same range
- **`src/canvas_chat/app.py`** — PEP 723 script comment kept in sync
- **`pixi.lock`** — regenerated with `pixi lock`

## Tests

- `pixi run test` — 139 passed (before commit)
