### PR TITLE
feat: llamabot backend proxy, DDG research refactor, research activity drawer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,7 +126,8 @@ canvas-chat/
 | `src/canvas_chat/static/js/committee.js`               | CommitteeFeature class             | Multi-LLM consultation, synthesis                                                   |
 | `src/canvas_chat/static/js/matrix.js`                  | MatrixFeature class                | Comparison matrix creation, cell filling                                            |
 | `src/canvas_chat/static/js/factcheck.js`               | FactcheckFeature class             | Claim verification, web search integration                                          |
-| `src/canvas_chat/static/js/research.js`                | ResearchFeature class              | Deep research with Exa API                                                          |
+| `src/canvas_chat/static/js/plugins/research.js`        | ResearchFeature class              | `/research`, `/search`; DDG/Exa SSE; activity log in ResearchNode output panel       |
+| `src/canvas_chat/static/js/plugins/research-node.js`   | ResearchNode protocol              | Research node header/actions; bottom drawer shows streaming research activity lines  |
 | `src/canvas_chat/static/js/code-feature.js`            | CodeFeature class                  | Self-healing code execution                                                         |
 | `src/canvas_chat/static/js/plugins/git-repo.js`        | GitRepoFeature class               | Git repository fetching with file selection (`/git` command)                        |
 | `src/canvas_chat/static/js/plugins/youtube.js`         | YouTubeFeature class               | YouTube video fetching with transcript (`/youtube` command)                         |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,12 +36,21 @@ This includes:
 - 2026-01-24: Removed TypeScript type checking from pre-commit hooks and pixi tasks. Project uses plain JavaScript with JSDoc annotations for documentation only, not strict type checking.
 - 2026-01-25: Consolidated `/code` command handling into CodeFeature plugin. All code node operations (`handleCode`, `handleNodeRunCode`, `handleNodeGenerate`, `handleNodeGenerateSubmit`, `gatherCodeGenerationContext`) have been moved from app.js to plugins/code.js. App.js now delegates to CodeFeature via canvas events (`nodeRunCode`, `nodeGenerate`, etc.).
 - 2026-03-15: Always use `encoding="utf-8"` when calling `read_text()`. On Windows, the default encoding is cp1252 which causes UnicodeDecodeError when reading UTF-8 files.
+- 2026-03-28: LLM backend migration (LiteLLM → llamabot) design lives under `docs/designs/llamabot-backend-proxy/` (LLD + EARS), linked from HLD and `docs/llds/backend-llm-proxy.md`. PocketFlow is not part of that plan.
 
 **Python commands:** Use `pixi run python` when running project Python commands so the pixi environment and dependencies are active.
 
 ## Codebase map
 
 Quick reference for which files to edit for common tasks.
+
+### Design documents (LLM backend migration)
+
+| Location | Purpose |
+| -------- | ------- |
+| [`docs/designs/llamabot-backend-proxy/LLD.md`](docs/designs/llamabot-backend-proxy/LLD.md) | Low-level design: llamabot SimpleBot/StructuredBot adapter; LiteLLM retained for images, token count, Copilot model list |
+| [`docs/designs/llamabot-backend-proxy/llm-proxy-EARS.md`](docs/designs/llamabot-backend-proxy/llm-proxy-EARS.md) | EARS requirements for API parity and bot usage |
+| [`docs/llds/backend-llm-proxy.md`](docs/llds/backend-llm-proxy.md) | Narrative LLM proxy + links to the LLD |
 
 ### Directory structure
 
@@ -257,6 +266,7 @@ Quick reference guide for finding the right documentation based on what you need
 | **Breadcrumb graph context (EARS / traceability)**        | [breadcrumb-nav-specs.md](docs/specs/breadcrumb-nav-specs.md)           | Requirements for parent › current › child bar and hover preview |
 | **Why is the plugin system designed this way?**           | [plugin-architecture.md](docs/explanation/plugin-architecture.md)       | Design rationale for three-level plugin architecture        |
 | **How does streaming work?**                              | [streaming-architecture.md](docs/explanation/streaming-architecture.md) | Server-sent events and streaming design                     |
+| **LLM backend (llamabot vs LiteLLM) — LLD + EARS**         | [LLD](docs/designs/llamabot-backend-proxy/LLD.md), [EARS](docs/designs/llamabot-backend-proxy/llm-proxy-EARS.md) | Design-driven migration: SimpleBot/StructuredBot adapter; LiteLLM for images/tokens/Copilot utilities |
 | **How does auto-layout work?**                            | [auto-layout.md](docs/explanation/auto-layout.md)                       | Node positioning and overlap resolution                     |
 | **How does the committee feature work internally?**       | [committee-architecture.md](docs/explanation/committee-architecture.md) | Multi-LLM consultation design                               |
 | **How does matrix evaluation work?**                      | [matrix-evaluation.md](docs/explanation/matrix-evaluation.md)           | Matrix cell filling and evaluation design                   |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -191,7 +191,7 @@ canvas-chat/
 | `src/canvas_chat/plugins/ddg_endpoints.py`      | DuckDuckGo search + research API   | DDG search/research endpoints (fallback when no Exa key); edit for DDG behavior |
 | `src/canvas_chat/plugins/pptx_endpoints.py`     | PPTX API endpoints                 | PPTX caption/title and narrative preset endpoints                               |
 | `src/canvas_chat/plugins/`                      | Python plugin modules              | Backend plugins (matrix_handler, code_handler, etc.)                            |
-| `modal_app.py`                                  | Modal deployment config            | Deployment settings                                                             |
+| `modal_app.py`                                  | Modal deployment config            | `pip_install` list MUST include runtime deps imported by `canvas_chat.app` (e.g. `llamabot`, matching `pyproject.toml`) |
 
 ### Key constants and their locations
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,7 @@ canvas-chat/
 
 | File                                            | Purpose                            | Edit for...                                                                     |
 | ----------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------- |
-| `src/canvas_chat/app.py`                        | FastAPI routes, LLM proxy          | API endpoints, backend logic                                                    |
+| `src/canvas_chat/app.py`                        | FastAPI routes, LLM proxy          | API endpoints; `litellm.acompletion` for SSE; per-request `SimpleBot` / `StructuredBot` (llamabot, `asyncio.to_thread`) + `copilot_extras_for_bot` after `prepare_copilot_openai_request` |
 | `src/canvas_chat/config.py`                     | Configuration management           | Model definitions, plugins, admin mode                                          |
 | `src/canvas_chat/__main__.py`                   | CLI entry point                    | Command-line interface, dev server                                              |
 | `src/canvas_chat/__init__.py`                   | Package initialization             | Package metadata, version                                                       |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ This includes:
 - 2026-01-25: Consolidated `/code` command handling into CodeFeature plugin. All code node operations (`handleCode`, `handleNodeRunCode`, `handleNodeGenerate`, `handleNodeGenerateSubmit`, `gatherCodeGenerationContext`) have been moved from app.js to plugins/code.js. App.js now delegates to CodeFeature via canvas events (`nodeRunCode`, `nodeGenerate`, etc.).
 - 2026-03-15: Always use `encoding="utf-8"` when calling `read_text()`. On Windows, the default encoding is cp1252 which causes UnicodeDecodeError when reading UTF-8 files.
 - 2026-03-28: LLM backend migration (LiteLLM → llamabot) design lives under `docs/designs/llamabot-backend-proxy/` (LLD + EARS), linked from HLD and `docs/llds/backend-llm-proxy.md`. PocketFlow is not part of that plan.
+- 2026-03-28: Pin `llamabot>=0.18.0` in `pyproject.toml` (PyPI includes `AsyncSimpleBot`/`AsyncStructuredBot`). Backend still uses sync bots + `asyncio.to_thread` until migrated.
 
 **Python commands:** Use `pixi run python` when running project Python commands so the pixi environment and dependencies are active.
 
@@ -58,6 +59,7 @@ Quick reference for which files to edit for common tasks.
 canvas-chat/
 ├── src/canvas_chat/          # Main Python package
 │   ├── app.py                # FastAPI backend routes
+│   ├── llm_messages.py       # OpenAI-style dicts → llamabot message tuples
 │   ├── config.py             # Configuration management
 │   ├── __main__.py           # CLI entry point
 │   └── static/               # Frontend assets
@@ -177,7 +179,8 @@ canvas-chat/
 
 | File                                            | Purpose                            | Edit for...                                                                     |
 | ----------------------------------------------- | ---------------------------------- | ------------------------------------------------------------------------------- |
-| `src/canvas_chat/app.py`                        | FastAPI routes, LLM proxy          | API endpoints; `litellm.acompletion` for SSE; per-request `SimpleBot` / `StructuredBot` (llamabot, `asyncio.to_thread`) + `copilot_extras_for_bot` after `prepare_copilot_openai_request` |
+| `src/canvas_chat/app.py`                        | FastAPI routes, LLM proxy          | API endpoints; `run_structured_summarize` / `run_structured_string_list` + Pydantic outputs; `AsyncSimpleBot` + `_stream_text_deltas_async_simple_bot` for streams; LiteLLM for `drop_params`, token count, Copilot models, `supports_response_schema`, `aimage_generation` |
+| `src/canvas_chat/llm_messages.py`               | Message shape helpers              | Map OpenAI-style dicts / Pydantic messages to `(system_prompt, list[BaseMessage])` for llamabot |
 | `src/canvas_chat/config.py`                     | Configuration management           | Model definitions, plugins, admin mode                                          |
 | `src/canvas_chat/__main__.py`                   | CLI entry point                    | Command-line interface, dev server                                              |
 | `src/canvas_chat/__init__.py`                   | Package initialization             | Package metadata, version                                                       |
@@ -202,6 +205,7 @@ canvas-chat/
 | `DEFAULT_KEYBINDINGS` / keybinding storage | `keybindings.js`, `storage.js` (`canvas-chat-keybindings`) | Default shortcuts; user overrides in Settings → Shortcuts                       |
 | Zoom wheel sensitivity                     | `storage.js` (`canvas-chat-zoom-wheel-sensitivity`), `utils.js` (`DEFAULT_ZOOM_WHEEL_SENSITIVITY` = 50) | Settings → Canvas; slider 50 = former “max” step, 100 = stronger; live `input` updates canvas |
 | CSS variables                              | `style.css:10-75`                                          | Colors, sizing, theming                                                         |
+| `DDG_PAGE_BODY_MAX_INPUT_TOKENS`           | `ddg_endpoints.py`                                         | Input token budget for fetched page markdown before per-page LLM summarize (clipped via `clip_page_markdown_to_input_token_budget`) |
 
 ### Zoom levels (semantic zoom)
 

--- a/docs/designs/llamabot-backend-proxy/LLD.md
+++ b/docs/designs/llamabot-backend-proxy/LLD.md
@@ -22,7 +22,7 @@ This LLD describes migrating **chat completions** (streaming and non-streaming) 
 
 - Centralize provider-agnostic configuration (model id, `api_key`, `base_url`, temperature, max tokens) in one module.
 - Use **SimpleBot** for unstructured text: SSE streams (`/api/chat`, `/api/generate-code`, `/api/matrix/fill`, committee streams, etc.) and one-shot calls (summarize, title, summary, `_llm_text`).
-- Use **StructuredBot** (or equivalent) for Pydantic-backed outputs: refine-query, matrix parse-two-lists, PPTX caption endpoints, `_llm_json_array` use cases.
+- Use **StructuredBot** (or equivalent) for Pydantic-backed outputs: refine-query, matrix parse-two-lists, PPTX caption endpoints, `run_structured_string_list` (DDG query lists).
 - Preserve **admin mode**, **GitHub Copilot** kwargs shaping (`prepare_copilot_openai_request`), and **user-facing error strings** (including Copilot auth hints).
 
 ## 3. Non-goals

--- a/docs/designs/llamabot-backend-proxy/LLD.md
+++ b/docs/designs/llamabot-backend-proxy/LLD.md
@@ -1,0 +1,85 @@
+# Low-Level Design: LLM backend (llamabot integration)
+
+**Parent:** [High-Level Design](../../high-level-design.md)
+**Status:** Design (pre-implementation)
+**Created:** 2026-03-28
+**Updated:** 2026-03-28
+
+## Related documents
+
+- [High-Level Design](../../high-level-design.md)
+- [Backend LLM proxy (narrative LLD)](../../llds/backend-llm-proxy.md)
+- [LLM proxy EARS](./llm-proxy-EARS.md)
+- [Backend API specs](../../specs/backend-api-specs.md)
+
+## 1. Context
+
+The FastAPI backend today routes **text** LLM work through **LiteLLM** (`litellm.acompletion`, structured outputs, streaming). **Image generation**, **token counting**, and **GitHub Copilot model discovery** also use LiteLLM-specific APIs and should remain on LiteLLM until a deliberate replacement exists.
+
+This LLD describes migrating **chat completions** (streaming and non-streaming) and **structured JSON outputs** to **llamabot** (`SimpleBot`, `StructuredBot`) behind a small adapter while **preserving** HTTP/SSE contracts for the existing frontend.
+
+## 2. Goals
+
+- Centralize provider-agnostic configuration (model id, `api_key`, `base_url`, temperature, max tokens) in one module.
+- Use **SimpleBot** for unstructured text: SSE streams (`/api/chat`, `/api/generate-code`, `/api/matrix/fill`, committee streams, etc.) and one-shot calls (summarize, title, summary, `_llm_text`).
+- Use **StructuredBot** (or equivalent) for Pydantic-backed outputs: refine-query, matrix parse-two-lists, PPTX caption endpoints, `_llm_json_array` use cases.
+- Preserve **admin mode**, **GitHub Copilot** kwargs shaping (`prepare_copilot_openai_request`), and **user-facing error strings** (including Copilot auth hints).
+
+## 3. Non-goals
+
+- **PocketFlow** or other graph orchestration frameworks for committee—committee stays as asyncio + queues + parallel SimpleBot streams unless a future design explicitly adds a workflow engine.
+- Removing the **LiteLLM** dependency entirely in the first iteration (images, tokens, Copilot model lists may keep using LiteLLM).
+- Changing frontend routes, request bodies, or SSE event names.
+
+## 4. Component overview
+
+```text
+┌─────────────┐     ┌──────────────────┐     ┌─────────────┐
+│  FastAPI    │────▶│  llm adapter     │────▶│  llamabot   │
+│  routes     │     │  (new module)    │     │  SimpleBot /│
+└─────────────┘     │  + copilot hook  │     │  Structured │
+       │            └────────┬─────────┘     └─────────────┘
+       │                     │
+       │                     └── (optional) litellm.supports_response_schema
+       │
+       └── unchanged: aimage_generation, token_counter, github_copilot_models
+```
+
+Planned module (name TBD, e.g. `canvas_chat/llm_adapter.py`):
+
+- Builds bot instances from request-scoped credentials after `inject_admin_credentials`.
+- Applies `prepare_copilot_openai_request`-equivalent inputs so Copilot continues to work.
+- Maps streaming chunks to the same SSE shapes routes emit today.
+- Maps structured results to existing Pydantic models (`RefinedQueryOutput`, matrix rows/columns, PPTX outputs, etc.).
+- Translates provider/SDK errors into the same HTTP status and SSE `error` payloads as today.
+
+## 5. Data and interfaces
+
+- **Inputs:** Same as current routes—OpenRouter-style model strings, optional `base_url`, per-provider API keys, message lists.
+- **Outputs:** Byte-for-byte compatible SSE where applicable; JSON bodies unchanged for REST endpoints.
+- **Structured capability detection:** May continue to call `litellm.supports_response_schema` in the adapter until StructuredBot exposes a single abstraction for “schema supported.”
+
+## 6. Error handling
+
+Handlers today catch LiteLLM exception types (`AuthenticationError`, `RateLimitError`, `APIError`, `APIConnectionError`). The adapter shall either:
+
+- Catch llamabot/provider exceptions and map them to the same user-visible strings, or
+- Document a thin exception-mapping table in code next to the adapter.
+
+## 7. Dependencies
+
+- **llamabot** (already in `pyproject.toml`; version to be pinned after API spike).
+- **litellm** retained for non-chat utilities as above.
+
+## 8. Testing strategy
+
+- Unit tests mock the **adapter** (not duplicated completion logic).
+- Existing integration tests that mock `litellm` at route level may be updated to mock the adapter once introduced.
+- E2E behaviour unchanged: same Cypress assumptions for SSE and JSON responses.
+
+## 9. Rollout
+
+1. Spike: confirm async streaming and structured APIs on target llamabot version.
+2. Implement adapter + migrate one streaming route (`/api/chat`).
+3. Migrate remaining streams and one-shots; then structured paths.
+4. Leave LiteLLM-only utilities in place; trim unused `acompletion` imports.

--- a/docs/designs/llamabot-backend-proxy/llm-proxy-EARS.md
+++ b/docs/designs/llamabot-backend-proxy/llm-proxy-EARS.md
@@ -25,7 +25,7 @@
 
 ## StructuredBot (structured outputs)
 
-- [ ] **LLM-BOT-STR-001**: The system shall use StructuredBot (or equivalent) for endpoints that require validated Pydantic output (refine-query, matrix parse-two-lists, PPTX caption/narrative endpoints, and list extraction currently implemented via `_llm_json_array`).
+- [ ] **LLM-BOT-STR-001**: The system shall use StructuredBot (or equivalent) for endpoints that require validated Pydantic output (refine-query, matrix parse-two-lists, PPTX caption/narrative endpoints, and DDG query lists via `run_structured_string_list`).
 
 - [ ] **LLM-BOT-STR-002**: Where the model does not support schema-constrained generation, the system shall fall back to unstructured generation and parse/validate in a way that preserves current behaviour (including existing fallback branches).
 

--- a/docs/designs/llamabot-backend-proxy/llm-proxy-EARS.md
+++ b/docs/designs/llamabot-backend-proxy/llm-proxy-EARS.md
@@ -1,0 +1,38 @@
+# LLM backend proxy — EARS (llamabot migration)
+
+**Parent LLD:** [LLD.md](./LLD.md)
+**Created:** 2026-03-28
+**Status:** Active gap (pre-implementation)
+
+## Related documents
+
+- [LLD](./LLD.md)
+- [Backend API specs](../../specs/backend-api-specs.md)
+
+## Parity and routing
+
+- [ ] **LLM-BOT-PAR-001**: The system shall preserve existing request and response contracts for `POST /api/chat`, `POST /api/summarize`, `POST /api/committee`, plugin routes that stream LLM output, and structured JSON endpoints listed in the LLD, so that clients require no changes for migration.
+
+- [ ] **LLM-BOT-PAR-002**: When serving streaming completions, the system shall emit the same SSE event names and payload shapes the frontend already consumes (`message`, `done`, `error`, and committee-specific events as today).
+
+- [ ] **LLM-BOT-PAR-003**: When `inject_admin_credentials` or user-supplied keys are applied, the system shall pass the same effective credentials and `base_url` into the llamabot layer as today’s LiteLLM kwargs receive after `prepare_copilot_openai_request`.
+
+## SimpleBot (unstructured text)
+
+- [ ] **LLM-BOT-SIM-001**: The system shall use SimpleBot (or an equivalent one-shot/stream helper from llamabot) for all unstructured text completions that currently call `litellm.acompletion` without a Pydantic `response_format`, including streaming and non-streaming paths.
+
+- [ ] **LLM-BOT-SIM-002**: When a streaming completion fails with an authentication, rate limit, or provider error, the system shall surface user-visible messages consistent with existing handlers (including GitHub Copilot auth guidance where applicable).
+
+## StructuredBot (structured outputs)
+
+- [ ] **LLM-BOT-STR-001**: The system shall use StructuredBot (or equivalent) for endpoints that require validated Pydantic output (refine-query, matrix parse-two-lists, PPTX caption/narrative endpoints, and list extraction currently implemented via `_llm_json_array`).
+
+- [ ] **LLM-BOT-STR-002**: Where the model does not support schema-constrained generation, the system shall fall back to unstructured generation and parse/validate in a way that preserves current behaviour (including existing fallback branches).
+
+## LiteLLM retention
+
+- [ ] **LLM-BOT-UTL-001**: The system shall continue to use LiteLLM for `aimage_generation` (non-Ollama image path), `token_counter` (including `GET /api/token-count`), and GitHub Copilot model enumeration (`github_copilot_models`, tests using `get_model_info`) until a separate design replaces those dependencies.
+
+## Committee orchestration
+
+- [ ] **LLM-BOT-COM-001**: The system shall implement the committee flow (parallel opinions, optional reviews, chairman synthesis) with the same concurrency and SSE sequencing as today, using SimpleBot streams per leg **without** introducing PocketFlow or another graph engine in this migration.

--- a/docs/high-level-design.md
+++ b/docs/high-level-design.md
@@ -4,7 +4,12 @@
 **Issue:** N/A (comprehensive HLD for entire application)
 **Status:** Draft
 **Created:** 2026-03-16
-**Updated:** 2026-03-17 (added build pipeline, Modal deployment, pip distribution)
+**Updated:** 2026-03-17 (added build pipeline, Modal deployment, pip distribution); 2026-03-28 (linked LLM backend LLD/EARS)
+
+## Related design documents
+
+- **[LLM backend (llamabot)](./designs/llamabot-backend-proxy/LLD.md)** — Low-level design for migrating text completions to llamabot while keeping API contracts stable.
+- **[LLM proxy EARS](./designs/llamabot-backend-proxy/llm-proxy-EARS.md)** — Requirements for parity, SimpleBot/StructuredBot usage, and retained LiteLLM utilities.
 
 ## 1. What Is This Project?
 

--- a/docs/high-level-design.md
+++ b/docs/high-level-design.md
@@ -4,12 +4,13 @@
 **Issue:** N/A (comprehensive HLD for entire application)
 **Status:** Draft
 **Created:** 2026-03-16
-**Updated:** 2026-03-17 (added build pipeline, Modal deployment, pip distribution); 2026-03-28 (linked LLM backend LLD/EARS)
+**Updated:** 2026-03-17 (added build pipeline, Modal deployment, pip distribution); 2026-03-28 (linked LLM backend LLD/EARS; research activity output panel and arrow-of-intent links to NODE-REQ-019 / RSCH-REQ-005)
 
 ## Related design documents
 
 - **[LLM backend (llamabot)](./designs/llamabot-backend-proxy/LLD.md)** — Low-level design for migrating text completions to llamabot while keeping API contracts stable.
 - **[LLM proxy EARS](./designs/llamabot-backend-proxy/llm-proxy-EARS.md)** — Requirements for parity, SimpleBot/StructuredBot usage, and retained LiteLLM utilities.
+- **[Research feature](./llds/research-feature.md)** — `/search` and `/research`, streaming, and the research node activity output panel.
 
 ## 1. What Is This Project?
 
@@ -95,6 +96,7 @@ All LLM responses stream in real-time.
 - See responses token-by-token as they're generated
 - Stop generation mid-stream
 - Continue stopped generations
+- **Intermediate activity** — For long-running streams (for example deep research), the UI SHOULD show what the system is doing in a dedicated place without crowding the main report. Research nodes use the same **slide-out output panel** pattern as code nodes and Git file selection: a chronological activity log (status lines and, for the DuckDuckGo fallback, per-source lines) while the node body shows the growing or final synthesized content. Requirements are specified in [NODE-REQ-019](./specs/node-types-specs.md) and [RSCH-REQ-005](./specs/feature-plugins-specs.md); design detail is in the [research LLD](./llds/research-feature.md).
 
 ### 4.5 Explicit Viewport Focus
 
@@ -166,6 +168,7 @@ Messages are the core node type, but the system supports many others:
 | **Data**      | Matrices for evaluation, tables from CSV/Excel   |
 | **Documents** | PDFs, PowerPoint, YouTube transcripts            |
 | **Code**      | Executable Python with output panels             |
+| **Research**  | Deep research reports with an optional activity log in the output panel |
 | **Multi-LLM** | Committee opinions, synthesis                    |
 
 ## 7. Edge Types

--- a/docs/how-to/deep-research.md
+++ b/docs/how-to/deep-research.md
@@ -70,6 +70,10 @@ You'll see status updates as it progresses. Example status messages include:
 
 The exact messages depend on which provider is used.
 
+### Research activity drawer
+
+While research runs, the **node** only shows your topic plus a short *In progress…* line so the card stays readable. Open the **slide-out panel** under the research node (same control as code output panels: expand/collapse at the bottom edge) for the live detail: chronological **status** lines from the backend, and—with the DuckDuckGo fallback—a short line each time a **source** is recorded. The final report still appears in the node when research completes. When research finishes, the activity log remains available until you start a new run on the same node (which clears it).
+
 ## Context-aware research
 
 When you select text or nodes before running `/research`, the AI refines your instructions based on that context.

--- a/docs/llds/backend-llm-proxy.md
+++ b/docs/llds/backend-llm-proxy.md
@@ -1,7 +1,13 @@
 # Backend: LLM Proxy and Services
 
 **Created**: 2026-03-16
+**Updated**: 2026-03-28
 **Status**: Design Phase
+
+## Related design documents
+
+- **[LLD: llamabot backend proxy](../designs/llamabot-backend-proxy/LLD.md)** — migration plan: SimpleBot/StructuredBot adapter, LiteLLM retained for images/tokens/Copilot utilities.
+- **[EARS: LLM proxy](../designs/llamabot-backend-proxy/llm-proxy-EARS.md)** — testable requirements for API parity and bot usage.
 
 ## Context and Design Philosophy
 
@@ -16,11 +22,20 @@ It does NOT store user data. All conversation data stays in the browser.
 
 ### Architecture
 
+**Target (in progress):** text completions are moving from raw LiteLLM `acompletion` to **llamabot** (`SimpleBot` for unstructured text and SSE, `StructuredBot` for Pydantic/JSON outputs) behind a small backend adapter, while **LiteLLM** remains for image generation, token counting, and Copilot-specific helpers. See the [LLD](../designs/llamabot-backend-proxy/LLD.md).
+
+```text
+Frontend → Backend → llamabot (SimpleBot / StructuredBot) → Provider APIs
+                  ↘ LiteLLM (images, token_counter, Copilot model list only)
+```
+
+Historically, all chat traffic went through LiteLLM end-to-end:
+
 ```text
 Frontend → Backend → LiteLLM → Provider APIs
 ```
 
-LiteLLM provides a unified API across providers:
+LiteLLM (still used where noted above) provides a unified API across providers:
 
 | Provider  | Example Model                  |
 | --------- | ------------------------------ |
@@ -53,7 +68,7 @@ Response: Server-Sent Events (SSE) streaming
 
 - **CORS**: Avoids CORS issues with direct provider calls
 - **Key management**: API keys stored in browser, not exposed to providers directly
-- **Unified interface**: Single endpoint works with any LiteLLM-supported model
+- **Unified interface**: Single endpoint works with any provider/model id the stack supports (same model strings as before; implementation detail may be llamabot + optional LiteLLM utilities)
 
 ## Services
 
@@ -112,7 +127,7 @@ In admin mode:
 
 ### Resolved
 
-1. ✅ LiteLLM - reduces provider-specific code
+1. ✅ LiteLLM - reduces provider-specific code (narrowed over time: chat completions migrate to llamabot; see LLD)
 2. ✅ SSE streaming - real-time token delivery
 3. ✅ No user data storage - privacy, simplicity
 
@@ -123,5 +138,6 @@ In admin mode:
 
 ## References
 
-- HLD: `/docs/high-level-design.md`
-- Implementation: `src/canvas_chat/app.py`
+- HLD: [high-level-design.md](../high-level-design.md)
+- LLD + EARS: [designs/llamabot-backend-proxy/](../designs/llamabot-backend-proxy/LLD.md)
+- Implementation: `src/canvas_chat/app.py` (and plugins under `src/canvas_chat/plugins/`)

--- a/docs/llds/research-feature.md
+++ b/docs/llds/research-feature.md
@@ -3,12 +3,25 @@
 **Created**: 2026-03-16
 **Status**: Implementation
 **Module**: ResearchFeature (deep research and web search)
+**Updated**: 2026-03-28 — Research activity output panel (arrow of intent: HLD §4.4 → this LLD → NODE-REQ-019, RSCH-REQ-005 → tests → code)
+
+## Arrow of intent (traceability)
+
+Documentation and implementation follow one chain so intent does not drift:
+
+```text
+[HLD: Streaming-First + intermediate activity](../high-level-design.md#44-streaming-first)
+        → [this LLD: Research activity output panel](#research-activity-output-panel)
+        → [NODE-REQ-019](../specs/node-types-specs.md) / [RSCH-REQ-005](../specs/feature-plugins-specs.md)
+        → [tests: ResearchNode output panel](../../tests/test_node_protocols.js)
+        → code: `plugins/research-node.js`, `plugins/research.js`, `canvas.ensureOutputPanelContent`
+```
 
 ## Context and Design Philosophy
 
 The ResearchFeature provides two related but distinct capabilities within Canvas-Chat. The `/search` command performs lightweight web searches and displays results as reference nodes. The `/research` command performs deep research, synthesizing information from multiple sources into a comprehensive report. Both commands support context-aware refinement, where selected text or nodes are used to clarify vague queries.
 
-The design philosophy centers on three principles. First, progressive disclosure recognizes that not all research needs are equal; `/search` is fast and lets users explore manually, while `/research` provides comprehensive synthesis for complex topics. Second, dual-provider architecture prioritizes Exa for quality but gracefully falls back to DuckDuckGo when no API key is available, ensuring the feature works for all users. Third, streaming-first experience provides real-time feedback during research, showing status updates and progressive content so users understand what's happening.
+The design philosophy centers on three principles. First, progressive disclosure recognizes that not all research needs are equal; `/search` is fast and lets users explore manually, while `/research` provides comprehensive synthesis for complex topics. Second, dual-provider architecture prioritizes Exa for quality but gracefully falls back to DuckDuckGo when no API key is available, ensuring the feature works for all users. Third, streaming-first experience provides real-time feedback during research, showing status updates and progressive content so users understand what's happening. Fourth, **separation of concerns in the UI**: while research runs, the main node body shows only a short in-progress placeholder plus the topic; the **slide-out output panel** carries the chronological **activity log** (status lines and, for DDG, per-source lines). When streaming finishes, the node body shows the full synthesized report.
 
 ## Technical Overview
 
@@ -146,8 +159,8 @@ The `handleResearch` method implements a more complex flow than search:
 3. **Streaming Registration**: Register with `StreamingManager` for stop/continue support
 4. **Query Refinement**: Same refinement process as search
 5. **Research Execution**: Call appropriate endpoint based on provider
-6. **SSE Processing**: Handle streaming events (status, content, sources)
-7. **Completion**: Clean up streaming state, generate summary
+6. **SSE Processing**: Handle streaming events (status, content, sources); append to `researchActivityLog` and call `canvas.ensureOutputPanelContent` so the activity panel appears on first chunk
+7. **Completion**: Clear `researchActivityActive`, clean up streaming state, generate summary
 
 ### Streaming Integration
 
@@ -248,6 +261,25 @@ Defined in `plugins/research-node.js`:
 - **Type Icon**: "📚"
 - **Header Buttons**: Nav Parent, Nav Child, Collapse, Stop, Continue, Reset Size, Fit Viewport, Delete
 - **Actions**: Reply, Create Flashcards, Copy
+- **Output panel** (`hasOutput` / `renderOutputPanel`): When `researchActivityLog` is non-empty, the canvas shows the standard slide-out panel below the node. The log is a single `<pre>` directly in the panel body (no nested card); the panel chrome provides padding and scroll. While `researchActivityActive` is true, a “Running…” line is shown below the log.
+
+### Research activity output panel
+
+**Problem:** Status and source progress were only visible in the main node body (or as dense markdown). For DuckDuckGo research, terminal-style logs are especially informative; users benefit from a dedicated **activity** surface that mirrors other features (code run output, Git file preview).
+
+**Approach:**
+
+1. **Node fields** (CRDT-backed primitives on the research node):
+   - `researchActivityLog` — newline-separated lines, capped (e.g. 300 lines) to avoid unbounded growth.
+   - `researchActivityActive` — boolean; true while the SSE stream is open; false on `done`, abort, or error.
+
+2. **Protocol** (`ResearchNode`): Implements `hasOutput()` when the trimmed log is non-empty; `renderOutputPanel(canvas)` returns escaped HTML for the log and optional running state (see [NODE-REQ-019](../specs/node-types-specs.md)).
+
+3. **Feature** (`ResearchFeature`): On stream start, seeds the log (e.g. “Starting research…”); on each `status` event appends the line; on each DDG `source` event appends a short “Source: …” line; updates the graph then calls `canvas.ensureOutputPanelContent(nodeId, node)` so the panel is **created** if absent or **refreshed** if present (`canvas.js`).
+
+4. **Canvas**: `ensureOutputPanelContent` wraps the pattern: if `wrapNode(node).hasOutput()` and no panel exists, `renderOutputPanel(node, wrapper)`; else `updateOutputPanelContent`.
+
+**Styling:** `nodes.css` — `.research-activity-log` (monospace text only; no inner box), `.research-activity-status`.
 
 ## Streaming Results Processing
 
@@ -273,21 +305,7 @@ The `true` parameter indicates streaming mode (appending vs replacing).
 
 ### DDG Streaming (Source-by-Source)
 
-For DDG research, sources arrive individually:
-
-```javascript
-if (eventType === 'source') {
-    const source = JSON.parse(data);
-    ddgSourceCount += 1;
-
-    // Build markdown for this source
-    ddgSourcesMd += `### [${title}](${url})...\n\n${summary}\n\n---\n\n`;
-
-    // Update display with growing sources list
-    const sourcesBlock = `## Sources (${ddgSourceCount})\n\n${ddgSourcesMd}`;
-    this.canvas.updateNodeContent(nodeId, content, true);
-}
-```
+For DDG research, sources arrive individually. Status and source lines are appended to the **activity log** (drawer) only. The **node body** stays a short placeholder (`*In progress…*`) until the final `content` event delivers the full report, so the canvas is not filled with duplicate status and source lists.
 
 ### Completion Handling
 
@@ -368,20 +386,22 @@ Backend API Call
         |
         v
 SSE Stream Processing
-  - status events: Update with progress
+  - status events: Append to activity log + refresh output panel; update main body (status / report)
   - content events: Append to report
+  - source events (DDG): Append source line to activity log; update main body sources section
   - sources events: Store for final section
         |
         v
-Completion: normalize + add sources + generate summary
+Completion: clear researchActivityActive + normalize + add sources + generate summary
 ```
 
 ## File Structure
 
 | File                       | Purpose                                                |
 | -------------------------- | ------------------------------------------------------ |
-| `plugins/research.js`      | ResearchFeature class with handleSearch/handleResearch |
-| `plugins/research-node.js` | ResearchNode protocol definition                       |
+| `plugins/research.js`      | ResearchFeature class with handleSearch/handleResearch; activity log + `ensureOutputPanelContent` |
+| `plugins/research-node.js` | ResearchNode protocol; `hasOutput` / `renderOutputPanel` for activity drawer |
+| `canvas.js`                | `ensureOutputPanelContent`, `renderOutputPanel`, `updateOutputPanelContent` |
 | `plugins/search-node.js`   | SearchNode protocol definition                         |
 | `app.py`                   | Exa API endpoints (lines 1822-2066)                    |
 | `plugins/ddg_endpoints.py` | DuckDuckGo fallback endpoints                          |
@@ -425,13 +445,14 @@ This LLD supports the following HLD components:
 
 - **Section 5.2: Backend LLM Proxy** - Research endpoints are part of the FastAPI backend
 - **Section 5.1: Frontend The Canvas** - Research nodes render on the SVG canvas
-- **Section 4.4: Streaming-First** - All research results stream in real-time
+- **Section 4.4: Streaming-First** - All research results stream in real-time; intermediate activity uses the output panel (see [NODE-REQ-019](../specs/node-types-specs.md))
 - **Section 4.3: Plugin-Extensible** - ResearchFeature is a Level 2 feature plugin
 - **Section 6: Node Types** - RESEARCH and SEARCH are documented node types
 - **Section 7: Edge Types** - EdgeType.REFERENCE and SEARCH_RESULT connect research graphs
 
 ## Related Documentation
 
+- [NODE-REQ-019](../specs/node-types-specs.md), [RSCH-REQ-005](../specs/feature-plugins-specs.md) — EARS requirements for the activity panel
 - [How to conduct deep research](../how-to/deep-research.md) - User guide for /research
 - [How to search the web](../how-to/web-search.md) - User guide for /search
 - [High-Level Design](../high-level-design.md) - System overview

--- a/docs/specs/backend-api-specs.md
+++ b/docs/specs/backend-api-specs.md
@@ -1,8 +1,11 @@
 # Backend API Specifications
 
 **Created**: 2026-03-16
+**Updated**: 2026-03-28
 **Status**: Active
 **HLD**: [High-Level Design](../high-level-design.md)
+
+**Implementation note:** HTTP paths, request bodies, and response shapes in this document are stable. The backend may implement LLM calls via **llamabot** (SimpleBot / StructuredBot) behind an adapter while preserving these contracts; see [LLD: llamabot backend proxy](../designs/llamabot-backend-proxy/LLD.md).
 
 ## Chat API
 

--- a/docs/specs/feature-plugins-specs.md
+++ b/docs/specs/feature-plugins-specs.md
@@ -1,6 +1,7 @@
 # Feature Plugins Specifications
 
 **Created**: 2026-03-16
+**Updated**: 2026-03-28 (RSCH-REQ-005 research activity visibility)
 **Status**: Active
 **HLD**: [High-Level Design](../high-level-design.md)
 
@@ -61,6 +62,12 @@ The system MUST use Exa API when available, falling back to DuckDuckGo when no E
 **Location**: `research.js`
 
 When context is selected, the system MUST refine the search query using the LLM before executing the search.
+
+### [x] RSCH-REQ-005: Research activity visibility
+
+**Location**: `plugins/research.js`, `plugins/research-node.js`, `canvas.js`
+
+During `/research`, the ResearchFeature MUST append streaming **status** lines (and, for the DuckDuckGo fallback, **source** summary lines) to the research node’s activity log and MUST refresh the output panel so users see intermediate progress. While streaming, the feature MUST NOT duplicate that status or per-source detail in the main node body (the body SHOULD show at most a short in-progress placeholder until the final report). On completion, stop, or error, the feature MUST clear the running indicator while MAY retain the final log for inspection.
 
 ## Code Feature
 

--- a/docs/specs/node-types-specs.md
+++ b/docs/specs/node-types-specs.md
@@ -1,6 +1,7 @@
 # Node Types Specifications
 
 **Created**: 2026-03-16
+**Updated**: 2026-03-28 (NODE-REQ-019 research activity output panel)
 **Status**: Active
 **HLD**: [High-Level Design](../high-level-design.md)
 
@@ -110,9 +111,15 @@ The system MUST provide an `html_slides` node type for HTML presentations. HTML 
 
 ### [x] NODE-REQ-018: Research Node
 
-**Location**: `plugins/research.js`
+**Location**: `plugins/research.js`, `plugins/research-node.js`
 
 The system MUST provide a `research` node type for deep research. Research nodes MUST display synthesized findings and sources.
+
+### [x] NODE-REQ-019: Research activity output panel
+
+**Location**: `plugins/research-node.js`, `plugins/research.js`, `canvas.js` (`ensureOutputPanelContent`)
+
+When a research stream is active or has produced activity lines, the research node protocol MUST expose a slide-out **output panel** (same mechanism as code output panels) when `hasOutput()` is true. The panel MUST render a chronological, plain-text activity log (server `status` events and, for DuckDuckGo research, per-`source` lines) distinct from the main node body report. The log MUST be stored on the node (for example `researchActivityLog` / `researchActivityActive`) and updated as SSE events arrive. The canvas MUST create the panel on first activity via `ensureOutputPanelContent` when the node was not initially rendered with a panel.
 
 ## Edge Type Requirements
 

--- a/modal_app.py
+++ b/modal_app.py
@@ -29,6 +29,7 @@ image = (
         "fastapi[standard]>=0.115.0",
         "uvicorn>=0.32.0",
         "litellm>=1.50.0,<1.82.7",
+        "llamabot>=0.18.0",
         "sse-starlette>=2.0.0",
         "pydantic>=2.0.0",
         "exa-py>=1.0.0",

--- a/pixi.lock
+++ b/pixi.lock
@@ -110,7 +110,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/73/8d100c4e48935f6a381df60f894ca9c063ea412ce354fbe7a17770ad4092/litellm-1.81.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ac/ec/b4ce46a18bad0b3057edd713c585b14b038ea824ea26167c9eb8eb98554c/llamabot-0.17.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/48/49/166b9460ef373f5060037dc1ebcb0bceb86df74b08e5709ef9da3dc05cd2/llamabot-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/c6/a04e9cef7c052717fcb28fb63b3824802488f688391895b618e39be0f684/lupa-2.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/9c/47293c58cc91769130fbf85531280e8cc7868f7fbb6d92f4670071b9cb3e/lxml-6.0.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
@@ -311,7 +311,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/0f/5312b944208efeec5dcbf8e0ed956f8f7c430b0c6458301d206380c90b56/litellm-1.81.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ac/ec/b4ce46a18bad0b3057edd713c585b14b038ea824ea26167c9eb8eb98554c/llamabot-0.17.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/48/49/166b9460ef373f5060037dc1ebcb0bceb86df74b08e5709ef9da3dc05cd2/llamabot-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/9c/59e6cffa0d672d662ae17bd7ac8ecd2c89c9449dee499e3eb13ca9cd10d9/lupa-2.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/3a/ea/a43ba9bb750d4ffdd885f2cd333572f5bb900cd2408b67fdda07e85978a0/lxml-6.0.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
@@ -506,7 +506,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/73/8d100c4e48935f6a381df60f894ca9c063ea412ce354fbe7a17770ad4092/litellm-1.81.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ac/ec/b4ce46a18bad0b3057edd713c585b14b038ea824ea26167c9eb8eb98554c/llamabot-0.17.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/48/49/166b9460ef373f5060037dc1ebcb0bceb86df74b08e5709ef9da3dc05cd2/llamabot-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/98/f9ff60db84a75ba8725506bbf448fb085bc77868a021998ed2a66d920568/lupa-2.6-cp314-cp314-macosx_11_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c8/e8/c128e37589463668794d503afaeb003987373c5f94d667124ffd8078bbd9/lxml-6.0.2-cp314-cp314-macosx_10_13_x86_64.whl
@@ -698,7 +698,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/73/8d100c4e48935f6a381df60f894ca9c063ea412ce354fbe7a17770ad4092/litellm-1.81.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ac/ec/b4ce46a18bad0b3057edd713c585b14b038ea824ea26167c9eb8eb98554c/llamabot-0.17.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/48/49/166b9460ef373f5060037dc1ebcb0bceb86df74b08e5709ef9da3dc05cd2/llamabot-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/66/9d/d9427394e54d22a35d1139ef12e845fd700d4872a67a34db32516170b746/lupa-2.6-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/03/15/d4a377b385ab693ce97b472fe0c77c2b16ec79590e688b3ccc71fba19884/lxml-6.0.2-cp314-cp314-macosx_10_13_universal2.whl
@@ -892,7 +892,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/e4/87e3ca82a8bf6e6bfffb42a539a1350dd6ced1b7169397bd439ba56fde10/litellm-1.82.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/79/f0/590cdda796ef68b3dee6bba6feebfa1c9a9e47f1c8cd6fa8417a22b47634/llamabot-0.17.15-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/48/49/166b9460ef373f5060037dc1ebcb0bceb86df74b08e5709ef9da3dc05cd2/llamabot-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/e0/c96cf13eccd20c9421ba910304dae0f619724dcf1702864fd59dd386404d/lxml-6.0.2-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
@@ -1114,7 +1114,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/73/8d100c4e48935f6a381df60f894ca9c063ea412ce354fbe7a17770ad4092/litellm-1.81.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ac/ec/b4ce46a18bad0b3057edd713c585b14b038ea824ea26167c9eb8eb98554c/llamabot-0.17.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/48/49/166b9460ef373f5060037dc1ebcb0bceb86df74b08e5709ef9da3dc05cd2/llamabot-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/23/c6/a04e9cef7c052717fcb28fb63b3824802488f688391895b618e39be0f684/lupa-2.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/29/9c/47293c58cc91769130fbf85531280e8cc7868f7fbb6d92f4670071b9cb3e/lxml-6.0.2-cp314-cp314-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl
@@ -1333,7 +1333,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/0f/5312b944208efeec5dcbf8e0ed956f8f7c430b0c6458301d206380c90b56/litellm-1.81.5-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ac/ec/b4ce46a18bad0b3057edd713c585b14b038ea824ea26167c9eb8eb98554c/llamabot-0.17.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/48/49/166b9460ef373f5060037dc1ebcb0bceb86df74b08e5709ef9da3dc05cd2/llamabot-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9e/9c/59e6cffa0d672d662ae17bd7ac8ecd2c89c9449dee499e3eb13ca9cd10d9/lupa-2.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/3a/ea/a43ba9bb750d4ffdd885f2cd333572f5bb900cd2408b67fdda07e85978a0/lxml-6.0.2-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl
@@ -1546,7 +1546,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/73/8d100c4e48935f6a381df60f894ca9c063ea412ce354fbe7a17770ad4092/litellm-1.81.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ac/ec/b4ce46a18bad0b3057edd713c585b14b038ea824ea26167c9eb8eb98554c/llamabot-0.17.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/48/49/166b9460ef373f5060037dc1ebcb0bceb86df74b08e5709ef9da3dc05cd2/llamabot-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/a3/98/f9ff60db84a75ba8725506bbf448fb085bc77868a021998ed2a66d920568/lupa-2.6-cp314-cp314-macosx_11_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c8/e8/c128e37589463668794d503afaeb003987373c5f94d667124ffd8078bbd9/lxml-6.0.2-cp314-cp314-macosx_10_13_x86_64.whl
@@ -1756,7 +1756,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/59/73/8d100c4e48935f6a381df60f894ca9c063ea412ce354fbe7a17770ad4092/litellm-1.81.1-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ac/ec/b4ce46a18bad0b3057edd713c585b14b038ea824ea26167c9eb8eb98554c/llamabot-0.17.14-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/48/49/166b9460ef373f5060037dc1ebcb0bceb86df74b08e5709ef9da3dc05cd2/llamabot-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/66/9d/d9427394e54d22a35d1139ef12e845fd700d4872a67a34db32516170b746/lupa-2.6-cp314-cp314-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/03/15/d4a377b385ab693ce97b472fe0c77c2b16ec79590e688b3ccc71fba19884/lxml-6.0.2-cp314-cp314-macosx_10_13_universal2.whl
@@ -1966,7 +1966,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/96/e4/87e3ca82a8bf6e6bfffb42a539a1350dd6ced1b7169397bd439ba56fde10/litellm-1.82.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/79/f0/590cdda796ef68b3dee6bba6feebfa1c9a9e47f1c8cd6fa8417a22b47634/llamabot-0.17.15-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/48/49/166b9460ef373f5060037dc1ebcb0bceb86df74b08e5709ef9da3dc05cd2/llamabot-0.18.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/0c/29/0348de65b8cc732daa3e33e67806420b2ae89bdce2b04af740289c5c6c8c/loguru-0.7.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e3/e0/c96cf13eccd20c9421ba910304dae0f619724dcf1702864fd59dd386404d/lxml-6.0.2-cp314-cp314-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl
@@ -2655,12 +2655,12 @@ packages:
 - pypi: ./
   name: canvas-chat
   version: 0.1.108
-  sha256: 22957aa625b3c1e2f077c88c613bd1f32aa7641656442b1339471f3e06f6e5ad
+  sha256: 1f015cea2dcc690fbf4cbce7100b2a435dd687313276a7807df24af2bbad3444
   requires_dist:
   - fastapi>=0.115.0
   - uvicorn>=0.32.0
   - litellm>=1.50.0,<1.82.7
-  - llamabot>=0.17.0
+  - llamabot>=0.18.0
   - pydantic>=2.0.0
   - sse-starlette>=2.0.0
   - exa-py>=2.0.2,<3
@@ -5794,10 +5794,10 @@ packages:
   - uvloop>=0.21.0,<0.22.0 ; sys_platform != 'win32' and extra == 'proxy'
   - websockets>=15.0.1,<16.0.0 ; extra == 'proxy'
   requires_python: '>=3.9,<4.0'
-- pypi: https://files.pythonhosted.org/packages/ac/ec/b4ce46a18bad0b3057edd713c585b14b038ea824ea26167c9eb8eb98554c/llamabot-0.17.14-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/48/49/166b9460ef373f5060037dc1ebcb0bceb86df74b08e5709ef9da3dc05cd2/llamabot-0.18.0-py3-none-any.whl
   name: llamabot
-  version: 0.17.14
-  sha256: e5d067af9699d95d519cae33acbe44a68964529a4e428cb20a45607e4724e754
+  version: 0.18.0
+  sha256: c5d6e7733beac28cccb3ac444104d8520fc98bdddbf89e4b8c8131bbf466d22c
   requires_dist:
   - beautifulsoup4
   - chonkie
@@ -5807,77 +5807,7 @@ packages:
   - fastmcp
   - httpx
   - jinja2
-  - litellm>=1.71.0
-  - loguru
-  - networkx
-  - numpy
-  - numpydoc
-  - openai
-  - pdfminer-six
-  - pocketflow
-  - pydantic>=2.0
-  - pyprojroot
-  - python-dotenv
-  - python-frontmatter
-  - python-multipart
-  - python-slugify
-  - sqlalchemy
-  - starlette
-  - tenacity
-  - tqdm
-  - typer>=0.15.3
-  - uvicorn
-  - docker ; extra == 'agent'
-  - markdownify ; extra == 'agent'
-  - case-converter ; extra == 'all'
-  - docker ; extra == 'all'
-  - gitpython ; extra == 'all'
-  - ics ; extra == 'all'
-  - ipykernel ; extra == 'all'
-  - lancedb>=0.22 ; extra == 'all'
-  - markdownify ; extra == 'all'
-  - modal ; extra == 'all'
-  - nbformat ; extra == 'all'
-  - prompt-toolkit ; extra == 'all'
-  - pylance ; extra == 'all'
-  - pyperclip ; extra == 'all'
-  - python-frontmatter ; extra == 'all'
-  - rank-bm25 ; extra == 'all'
-  - rerankers ; extra == 'all'
-  - rich ; extra == 'all'
-  - sentence-transformers ; extra == 'all'
-  - tzlocal ; extra == 'all'
-  - case-converter ; extra == 'cli'
-  - gitpython ; extra == 'cli'
-  - nbformat ; extra == 'cli'
-  - prompt-toolkit ; extra == 'cli'
-  - pyperclip ; extra == 'cli'
-  - python-frontmatter ; extra == 'cli'
-  - rich ; extra == 'cli'
-  - ics ; extra == 'notebooks'
-  - ipykernel ; extra == 'notebooks'
-  - modal ; extra == 'notebooks'
-  - tzlocal ; extra == 'notebooks'
-  - lancedb>=0.22 ; extra == 'rag'
-  - pylance ; extra == 'rag'
-  - rank-bm25 ; extra == 'rag'
-  - rerankers ; extra == 'rag'
-  - sentence-transformers ; extra == 'rag'
-  requires_python: '>=3.10,<3.14'
-- pypi: https://files.pythonhosted.org/packages/79/f0/590cdda796ef68b3dee6bba6feebfa1c9a9e47f1c8cd6fa8417a22b47634/llamabot-0.17.15-py3-none-any.whl
-  name: llamabot
-  version: 0.17.15
-  sha256: c626db444d6079dd549601eca7a6a88c61d1518da262c3588cdbaee8605642c2
-  requires_dist:
-  - beautifulsoup4
-  - chonkie
-  - docstring-parser>=0.17.0,<0.18
-  - duckduckgo-search
-  - fastapi>=0.115.9
-  - fastmcp
-  - httpx
-  - jinja2
-  - litellm>=1.71.0
+  - litellm>=1.71.0,<1.82.7
   - loguru
   - networkx
   - numpy

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
     "fastapi>=0.115.0",
     "uvicorn>=0.32.0",
     "litellm>=1.50.0,<1.82.7",
-    "llamabot>=0.17.0",
+    "llamabot>=0.18.0",
     "pydantic>=2.0.0",
     "sse-starlette>=2.0.0", "exa-py>=2.0.2,<3", "modal>=1.3.0.post1,<2", "httpx>=0.28.1,<0.29", "pytest>=9.0.2,<10", "build>=1.3.0,<2", "html2text>=2025.4.15,<2026",
     "pymupdf>=1.24.0",

--- a/src/canvas_chat/app.py
+++ b/src/canvas_chat/app.py
@@ -24,6 +24,7 @@ import os
 import sys
 import time
 import traceback
+from collections.abc import AsyncGenerator
 from pathlib import Path
 from typing import Any, TypeVar
 from uuid import uuid4
@@ -43,7 +44,13 @@ from fastapi import (
 )
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
-from llamabot import SimpleBot, StructuredBot
+from litellm.exceptions import (
+    APIConnectionError,
+    APIError,
+    AuthenticationError,
+    RateLimitError,
+)
+from llamabot import AsyncSimpleBot, AsyncStructuredBot
 from llamabot.components.messages import HumanMessage
 from pydantic import BaseModel, Field
 from sse_starlette.sse import EventSourceResponse
@@ -51,6 +58,10 @@ from sse_starlette.sse import EventSourceResponse
 from canvas_chat import __version__
 from canvas_chat.config import AppConfig, is_github_copilot_enabled
 from canvas_chat.file_upload_registry import FileUploadRegistry
+from canvas_chat.llm_messages import (
+    dict_messages_to_system_and_rest,
+    pydantic_messages_to_system_and_rest,
+)
 
 # Import built-in file upload handler plugins (registers them)
 # Import built-in URL fetch handler plugins (registers them)
@@ -67,6 +78,10 @@ from canvas_chat.plugins import (
 )
 from canvas_chat.plugins.pdf_handler import MAX_PDF_SIZE
 from canvas_chat.url_fetch_registry import UrlFetchRegistry
+
+# Text completions use llamabot AsyncSimpleBot / AsyncStructuredBot. LiteLLM is
+# still imported for drop_params, token_counter, Copilot model list, images,
+# and supports_response_schema (StructuredBot uses litellm internally too).
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -229,6 +244,87 @@ class SummarizeRequest(BaseModel):
     model: str = "openai/gpt-4o-mini"
     api_key: str | None = None
     base_url: str | None = None
+    summary_type: str | None = Field(
+        None,
+        description=(
+            "Optional free-text: desired summary style, focus, or format "
+            "(e.g. bullet outline, timeline, key decisions only)."
+        ),
+    )
+    summary_length: str | None = Field(
+        None,
+        description=(
+            "Optional free-text length guidance (e.g. '2–3 sentences', '~150 words')."
+        ),
+    )
+
+
+class SummarizeOutput(BaseModel):
+    """Structured LLM output for /api/summarize (single field)."""
+
+    summary: str = Field(
+        ...,
+        description=(
+            "The summary text, honoring any summary_type and summary_length "
+            "instructions from the request."
+        ),
+    )
+
+
+_SUMMARIZE_DEFAULT_SYSTEM = (
+    "You are a helpful assistant that writes concise, accurate summaries."
+)
+_SUMMARIZE_SCHEMA_HINT = (
+    "\n\nRespond using the provided JSON schema: put the entire response in the "
+    '"summary" field (markdown allowed inside the string).'
+)
+
+
+async def run_structured_summarize(
+    *,
+    model: str,
+    api_key: str | None,
+    base_url: str | None,
+    user_prompt: str,
+    system_prompt: str | None = None,
+    max_tokens: int | None = 500,
+    temperature: float = 0.3,
+    num_attempts: int = 5,
+) -> str:
+    """Run a single structured completion using :class:`SummarizeOutput`.
+
+    Shared by :func:`summarize` and plugins (e.g. DDG research) so all use the
+    same schema and Copilot preparation.
+
+    :param system_prompt: Task-specific system instructions; defaults to branch-summary
+        behavior. The JSON ``summary``-field hint is always appended.
+    """
+    full_system = (system_prompt or _SUMMARIZE_DEFAULT_SYSTEM) + _SUMMARIZE_SCHEMA_HINT
+
+    prep = {
+        "model": model,
+        "messages": [],
+        "api_key": api_key,
+        "base_url": base_url,
+    }
+    prep = prepare_copilot_openai_request(prep, model, api_key)
+    extras = copilot_extras_for_bot(prep)
+    completion_kwargs = dict(extras)
+    if max_tokens is not None:
+        completion_kwargs["max_tokens"] = max_tokens
+    bot = AsyncStructuredBot(
+        system_prompt=full_system,
+        pydantic_model=SummarizeOutput,
+        model_name=prep["model"],
+        temperature=temperature,
+        stream_target="none",
+        api_key=prep.get("api_key"),
+        **completion_kwargs,
+    )
+    result = await bot(HumanMessage(content=user_prompt), num_attempts=num_attempts)
+    if result is None:
+        raise RuntimeError("Structured summarization returned None")
+    return result.summary.strip()
 
 
 class CopilotAuthStartResponse(BaseModel):
@@ -597,6 +693,36 @@ def copilot_extras_for_bot(prepared: dict[str, Any]) -> dict[str, Any]:
     if prepared.get("extra_headers"):
         out["extra_headers"] = prepared["extra_headers"]
     return out
+
+
+async def _stream_text_deltas_async_simple_bot(
+    messages: list[dict[str, Any]],
+    prepared: dict[str, Any],
+    temperature: float,
+) -> AsyncGenerator[str, None]:
+    """Stream assistant text deltas via :class:`~llamabot.bot.simplebot.AsyncSimpleBot`.
+
+    ``prepared`` must be the return value of :func:`prepare_copilot_openai_request`.
+    """
+    system_prompt, rest = dict_messages_to_system_and_rest(messages)
+    if not rest:
+        rest = [HumanMessage(content="")]
+    extras = copilot_extras_for_bot(prepared)
+    completion_kwargs = dict(extras)
+    mt = prepared.get("max_tokens")
+    if mt is not None:
+        completion_kwargs["max_tokens"] = mt
+    bot = AsyncSimpleBot(
+        system_prompt=system_prompt,
+        model_name=prepared["model"],
+        temperature=temperature,
+        stream_target="none",
+        api_key=prepared.get("api_key"),
+        **completion_kwargs,
+    )
+    async for delta in bot.stream_async(*rest):
+        if delta:
+            yield delta
 
 
 def get_copilot_auth_headers(access_token: str | None = None) -> dict:
@@ -1255,17 +1381,15 @@ async def chat(request: ChatRequest, http_request: Request):
     Stream a chat completion response.
 
     The frontend sends the full conversation context (resolved from the DAG).
-    Streams via litellm.acompletion with OpenAI-style kwargs.
+    Streams via llamabot :meth:`~llamabot.bot.simplebot.AsyncSimpleBot.stream_async`.
     """
     # Inject admin credentials if in admin mode
     inject_admin_credentials(request)
 
-    # Build kwargs for litellm
     kwargs = {
         "model": request.model,
-        "messages": [{"role": m.role, "content": m.content} for m in request.messages],
+        "messages": [],
         "temperature": request.temperature,
-        "stream": True,
     }
 
     if request.max_tokens:
@@ -1281,19 +1405,38 @@ async def chat(request: ChatRequest, http_request: Request):
 
     kwargs = prepare_copilot_openai_request(kwargs, request.model, request.api_key)
 
+    system_prompt, base_msgs = pydantic_messages_to_system_and_rest(request.messages)
+    if not base_msgs:
+        raise HTTPException(
+            status_code=400,
+            detail="At least one user, assistant, or tool message is required.",
+        )
+
+    extras = copilot_extras_for_bot(kwargs)
+    completion_kwargs = dict(extras)
+    if request.max_tokens:
+        completion_kwargs["max_tokens"] = request.max_tokens
+
+    chat_bot = AsyncSimpleBot(
+        system_prompt=system_prompt,
+        model_name=kwargs["model"],
+        temperature=request.temperature,
+        stream_target="none",
+        api_key=kwargs.get("api_key"),
+        **completion_kwargs,
+    )
+
     async def generate():
         """Generate SSE events from the LLM stream."""
         try:
-            response = await litellm.acompletion(**kwargs)
-            async for chunk in response:
-                if chunk.choices and chunk.choices[0].delta.content:
-                    content = chunk.choices[0].delta.content
-                    yield {"event": "message", "data": content}
+            async for delta in chat_bot.stream_async(*base_msgs):
+                if delta:
+                    yield {"event": "message", "data": delta}
 
             # Send completion signal
             yield {"event": "done", "data": ""}
 
-        except litellm.AuthenticationError as e:
+        except AuthenticationError as e:
             error_msg = str(e)
             # Check for GitHub Copilot auth issues
             if (
@@ -1312,9 +1455,9 @@ async def chat(request: ChatRequest, http_request: Request):
             else:
                 yield {"event": "error", "data": f"Authentication failed: {error_msg}"}
 
-        except litellm.RateLimitError as e:
+        except RateLimitError as e:
             yield {"event": "error", "data": f"Rate limit exceeded: {e}"}
-        except litellm.APIError as e:
+        except APIError as e:
             yield {"event": "error", "data": f"API error: {e}"}
         except Exception as e:
             error_msg = str(e)
@@ -1345,57 +1488,64 @@ async def summarize(request: SummarizeRequest):
     Generate a summary of a conversation branch.
 
     Used for creating summary nodes that condense long branches.
+    Returns structured JSON with a single ``summary`` field (validated via
+    :class:`SummarizeOutput`).
     """
-    # Inject admin credentials if in admin mode
     inject_admin_credentials(request)
 
-    # Build the summarization prompt
+    if not litellm.supports_response_schema(
+        model=request.model, custom_llm_provider=None
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Summarization requires a model that supports structured JSON "
+                "(response_schema). Choose another model or provider."
+            ),
+        )
+
     conversation = "\n".join([f"{m.role}: {m.content}" for m in request.messages])
 
-    summary_prompt = f"""Please provide a concise summary of the following conversation.
+    guidance_parts: list[str] = []
+    if (request.summary_type or "").strip():
+        guidance_parts.append(
+            "Desired summary type or focus (follow this):\n"
+            f"{request.summary_type.strip()}"
+        )
+    if (request.summary_length or "").strip():
+        guidance_parts.append(
+            "Desired length or brevity (follow this):\n"
+            f"{request.summary_length.strip()}"
+        )
+    guidance_block = "\n\n".join(guidance_parts) + "\n\n" if guidance_parts else ""
+
+    user_prompt = f"""{guidance_block}Summarize the following conversation.
 Focus on the key points, decisions, and insights discussed.
 
 Conversation:
-{conversation}
-
-Summary:"""
-
-    kwargs = {
-        "model": request.model,
-        "messages": [{"role": "user", "content": summary_prompt}],
-        "temperature": 0.3,  # Lower temperature for more consistent summaries
-        "max_tokens": 500,
-    }
-
-    if request.api_key:
-        kwargs["api_key"] = request.api_key
-
-    if request.base_url:
-        kwargs["base_url"] = request.base_url
-
-    kwargs = prepare_copilot_openai_request(kwargs, request.model, request.api_key)
+{conversation}"""
 
     try:
-        extras = copilot_extras_for_bot(kwargs)
-        completion_kwargs = dict(extras)
-        completion_kwargs["max_tokens"] = 500
-        summarize_bot = SimpleBot(
-            system_prompt=(
-                "You are a helpful assistant that writes concise, accurate summaries."
-            ),
-            model_name=kwargs["model"],
+        summary_text = await run_structured_summarize(
+            model=request.model,
+            api_key=request.api_key,
+            base_url=request.base_url,
+            user_prompt=user_prompt,
+            system_prompt=None,
+            max_tokens=500,
             temperature=0.3,
-            stream_target="none",
-            api_key=kwargs.get("api_key"),
-            **completion_kwargs,
+            num_attempts=5,
         )
-
-        def _summarize_run() -> str:
-            out = summarize_bot(HumanMessage(content=summary_prompt))
-            return out.content if hasattr(out, "content") else str(out)
-
-        summary = await asyncio.to_thread(_summarize_run)
-        return {"summary": summary}
+        return {"summary": summary_text}
+    except HTTPException:
+        raise
+    except RuntimeError as e:
+        if "Structured summarization returned None" in str(e):
+            raise HTTPException(
+                status_code=502,
+                detail="Could not obtain valid structured summary after retries.",
+            ) from e
+        raise HTTPException(status_code=500, detail=str(e)) from e
     except Exception as e:
         error_msg = str(e)
         if request.model.startswith("github_copilot/") and (
@@ -1599,103 +1749,55 @@ Examples:
 - User: "what are alternatives?" Context: "React framework..." → "React framework alternatives comparison" """  # noqa: E501
 
     try:
-        # Check if model supports structured outputs
-        # LiteLLM's supports_response_schema checks if model supports
-        # response_format
-        supports_structured = litellm.supports_response_schema(
+        if not litellm.supports_response_schema(
             model=request.model, custom_llm_provider=None
-        )
-
-        kwargs = {
-            "model": request.model,
-            "messages": [
-                {"role": "system", "content": system_prompt},
-                {
-                    "role": "user",
-                    "content": (
-                        f"User query: {request.user_query}\n\n"
-                        f"Context:\n{request.context[:2000]}"
-                    ),
-                },
-            ],
-            "temperature": 0.3,
-            "max_tokens": 150,
-        }
-
-        # Add API key if provided
-        if request.api_key:
-            kwargs["api_key"] = request.api_key
-        if request.base_url:
-            kwargs["base_url"] = request.base_url
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Refine-query requires a model that supports structured JSON "
+                    "(response_schema). Choose another model or provider."
+                ),
+            )
 
         user_content = (
             f"User query: {request.user_query}\n\nContext:\n{request.context[:2000]}"
         )
 
-        # Use structured generation if supported (llamabot StructuredBot)
-        if supports_structured:
-            logger.info(f"Using structured generation for model {request.model}")
-            try:
-                prep = {
-                    "model": request.model,
-                    "messages": [],
-                    "api_key": request.api_key,
-                    "base_url": request.base_url,
-                }
-                prep = prepare_copilot_openai_request(
-                    prep, request.model, request.api_key
-                )
-                extras = copilot_extras_for_bot(prep)
-                completion_kwargs = dict(extras)
-                completion_kwargs["max_tokens"] = 150
-                refine_query_bot = StructuredBot(
-                    system_prompt=system_prompt,
-                    pydantic_model=RefinedQueryOutput,
-                    model_name=prep["model"],
-                    temperature=0.3,
-                    stream_target="none",
-                    api_key=prep.get("api_key"),
-                    **completion_kwargs,
-                )
+        prep = {
+            "model": request.model,
+            "messages": [],
+            "api_key": request.api_key,
+            "base_url": request.base_url,
+        }
+        prep = prepare_copilot_openai_request(prep, request.model, request.api_key)
+        extras = copilot_extras_for_bot(prep)
+        completion_kwargs = dict(extras)
+        completion_kwargs["max_tokens"] = 150
+        refine_query_bot = AsyncStructuredBot(
+            system_prompt=system_prompt,
+            pydantic_model=RefinedQueryOutput,
+            model_name=prep["model"],
+            temperature=0.3,
+            stream_target="none",
+            api_key=prep.get("api_key"),
+            **completion_kwargs,
+        )
 
-                def _refine_structured_run() -> RefinedQueryOutput:
-                    r = refine_query_bot(
-                        HumanMessage(content=user_content), num_attempts=5
-                    )
-                    if r is None:
-                        raise RuntimeError("StructuredBot returned None")
-                    return r
-
-                result = await asyncio.to_thread(_refine_structured_run)
-                refined_query = result.refined_query.strip()
-            except Exception as structured_error:
-                # If structured generation fails, fall back to regular completion
-                logger.warning(
-                    f"Structured generation failed for {request.model}: "
-                    f"{structured_error}. Falling back to regular completion."
-                )
-                kwargs.pop("response_format", None)
-                kw = {**kwargs, "stream": False}
-                response = await litellm.acompletion(**kw)
-                refined_query = (response.choices[0].message.content or "").strip()
-
-                # Remove quotes if the LLM wrapped the query in them
-                if refined_query.startswith('"') and refined_query.endswith('"'):
-                    refined_query = refined_query[1:-1]
-        else:
-            logger.info(
-                f"Model {request.model} doesn't support structured generation, "
-                "using regular completion"
+        logger.info(f"Using structured generation for model {request.model}")
+        result = await refine_query_bot(
+            HumanMessage(content=user_content), num_attempts=5
+        )
+        if result is None:
+            raise HTTPException(
+                status_code=502,
+                detail="Could not obtain valid structured output after retries.",
             )
-            kw = {**kwargs, "stream": False}
-            response = await litellm.acompletion(**kw)
-            refined_query = (response.choices[0].message.content or "").strip()
+        refined_query = result.refined_query.strip()
 
-            # Remove quotes if the LLM wrapped the query in them
-            if refined_query.startswith('"') and refined_query.endswith('"'):
-                refined_query = refined_query[1:-1]
+        if refined_query.startswith('"') and refined_query.endswith('"'):
+            refined_query = refined_query[1:-1]
 
-        # If LLM returned empty, fall back to original query
         if not refined_query:
             logger.warning("LLM returned empty refined query, using original")
             refined_query = request.user_query
@@ -1703,14 +1805,12 @@ Examples:
         logger.info(f"Refined query: '{refined_query}'")
         return {"original_query": request.user_query, "refined_query": refined_query}
 
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error(f"Failed to refine query: {e}")
         logger.error(traceback.format_exc())
-        # Fall back to the original query if LLM fails
-        return {
-            "original_query": request.user_query,
-            "refined_query": request.user_query,
-        }
+        raise HTTPException(status_code=500, detail=str(e)) from e
 
 
 class ImageGenerationRequest(BaseModel):
@@ -1853,13 +1953,13 @@ async def generate_image(request: ImageGenerationRequest):
             "revised_prompt": None,  # Ollama doesn't support revised prompt
         }
 
-    except litellm.AuthenticationError as e:
+    except AuthenticationError as e:
         logger.error(f"Authentication error: {e}")
         raise HTTPException(
             status_code=401,
             detail=f"Authentication failed: {str(e)}. Please check your API key.",
         ) from e
-    except litellm.RateLimitError as e:
+    except RateLimitError as e:
         logger.error(f"Rate limit error: {e}")
         raise HTTPException(
             status_code=429,
@@ -1925,38 +2025,6 @@ async def exa_search(request: ExaSearchRequest):
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-def _extract_json_array(text: str) -> list[str]:
-    """Parse a JSON array of strings from LLM output.
-
-    Includes a small best-effort fallback that extracts the first `[...]` region
-    if the model wraps the JSON in extra text.
-    """
-    text = (text or "").strip()
-    if not text:
-        return []
-
-    # Strict parse
-    try:
-        data = json.loads(text)
-        if isinstance(data, list):
-            return [str(x).strip() for x in data if str(x).strip()]
-    except Exception:
-        pass
-
-    # Best-effort: find first [...] region
-    start = text.find("[")
-    end = text.rfind("]")
-    if start != -1 and end != -1 and end > start:
-        try:
-            data = json.loads(text[start : end + 1])
-            if isinstance(data, list):
-                return [str(x).strip() for x in data if str(x).strip()]
-        except Exception:
-            return []
-
-    return []
-
-
 def _dedupe_preserve_order(items: list[str]) -> list[str]:
     seen: set[str] = set()
     out: list[str] = []
@@ -1972,33 +2040,7 @@ def _dedupe_preserve_order(items: list[str]) -> list[str]:
     return out
 
 
-async def _llm_text(
-    *,
-    model: str,
-    api_key: str | None,
-    base_url: str | None,
-    messages: list[dict],
-    temperature: float = 0.3,
-    max_tokens: int | None = None,
-) -> str:
-    kwargs: dict[str, Any] = {
-        "model": model,
-        "messages": messages,
-        "temperature": temperature,
-        "stream": False,
-    }
-    if max_tokens is not None:
-        kwargs["max_tokens"] = max_tokens
-    if api_key:
-        kwargs["api_key"] = api_key
-    if base_url:
-        kwargs["base_url"] = base_url
-    kwargs = prepare_copilot_openai_request(kwargs, model, api_key)
-    response = await litellm.acompletion(**kwargs)
-    return (response.choices[0].message.content or "").strip()
-
-
-async def _llm_json_array(
+async def run_structured_string_list(
     *,
     model: str,
     api_key: str | None,
@@ -2008,57 +2050,41 @@ async def _llm_json_array(
     temperature: float = 0.3,
     max_tokens: int = 250,
 ) -> list[str]:
-    supports_structured = litellm.supports_response_schema(
-        model=model, custom_llm_provider=None
-    )
-    if supports_structured:
-        try:
-            prep = {
-                "model": model,
-                "messages": [],
-                "api_key": api_key,
-                "base_url": base_url,
-            }
-            prep = prepare_copilot_openai_request(prep, model, api_key)
-            extras = copilot_extras_for_bot(prep)
-            completion_kwargs = dict(extras)
-            completion_kwargs["max_tokens"] = max_tokens
-            json_list_bot = StructuredBot(
-                system_prompt=system_prompt,
-                pydantic_model=JsonStringListOutput,
-                model_name=prep["model"],
-                temperature=temperature,
-                stream_target="none",
-                api_key=prep.get("api_key"),
-                **completion_kwargs,
-            )
+    """Return a deduped list of strings using ``AsyncStructuredBot``.
 
-            def _json_list_run() -> JsonStringListOutput:
-                r = json_list_bot(HumanMessage(content=user_prompt), num_attempts=5)
-                if r is None:
-                    raise RuntimeError("StructuredBot returned None")
-                return r
+    Uses :class:`JsonStringListOutput` (field ``items``). Raises :class:`ValueError`
+    if the model does not support ``supports_response_schema``.
+    """
+    if not litellm.supports_response_schema(model=model, custom_llm_provider=None):
+        raise ValueError(
+            "Structured list generation requires a model that supports structured "
+            "JSON (response_schema)."
+        )
 
-            result = await asyncio.to_thread(_json_list_run)
-            return _dedupe_preserve_order(result.items)
-        except Exception:
-            logger.warning(
-                "Structured list extraction failed; falling back to text parsing",
-                exc_info=True,
-            )
-
-    text = await _llm_text(
-        model=model,
-        api_key=api_key,
-        base_url=base_url,
-        messages=[
-            {"role": "system", "content": system_prompt},
-            {"role": "user", "content": user_prompt},
-        ],
+    prep = {
+        "model": model,
+        "messages": [],
+        "api_key": api_key,
+        "base_url": base_url,
+    }
+    prep = prepare_copilot_openai_request(prep, model, api_key)
+    extras = copilot_extras_for_bot(prep)
+    completion_kwargs = dict(extras)
+    completion_kwargs["max_tokens"] = max_tokens
+    json_list_bot = AsyncStructuredBot(
+        system_prompt=system_prompt,
+        pydantic_model=JsonStringListOutput,
+        model_name=prep["model"],
         temperature=temperature,
-        max_tokens=max_tokens,
+        stream_target="none",
+        api_key=prep.get("api_key"),
+        **completion_kwargs,
     )
-    return _dedupe_preserve_order(_extract_json_array(text))
+
+    result = await json_list_bot(HumanMessage(content=user_prompt), num_attempts=5)
+    if result is None:
+        raise RuntimeError("StructuredBot returned None")
+    return _dedupe_preserve_order(result.items)
 
 
 def format_research_output(output) -> str:
@@ -2723,7 +2749,7 @@ Examples of good titles:
         extras = copilot_extras_for_bot(prepared)
         completion_kwargs = dict(extras)
         completion_kwargs["max_tokens"] = 50
-        title_bot = SimpleBot(
+        title_bot = AsyncSimpleBot(
             system_prompt=system_prompt,
             model_name=prepared["model"],
             temperature=0.7,
@@ -2732,17 +2758,14 @@ Examples of good titles:
             **completion_kwargs,
         )
 
-        def _title_run() -> str:
-            out = title_bot(
-                HumanMessage(
-                    content=(
-                        f"Generate a title for this conversation:\n\n{request.content}"
-                    )
+        out = await title_bot(
+            HumanMessage(
+                content=(
+                    f"Generate a title for this conversation:\n\n{request.content}"
                 )
             )
-            return out.content if hasattr(out, "content") else str(out)
-
-        title = await asyncio.to_thread(_title_run)
+        )
+        title = out.content if hasattr(out, "content") else str(out)
 
         # Clean up any quotes or extra formatting
         title = title.strip("\"'")
@@ -2802,7 +2825,7 @@ Examples:
         extras = copilot_extras_for_bot(prepared)
         completion_kwargs = dict(extras)
         completion_kwargs["max_tokens"] = 30
-        node_summary_bot = SimpleBot(
+        node_summary_bot = AsyncSimpleBot(
             system_prompt=system_prompt,
             model_name=prepared["model"],
             temperature=0.5,
@@ -2811,17 +2834,14 @@ Examples:
             **completion_kwargs,
         )
 
-        def _node_summary_run() -> str:
-            out = node_summary_bot(
-                HumanMessage(
-                    content=(
-                        f"Summarize this content:\n\n{request.content[:2000]}"  # noqa: E501
-                    )
+        out = await node_summary_bot(
+            HumanMessage(
+                content=(
+                    f"Summarize this content:\n\n{request.content[:2000]}"  # noqa: E501
                 )
             )
-            return out.content if hasattr(out, "content") else str(out)
-
-        content = await asyncio.to_thread(_node_summary_run)
+        )
+        content = out.content if hasattr(out, "content") else str(out)
 
         # Handle None or empty content from LLM
         if not content:
@@ -2845,7 +2865,7 @@ Examples:
         logger.info(f"Generated summary: {summary}")
         return {"summary": summary}
 
-    except litellm.APIConnectionError as e:
+    except APIConnectionError as e:
         # Handle Gemini MAX_TOKENS bug in LiteLLM
         error_str = str(e).lower()
         if "max_tokens" in error_str or "finishreason" in error_str:
@@ -2922,9 +2942,7 @@ async def stream_single_opinion(
 
         kwargs = {
             "model": model,
-            "messages": messages,
             "temperature": 0.7,
-            "stream": True,
         }
 
         if api_key:
@@ -2936,17 +2954,16 @@ async def stream_single_opinion(
 
         full_content = ""
 
-        response = await litellm.acompletion(**kwargs)
-        async for chunk in response:
-            if chunk.choices and chunk.choices[0].delta.content:
-                content = chunk.choices[0].delta.content
-                full_content += content
-                await queue.put(
-                    {
-                        "event": "opinion_chunk",
-                        "data": {"index": index, "content": content},
-                    }
-                )
+        async for content in _stream_text_deltas_async_simple_bot(
+            messages, kwargs, temperature=0.7
+        ):
+            full_content += content
+            await queue.put(
+                {
+                    "event": "opinion_chunk",
+                    "data": {"index": index, "content": content},
+                }
+            )
 
         await queue.put(
             {
@@ -3015,9 +3032,7 @@ Please review and rank these opinions.""",
 
         kwargs = {
             "model": reviewer_model,
-            "messages": messages,
             "temperature": 0.5,
-            "stream": True,
         }
 
         if api_key:
@@ -3029,20 +3044,19 @@ Please review and rank these opinions.""",
 
         full_content = ""
 
-        response = await litellm.acompletion(**kwargs)
-        async for chunk in response:
-            if chunk.choices and chunk.choices[0].delta.content:
-                content = chunk.choices[0].delta.content
-                full_content += content
-                await queue.put(
-                    {
-                        "event": "review_chunk",
-                        "data": {
-                            "reviewer_index": reviewer_index,
-                            "content": content,
-                        },
-                    }
-                )
+        async for content in _stream_text_deltas_async_simple_bot(
+            messages, kwargs, temperature=0.5
+        ):
+            full_content += content
+            await queue.put(
+                {
+                    "event": "review_chunk",
+                    "data": {
+                        "reviewer_index": reviewer_index,
+                        "content": content,
+                    },
+                }
+            )
 
         await queue.put(
             {
@@ -3267,20 +3281,20 @@ Provide your own assessment of the most accurate and helpful response."""
                 request.chairman_model, request.api_keys
             )
 
+            synthesis_messages = [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a chairman synthesizing committee opinions "
+                        "into a final, comprehensive answer."
+                    ),
+                },
+                {"role": "user", "content": synthesis_prompt},
+            ]
+
             kwargs = {
                 "model": request.chairman_model,
-                "messages": [
-                    {
-                        "role": "system",
-                        "content": (
-                            "You are a chairman synthesizing committee opinions "
-                            "into a final, comprehensive answer."
-                        ),
-                    },
-                    {"role": "user", "content": synthesis_prompt},
-                ],
                 "temperature": 0.5,
-                "stream": True,
             }
 
             if chairman_api_key:
@@ -3294,15 +3308,14 @@ Provide your own assessment of the most accurate and helpful response."""
 
             synthesis_content = ""
 
-            response = await litellm.acompletion(**kwargs)
-            async for chunk in response:
-                if chunk.choices and chunk.choices[0].delta.content:
-                    content = chunk.choices[0].delta.content
-                    synthesis_content += content
-                    yield {
-                        "event": "synthesis_chunk",
-                        "data": json.dumps({"content": content}),
-                    }
+            async for content in _stream_text_deltas_async_simple_bot(
+                synthesis_messages, kwargs, temperature=0.5
+            ):
+                synthesis_content += content
+                yield {
+                    "event": "synthesis_chunk",
+                    "data": json.dumps({"content": content}),
+                }
 
             yield {
                 "event": "synthesis_done",

--- a/src/canvas_chat/app.py
+++ b/src/canvas_chat/app.py
@@ -43,6 +43,8 @@ from fastapi import (
 )
 from fastapi.responses import HTMLResponse
 from fastapi.staticfiles import StaticFiles
+from llamabot import SimpleBot, StructuredBot
+from llamabot.components.messages import HumanMessage
 from pydantic import BaseModel, Field
 from sse_starlette.sse import EventSourceResponse
 
@@ -585,6 +587,16 @@ def prepare_copilot_openai_request(
     add_copilot_headers(kwargs, model)
 
     return kwargs
+
+
+def copilot_extras_for_bot(prepared: dict[str, Any]) -> dict[str, Any]:
+    """Kwargs for llamabot (e.g. base_url, headers) after Copilot request prep."""
+    out: dict[str, Any] = {}
+    if prepared.get("base_url"):
+        out["base_url"] = prepared["base_url"]
+    if prepared.get("extra_headers"):
+        out["extra_headers"] = prepared["extra_headers"]
+    return out
 
 
 def get_copilot_auth_headers(access_token: str | None = None) -> dict:
@@ -1243,7 +1255,7 @@ async def chat(request: ChatRequest, http_request: Request):
     Stream a chat completion response.
 
     The frontend sends the full conversation context (resolved from the DAG).
-    We proxy to LiteLLM and stream the response back via SSE.
+    Streams via litellm.acompletion with OpenAI-style kwargs.
     """
     # Inject admin credentials if in admin mode
     inject_admin_credentials(request)
@@ -1273,7 +1285,6 @@ async def chat(request: ChatRequest, http_request: Request):
         """Generate SSE events from the LLM stream."""
         try:
             response = await litellm.acompletion(**kwargs)
-
             async for chunk in response:
                 if chunk.choices and chunk.choices[0].delta.content:
                     content = chunk.choices[0].delta.content
@@ -1365,8 +1376,25 @@ Summary:"""
     kwargs = prepare_copilot_openai_request(kwargs, request.model, request.api_key)
 
     try:
-        response = await litellm.acompletion(**kwargs)
-        summary = response.choices[0].message.content
+        extras = copilot_extras_for_bot(kwargs)
+        completion_kwargs = dict(extras)
+        completion_kwargs["max_tokens"] = 500
+        summarize_bot = SimpleBot(
+            system_prompt=(
+                "You are a helpful assistant that writes concise, accurate summaries."
+            ),
+            model_name=kwargs["model"],
+            temperature=0.3,
+            stream_target="none",
+            api_key=kwargs.get("api_key"),
+            **completion_kwargs,
+        )
+
+        def _summarize_run() -> str:
+            out = summarize_bot(HumanMessage(content=summary_prompt))
+            return out.content if hasattr(out, "content") else str(out)
+
+        summary = await asyncio.to_thread(_summarize_run)
         return {"summary": summary}
     except Exception as e:
         error_msg = str(e)
@@ -1484,6 +1512,15 @@ class RefineQueryRequest(BaseModel):
     base_url: str | None = None
 
 
+class JsonStringListOutput(BaseModel):
+    """Structured output for list extraction (DDG follow-ups, etc.)."""
+
+    items: list[str] = Field(
+        default_factory=list,
+        description="List of distinct short strings.",
+    )
+
+
 class RefinedQueryOutput(BaseModel):
     """Structured output for refined query - used with LLM structured generation."""
 
@@ -1591,42 +1628,56 @@ Examples:
         if request.base_url:
             kwargs["base_url"] = request.base_url
 
-        # Use structured generation if supported
+        user_content = (
+            f"User query: {request.user_query}\n\nContext:\n{request.context[:2000]}"
+        )
+
+        # Use structured generation if supported (llamabot StructuredBot)
         if supports_structured:
             logger.info(f"Using structured generation for model {request.model}")
             try:
-                kwargs["response_format"] = RefinedQueryOutput
-                response = await litellm.acompletion(**kwargs)
+                prep = {
+                    "model": request.model,
+                    "messages": [],
+                    "api_key": request.api_key,
+                    "base_url": request.base_url,
+                }
+                prep = prepare_copilot_openai_request(
+                    prep, request.model, request.api_key
+                )
+                extras = copilot_extras_for_bot(prep)
+                completion_kwargs = dict(extras)
+                completion_kwargs["max_tokens"] = 150
+                refine_query_bot = StructuredBot(
+                    system_prompt=system_prompt,
+                    pydantic_model=RefinedQueryOutput,
+                    model_name=prep["model"],
+                    temperature=0.3,
+                    stream_target="none",
+                    api_key=prep.get("api_key"),
+                    **completion_kwargs,
+                )
 
-                # With structured generation, response is already parsed
-                if hasattr(response, "choices") and response.choices:
-                    # LiteLLM returns structured object directly in message content
-                    content = response.choices[0].message.content
-                    if isinstance(content, str):
-                        # Parse JSON if returned as string
-                        import json
+                def _refine_structured_run() -> RefinedQueryOutput:
+                    r = refine_query_bot(
+                        HumanMessage(content=user_content), num_attempts=5
+                    )
+                    if r is None:
+                        raise RuntimeError("StructuredBot returned None")
+                    return r
 
-                        parsed = json.loads(content)
-                        refined_query = parsed.get("refined_query", "").strip()
-                    elif hasattr(content, "refined_query"):
-                        # Direct object access
-                        refined_query = content.refined_query.strip()
-                    else:
-                        # Fallback: treat as dict
-                        refined_query = content.get("refined_query", "").strip()
-                else:
-                    logger.warning("Unexpected structured response format")
-                    refined_query = request.user_query
+                result = await asyncio.to_thread(_refine_structured_run)
+                refined_query = result.refined_query.strip()
             except Exception as structured_error:
                 # If structured generation fails, fall back to regular completion
                 logger.warning(
                     f"Structured generation failed for {request.model}: "
                     f"{structured_error}. Falling back to regular completion."
                 )
-                # Remove response_format and retry with regular completion
                 kwargs.pop("response_format", None)
-                response = await litellm.acompletion(**kwargs)
-                refined_query = response.choices[0].message.content.strip()
+                kw = {**kwargs, "stream": False}
+                response = await litellm.acompletion(**kw)
+                refined_query = (response.choices[0].message.content or "").strip()
 
                 # Remove quotes if the LLM wrapped the query in them
                 if refined_query.startswith('"') and refined_query.endswith('"'):
@@ -1636,8 +1687,9 @@ Examples:
                 f"Model {request.model} doesn't support structured generation, "
                 "using regular completion"
             )
-            response = await litellm.acompletion(**kwargs)
-            refined_query = response.choices[0].message.content.strip()
+            kw = {**kwargs, "stream": False}
+            response = await litellm.acompletion(**kw)
+            refined_query = (response.choices[0].message.content or "").strip()
 
             # Remove quotes if the LLM wrapped the query in them
             if refined_query.startswith('"') and refined_query.endswith('"'):
@@ -1929,10 +1981,11 @@ async def _llm_text(
     temperature: float = 0.3,
     max_tokens: int | None = None,
 ) -> str:
-    kwargs: dict = {
+    kwargs: dict[str, Any] = {
         "model": model,
         "messages": messages,
         "temperature": temperature,
+        "stream": False,
     }
     if max_tokens is not None:
         kwargs["max_tokens"] = max_tokens
@@ -1940,7 +1993,6 @@ async def _llm_text(
         kwargs["api_key"] = api_key
     if base_url:
         kwargs["base_url"] = base_url
-
     kwargs = prepare_copilot_openai_request(kwargs, model, api_key)
     response = await litellm.acompletion(**kwargs)
     return (response.choices[0].message.content or "").strip()
@@ -1956,6 +2008,45 @@ async def _llm_json_array(
     temperature: float = 0.3,
     max_tokens: int = 250,
 ) -> list[str]:
+    supports_structured = litellm.supports_response_schema(
+        model=model, custom_llm_provider=None
+    )
+    if supports_structured:
+        try:
+            prep = {
+                "model": model,
+                "messages": [],
+                "api_key": api_key,
+                "base_url": base_url,
+            }
+            prep = prepare_copilot_openai_request(prep, model, api_key)
+            extras = copilot_extras_for_bot(prep)
+            completion_kwargs = dict(extras)
+            completion_kwargs["max_tokens"] = max_tokens
+            json_list_bot = StructuredBot(
+                system_prompt=system_prompt,
+                pydantic_model=JsonStringListOutput,
+                model_name=prep["model"],
+                temperature=temperature,
+                stream_target="none",
+                api_key=prep.get("api_key"),
+                **completion_kwargs,
+            )
+
+            def _json_list_run() -> JsonStringListOutput:
+                r = json_list_bot(HumanMessage(content=user_prompt), num_attempts=5)
+                if r is None:
+                    raise RuntimeError("StructuredBot returned None")
+                return r
+
+            result = await asyncio.to_thread(_json_list_run)
+            return _dedupe_preserve_order(result.items)
+        except Exception:
+            logger.warning(
+                "Structured list extraction failed; falling back to text parsing",
+                exc_info=True,
+            )
+
     text = await _llm_text(
         model=model,
         api_key=api_key,
@@ -2620,32 +2711,38 @@ Examples of good titles:
     )
 
     try:
-        kwargs = {
-            "model": request.model,
-            "messages": [
-                {"role": "system", "content": system_prompt},
-                {
-                    "role": "user",
-                    "content": (
-                        f"Generate a title for this conversation:\n\n{request.content}"
-                    ),
-                },
-            ],
-            "temperature": 0.7,
-            "max_tokens": 50,
-        }
-
         api_key = get_api_key_for_provider(provider, request.api_key)
-        if api_key:
-            kwargs["api_key"] = api_key
 
-        if request.base_url:
-            kwargs["base_url"] = request.base_url
+        prepared = {
+            "model": request.model,
+            "messages": [],
+            "api_key": api_key,
+            "base_url": request.base_url,
+        }
+        prepared = prepare_copilot_openai_request(prepared, request.model, api_key)
+        extras = copilot_extras_for_bot(prepared)
+        completion_kwargs = dict(extras)
+        completion_kwargs["max_tokens"] = 50
+        title_bot = SimpleBot(
+            system_prompt=system_prompt,
+            model_name=prepared["model"],
+            temperature=0.7,
+            stream_target="none",
+            api_key=prepared.get("api_key"),
+            **completion_kwargs,
+        )
 
-        kwargs = prepare_copilot_openai_request(kwargs, request.model, api_key)
+        def _title_run() -> str:
+            out = title_bot(
+                HumanMessage(
+                    content=(
+                        f"Generate a title for this conversation:\n\n{request.content}"
+                    )
+                )
+            )
+            return out.content if hasattr(out, "content") else str(out)
 
-        response = await litellm.acompletion(**kwargs)
-        title = response.choices[0].message.content.strip()
+        title = await asyncio.to_thread(_title_run)
 
         # Clean up any quotes or extra formatting
         title = title.strip("\"'")
@@ -2693,30 +2790,38 @@ Examples:
     )
 
     try:
-        kwargs = {
-            "model": request.model,
-            "messages": [
-                {"role": "system", "content": system_prompt},
-                {
-                    "role": "user",
-                    "content": f"Summarize this content:\n\n{request.content[:2000]}",  # noqa: E501
-                },
-            ],
-            "temperature": 0.5,
-            "max_tokens": 30,
-        }
-
         api_key = get_api_key_for_provider(provider, request.api_key)
-        if api_key:
-            kwargs["api_key"] = api_key
 
-        if request.base_url:
-            kwargs["base_url"] = request.base_url
+        prepared = {
+            "model": request.model,
+            "messages": [],
+            "api_key": api_key,
+            "base_url": request.base_url,
+        }
+        prepared = prepare_copilot_openai_request(prepared, request.model, api_key)
+        extras = copilot_extras_for_bot(prepared)
+        completion_kwargs = dict(extras)
+        completion_kwargs["max_tokens"] = 30
+        node_summary_bot = SimpleBot(
+            system_prompt=system_prompt,
+            model_name=prepared["model"],
+            temperature=0.5,
+            stream_target="none",
+            api_key=prepared.get("api_key"),
+            **completion_kwargs,
+        )
 
-        kwargs = prepare_copilot_openai_request(kwargs, request.model, api_key)
+        def _node_summary_run() -> str:
+            out = node_summary_bot(
+                HumanMessage(
+                    content=(
+                        f"Summarize this content:\n\n{request.content[:2000]}"  # noqa: E501
+                    )
+                )
+            )
+            return out.content if hasattr(out, "content") else str(out)
 
-        response = await litellm.acompletion(**kwargs)
-        content = response.choices[0].message.content
+        content = await asyncio.to_thread(_node_summary_run)
 
         # Handle None or empty content from LLM
         if not content:
@@ -2829,9 +2934,9 @@ async def stream_single_opinion(
 
         kwargs = prepare_copilot_openai_request(kwargs, model, api_key)
 
-        response = await litellm.acompletion(**kwargs)
         full_content = ""
 
+        response = await litellm.acompletion(**kwargs)
         async for chunk in response:
             if chunk.choices and chunk.choices[0].delta.content:
                 content = chunk.choices[0].delta.content
@@ -2922,9 +3027,9 @@ Please review and rank these opinions.""",
 
         kwargs = prepare_copilot_openai_request(kwargs, reviewer_model, api_key)
 
-        response = await litellm.acompletion(**kwargs)
         full_content = ""
 
+        response = await litellm.acompletion(**kwargs)
         async for chunk in response:
             if chunk.choices and chunk.choices[0].delta.content:
                 content = chunk.choices[0].delta.content
@@ -2932,7 +3037,10 @@ Please review and rank these opinions.""",
                 await queue.put(
                     {
                         "event": "review_chunk",
-                        "data": {"reviewer_index": reviewer_index, "content": content},
+                        "data": {
+                            "reviewer_index": reviewer_index,
+                            "content": content,
+                        },
                     }
                 )
 
@@ -3184,9 +3292,9 @@ Provide your own assessment of the most accurate and helpful response."""
                 kwargs, request.chairman_model, chairman_api_key
             )
 
-            response = await litellm.acompletion(**kwargs)
             synthesis_content = ""
 
+            response = await litellm.acompletion(**kwargs)
             async for chunk in response:
                 if chunk.choices and chunk.choices[0].delta.content:
                     content = chunk.choices[0].delta.content

--- a/src/canvas_chat/app.py
+++ b/src/canvas_chat/app.py
@@ -79,6 +79,60 @@ from canvas_chat.plugins import (
 from canvas_chat.plugins.pdf_handler import MAX_PDF_SIZE
 from canvas_chat.url_fetch_registry import UrlFetchRegistry
 
+# LiteLLM: patch before StructuredBot uses ``get_supported_openai_params`` (see below).
+litellm.drop_params = True  # Drop unsupported params gracefully
+
+
+def _patch_litellm_for_llamabot_structured_and_copilot() -> None:
+    """Fix LiteLLM + llamabot StructuredBot for GitHub Copilot model IDs.
+
+    For ``github_copilot/...``, LiteLLM often returns ``None`` from
+    :func:`litellm.get_supported_openai_params`, and ``False`` from
+    :func:`litellm.supports_response_schema`. llamabot's
+    :class:`~llamabot.bot.structuredbot.StructuredBot` then does
+    ``\"response_format\" in params`` and crashes with
+    ``TypeError: argument of type 'NoneType' is not a container or iterable``,
+    or raises ``ValueError`` when params is ``[]``.
+
+    Copilot's chat API is OpenAI-compatible and supports JSON / schema-style
+    responses for structured extraction. We mirror OpenAI's supported param list
+    and treat Copilot as schema-capable when the upstream helpers return
+    unknown/unsupported.
+
+    llamabot imports these functions into ``structuredbot`` by name; after
+    patching :mod:`litellm`, rebind them on that module so runtime lookups use
+    the wrappers.
+    """
+    _orig_params = litellm.get_supported_openai_params
+    _orig_schema = litellm.supports_response_schema
+
+    def _params_wrapped(*args: Any, **kwargs: Any) -> Any:
+        out = _orig_params(*args, **kwargs)
+        if out is not None:
+            return out
+        model = args[0] if args else kwargs.get("model", "")
+        if isinstance(model, str) and model.startswith("github_copilot/"):
+            if args:
+                return _orig_params("openai/gpt-4o", *args[1:])
+            return _orig_params(**{**kwargs, "model": "openai/gpt-4o"})
+        return []
+
+    def _schema_wrapped(model: str, custom_llm_provider: str | None = None) -> bool:
+        if isinstance(model, str) and model.startswith("github_copilot/"):
+            return True
+        return _orig_schema(model=model, custom_llm_provider=custom_llm_provider)
+
+    litellm.get_supported_openai_params = _params_wrapped  # type: ignore[method-assign]
+    litellm.supports_response_schema = _schema_wrapped  # type: ignore[method-assign]
+
+
+_patch_litellm_for_llamabot_structured_and_copilot()
+
+import llamabot.bot.structuredbot as _lb_structured  # noqa: E402
+
+_lb_structured.get_supported_openai_params = litellm.get_supported_openai_params
+_lb_structured.supports_response_schema = litellm.supports_response_schema
+
 # Text completions use llamabot AsyncSimpleBot / AsyncStructuredBot. LiteLLM is
 # still imported for drop_params, token_counter, Copilot model list, images,
 # and supports_response_schema (StructuredBot uses litellm internally too).
@@ -86,9 +140,6 @@ from canvas_chat.url_fetch_registry import UrlFetchRegistry
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
-
-# Configure litellm
-litellm.drop_params = True  # Drop unsupported params gracefully
 
 app = FastAPI(title="Canvas Chat", version=__version__)
 
@@ -2050,17 +2101,12 @@ async def run_structured_string_list(
     temperature: float = 0.3,
     max_tokens: int = 250,
 ) -> list[str]:
-    """Return a deduped list of strings using ``AsyncStructuredBot``.
+    """Return a deduped list of strings using :class:`AsyncStructuredBot`.
 
-    Uses :class:`JsonStringListOutput` (field ``items``). Raises :class:`ValueError`
-    if the model does not support ``supports_response_schema``.
+    Same pattern as :func:`run_structured_summarize`: no LiteLLM
+    ``supports_response_schema`` gate—StructuredBot + provider handle JSON
+    extraction; retries apply via ``num_attempts`` on the bot.
     """
-    if not litellm.supports_response_schema(model=model, custom_llm_provider=None):
-        raise ValueError(
-            "Structured list generation requires a model that supports structured "
-            "JSON (response_schema)."
-        )
-
     prep = {
         "model": model,
         "messages": [],

--- a/src/canvas_chat/llm_messages.py
+++ b/src/canvas_chat/llm_messages.py
@@ -1,0 +1,74 @@
+"""Map OpenAI-style chat payloads to llamabot ``BaseMessage`` lists."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from llamabot.components.messages import (
+    AIMessage,
+    BaseMessage,
+    HumanMessage,
+    ToolMessage,
+)
+
+
+def message_content_to_str(content: str | list[Any]) -> str:
+    """Normalize multimodal or string content to a single string for the LLM."""
+    if isinstance(content, str):
+        return content
+    return json.dumps(content)
+
+
+def dict_messages_to_system_and_rest(
+    messages: list[dict[str, Any]],
+) -> tuple[str, list[BaseMessage]]:
+    """Split OpenAI-style dict messages into system prompt text and conversation turns.
+
+    :param messages: Each dict should have ``role`` and ``content`` (string or list).
+    :returns: ``(system_prompt, rest)`` where ``rest`` is user/assistant/tool messages.
+    """
+    system_chunks: list[str] = []
+    rest: list[BaseMessage] = []
+    for m in messages:
+        role = m.get("role", "user")
+        raw = m.get("content", "")
+        content = message_content_to_str(raw) if not isinstance(raw, str) else raw
+        if role == "system":
+            system_chunks.append(content)
+        elif role == "user":
+            rest.append(HumanMessage(content=content))
+        elif role == "assistant":
+            rest.append(AIMessage(content=content))
+        elif role == "tool":
+            rest.append(ToolMessage(content=content))
+        else:
+            rest.append(HumanMessage(content=content))
+    system_prompt = (
+        "\n\n".join(system_chunks) if system_chunks else "You are a helpful assistant."
+    )
+    return system_prompt, rest
+
+
+def pydantic_messages_to_system_and_rest(
+    messages: list[Any],
+) -> tuple[str, list[BaseMessage]]:
+    """Like :func:`dict_messages_to_system_and_rest` for Pydantic ``Message`` models."""
+    system_chunks: list[str] = []
+    rest: list[BaseMessage] = []
+    for m in messages:
+        content = message_content_to_str(m.content)
+        if m.role == "system":
+            system_chunks.append(content)
+        elif m.role == "user":
+            rest.append(HumanMessage(content=content))
+        elif m.role == "assistant":
+            rest.append(AIMessage(content=content))
+        elif m.role == "tool":
+            rest.append(ToolMessage(content=content))
+        else:
+            rest.append(HumanMessage(content=content))
+    system_prompt = (
+        "\n\n".join(system_chunks) if system_chunks else "You are a helpful assistant."
+    )
+    return system_prompt, rest

--- a/src/canvas_chat/plugins/code_handler.py
+++ b/src/canvas_chat/plugins/code_handler.py
@@ -76,7 +76,10 @@ def register_endpoints(app):
 
         try:
             # Import here to avoid circular imports
+            from litellm.exceptions import AuthenticationError, RateLimitError
+
             from canvas_chat.app import (
+                _stream_text_deltas_async_simple_bot,
                 extract_provider,
                 get_api_key_for_provider,
                 prepare_copilot_openai_request,
@@ -163,9 +166,7 @@ def register_endpoints(app):
 
             kwargs = {
                 "model": request.model,
-                "messages": messages,
                 "temperature": 0.3,  # Lower temperature for code generation
-                "stream": True,
             }
 
             if api_key:
@@ -177,18 +178,15 @@ def register_endpoints(app):
 
             async def generate():
                 try:
-                    import litellm
-
-                    response = await litellm.acompletion(**kwargs)
-                    async for chunk in response:
-                        if chunk.choices and chunk.choices[0].delta.content:
-                            content = chunk.choices[0].delta.content
-                            yield {"event": "message", "data": content}
+                    async for content in _stream_text_deltas_async_simple_bot(
+                        messages, kwargs, temperature=0.3
+                    ):
+                        yield {"event": "message", "data": content}
                     yield {"event": "done", "data": ""}
-                except litellm.AuthenticationError as e:
+                except AuthenticationError as e:
                     logger.error(f"Authentication error: {e}")
                     yield {"event": "error", "data": f"Authentication failed: {e}"}
-                except litellm.RateLimitError as e:
+                except RateLimitError as e:
                     logger.error(f"Rate limit error: {e}")
                     yield {"event": "error", "data": f"Rate limit exceeded: {e}"}
                 except Exception as e:

--- a/src/canvas_chat/plugins/code_handler.py
+++ b/src/canvas_chat/plugins/code_handler.py
@@ -79,7 +79,6 @@ def register_endpoints(app):
             from canvas_chat.app import (
                 extract_provider,
                 get_api_key_for_provider,
-                litellm,
                 prepare_copilot_openai_request,
             )
 
@@ -178,6 +177,8 @@ def register_endpoints(app):
 
             async def generate():
                 try:
+                    import litellm
+
                     response = await litellm.acompletion(**kwargs)
                     async for chunk in response:
                         if chunk.choices and chunk.choices[0].delta.content:

--- a/src/canvas_chat/plugins/ddg_endpoints.py
+++ b/src/canvas_chat/plugins/ddg_endpoints.py
@@ -15,6 +15,8 @@ import asyncio
 import json
 import logging
 import traceback
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
 from typing import Any
 
 import httpx
@@ -70,6 +72,42 @@ class DDGResearchSource(BaseModel):
     summary: str
     iteration: int
     query: str
+
+
+@dataclass(frozen=True)
+class DDGResearchRuntime:
+    """Clamped limits and strings for one DDG research SSE run."""
+
+    instructions: str
+    context: str
+    model: str
+    api_key: str | None
+    base_url: str | None
+    max_iterations: int
+    max_sources: int
+    max_queries_per_iteration: int
+    max_results_per_query: int
+    max_sources_per_iteration: int
+
+
+def build_ddg_research_runtime(request: DDGResearchRequest) -> DDGResearchRuntime:
+    max_iterations = max(1, min(request.max_iterations, 8))
+    max_sources = max(5, min(request.max_sources, 80))
+    max_queries_per_iteration = max(1, min(request.max_queries_per_iteration, 8))
+    max_results_per_query = max(1, min(request.max_results_per_query, 25))
+    per_iteration_sources = max_sources_per_iteration(max_sources, max_iterations)
+    return DDGResearchRuntime(
+        instructions=request.instructions.strip(),
+        context=(request.context or "").strip(),
+        model=request.model,
+        api_key=request.api_key,
+        base_url=request.base_url,
+        max_iterations=max_iterations,
+        max_sources=max_sources,
+        max_queries_per_iteration=max_queries_per_iteration,
+        max_results_per_query=max_results_per_query,
+        max_sources_per_iteration=per_iteration_sources,
+    )
 
 
 # --- DDG Deep Research prompt templates ---
@@ -133,8 +171,65 @@ Write in markdown. Rules:
 - If evidence is thin or conflicting, say so explicitly.
 """
 
+# Input-side token budget for fetched page markdown in the per-page summarize
+# prompt (instructions, context, URL, and snippet are added on top). Clipping
+# uses LiteLLM's token counter for ``model`` when available so the cap tracks
+# tokenizer density instead of a fixed character slice.
+DDG_PAGE_BODY_MAX_INPUT_TOKENS = 3000
 
-def _max_sources_per_iteration(max_sources: int, max_iterations: int) -> int:
+
+def clip_page_markdown_to_input_token_budget(
+    text: str,
+    *,
+    model: str,
+    max_input_tokens: int,
+) -> str:
+    """Return a prefix of ``text`` whose token count is at most ``max_input_tokens``.
+
+    Uses :func:`litellm.token_counter` for ``model`` when it succeeds; otherwise
+    falls back to a ~4 characters per token heuristic. Avoids counting or
+    binary-searching over extremely long strings by capping an initial slice.
+    """
+    if not text:
+        return ""
+    if max_input_tokens <= 0:
+        return ""
+
+    try:
+        import litellm
+    except ImportError:
+        litellm = None
+
+    def token_count(fragment: str) -> int:
+        if litellm is None:
+            return max(1, len(fragment) // 4)
+        try:
+            return int(litellm.token_counter(model=model, text=fragment))
+        except Exception:
+            return max(1, len(fragment) // 4)
+
+    # Cheap bound for Latin-ish text; refine if the slice is still too token-dense.
+    char_upper = max_input_tokens * 8
+    if len(text) > char_upper:
+        text = text[:char_upper]
+
+    if token_count(text) <= max_input_tokens:
+        return text
+
+    lo, hi = 0, len(text)
+    best = 0
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        prefix = text[:mid]
+        if token_count(prefix) <= max_input_tokens:
+            best = mid
+            lo = mid + 1
+        else:
+            hi = mid - 1
+    return text[:best]
+
+
+def max_sources_per_iteration(max_sources: int, max_iterations: int) -> int:
     """Compute per-iteration source cap so sources are spread across iterations.
 
     Ensures at least 5 sources per iteration and uses ceiling division so
@@ -145,6 +240,474 @@ def _max_sources_per_iteration(max_sources: int, max_iterations: int) -> int:
         5,
         (max_sources + max_iterations - 1) // max_iterations,
     )
+
+
+async def ddg_search_with_retry(
+    ddgs: Any,
+    query: str,
+    *,
+    max_results: int,
+    max_retries: int = 3,
+) -> list[dict]:
+    """Run ``ddgs.text`` with exponential backoff on empty results or errors."""
+    for attempt in range(max_retries):
+        try:
+            results = list(
+                ddgs.text(
+                    query,
+                    max_results=max_results,
+                )
+            )
+            if results:
+                return results
+            if attempt < max_retries - 1:
+                wait_time = 2.0 * (2**attempt)
+                logger.warning(
+                    f"DDG query returned empty results: {query} "
+                    f"(attempt {attempt + 1}/{max_retries}, waiting {wait_time}s)"
+                )
+                await asyncio.sleep(wait_time)
+        except Exception as e:
+            if attempt < max_retries - 1:
+                wait_time = 2.0 * (2**attempt)
+                logger.warning(
+                    f"DDG query failed: {query} ({e}) "
+                    f"(attempt {attempt + 1}/{max_retries}, waiting {wait_time}s)"
+                )
+                await asyncio.sleep(wait_time)
+            else:
+                logger.error(f"DDG query failed after retries: {query} ({e})")
+    return []
+
+
+async def ddg_fetch_page_to_source(
+    r: dict,
+    *,
+    runtime: DDGResearchRuntime,
+    client: httpx.AsyncClient,
+    iteration: int,
+    semaphore: asyncio.Semaphore,
+) -> DDGResearchSource | None:
+    """Fetch URL, summarize with LLM, return source row (or None on failure)."""
+    from canvas_chat.app import (
+        fetch_url_directly,
+        fetch_url_via_jina,
+        run_structured_summarize,
+    )
+
+    url = r["url"]
+    query = r["query"]
+    snippet = r["snippet"]
+    instructions = runtime.instructions
+    context = runtime.context
+
+    async with semaphore:
+        try:
+            try:
+                title, content_md = await fetch_url_via_jina(url, client)
+            except Exception:
+                title, content_md = await fetch_url_directly(url, client)
+
+            content_md = (content_md or "").strip()
+            if not content_md:
+                return None
+
+            content_for_llm = clip_page_markdown_to_input_token_budget(
+                content_md,
+                model=runtime.model,
+                max_input_tokens=DDG_PAGE_BODY_MAX_INPUT_TOKENS,
+            )
+
+            user_prompt = (
+                f"Research instructions:\n{instructions}\n\n"
+                + (f"Context:\n{context[:2000]}\n\n" if context else "")
+                + (f"Search query that found this page: {query}\n\n")
+                + f"Page title: {title}\n"
+                + f"URL: {url}\n"
+                + (f"Snippet: {snippet}\n\n" if snippet else "\n")
+                + (f"Page content (markdown):\n{content_for_llm}\n")
+            )
+
+            summary = await run_structured_summarize(
+                model=runtime.model,
+                api_key=runtime.api_key,
+                base_url=runtime.base_url,
+                user_prompt=user_prompt,
+                system_prompt=DDG_RESEARCH_PAGE_SUMMARY_SYSTEM_PROMPT,
+                max_tokens=450,
+                temperature=0.3,
+            )
+
+            final_title = (
+                title if title and title != "Untitled" else (r["title"] or "Untitled")
+            )
+
+            return DDGResearchSource(
+                url=url,
+                title=final_title,
+                snippet=snippet or None,
+                summary=summary,
+                iteration=iteration,
+                query=query,
+            )
+
+        except Exception as e:
+            logger.warning(f"Failed to process URL: {url} ({e})")
+            return None
+
+
+async def ddg_synthesize_final_report(
+    runtime: DDGResearchRuntime,
+    sources_md: str,
+) -> str:
+    """Synthesis report markdown, or fallback body on LLM failure."""
+    from canvas_chat.app import run_structured_summarize
+
+    synthesis_user_prompt = (
+        f"Research instructions:\n{runtime.instructions}\n\n"
+        + (f"Context:\n{runtime.context[:2000]}\n\n" if runtime.context else "")
+        + f"Sources (title, url, summary):\n{sources_md}\n"
+    )
+    try:
+        return await run_structured_summarize(
+            model=runtime.model,
+            api_key=runtime.api_key,
+            base_url=runtime.base_url,
+            user_prompt=synthesis_user_prompt,
+            system_prompt=DDG_RESEARCH_SYNTHESIS_SYSTEM_PROMPT,
+            max_tokens=8192,
+            temperature=0.3,
+        )
+    except Exception as e:
+        logger.error(f"Report synthesis failed: {e}")
+        return (
+            f"**Research Report**\n\n"
+            f"*Note: Report generation encountered an error. "
+            f"Below are the sources that were found:*\n\n"
+            f"## Sources Found\n\n"
+            f"{sources_md}\n\n"
+            f"*Error: {str(e)}*"
+        )
+
+
+async def ddg_research_event_stream(
+    runtime: DDGResearchRuntime,
+) -> AsyncIterator[dict[str, Any]]:
+    """SSE events for one DDG deep-research run."""
+    from ddgs import DDGS
+
+    from canvas_chat.app import run_structured_string_list
+
+    try:
+        if not runtime.instructions:
+            yield {"event": "error", "data": "Empty research instructions"}
+            return
+
+        yield {
+            "event": "status",
+            "data": "Generating initial search queries...",
+        }
+
+        seed_user_prompt = (
+            f"Research instructions:\n{runtime.instructions}\n\n"
+            + (f"Context:\n{runtime.context[:2000]}\n\n" if runtime.context else "")
+            + "Return JSON array of DDG search queries."
+        )
+        next_queries = await run_structured_string_list(
+            model=runtime.model,
+            api_key=runtime.api_key,
+            base_url=runtime.base_url,
+            system_prompt=DDG_RESEARCH_QUERY_GEN_SYSTEM_PROMPT,
+            user_prompt=seed_user_prompt,
+        )
+
+        if not next_queries:
+            next_queries = [runtime.instructions[:120]]
+
+        seen_queries: set[str] = set()
+        seen_urls: set[str] = set()
+        sources: list[DDGResearchSource] = []
+        min_iterations = min(3, runtime.max_iterations)
+
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            for iteration in range(1, runtime.max_iterations + 1):
+                iteration_queries = [
+                    q
+                    for q in next_queries
+                    if q.strip() and q.strip().lower() not in seen_queries
+                ][: runtime.max_queries_per_iteration]
+
+                if not iteration_queries:
+                    yield {
+                        "event": "status",
+                        "data": "No new queries to search; stopping early.",
+                    }
+                    break
+
+                for q in iteration_queries:
+                    seen_queries.add(q.strip().lower())
+
+                yield {
+                    "event": "status",
+                    "data": (
+                        f"Iteration {iteration}/{runtime.max_iterations}: "
+                        "searching DuckDuckGo..."
+                    ),
+                }
+
+                url_to_result: dict[str, dict] = {}
+
+                with DDGS() as ddgs:
+                    for q in iteration_queries:
+                        results = await ddg_search_with_retry(
+                            ddgs,
+                            q,
+                            max_results=runtime.max_results_per_query,
+                        )
+
+                        query_lower = q.lower()
+                        query_words = set(query_lower.split())
+                        relevant_results = []
+                        for r in results:
+                            url = (r.get("href") or "").strip()
+                            if not url:
+                                continue
+                            if url in url_to_result or url in seen_urls:
+                                continue
+
+                            title = (r.get("title") or "").lower()
+                            snippet = (r.get("body") or "").lower()
+                            combined_text = f"{title} {snippet}"
+
+                            min_matches = 2 if len(query_words) > 2 else 1
+                            matches = sum(
+                                1 for word in query_words if word in combined_text
+                            )
+
+                            if matches >= min_matches:
+                                relevant_results.append(r)
+                            else:
+                                logger.debug(
+                                    f"Skipping irrelevant result for "
+                                    f"'{q}': {r.get('title', 'Untitled')}"
+                                )
+
+                        for r in relevant_results:
+                            url = (r.get("href") or "").strip()
+                            url_to_result[url] = {
+                                "query": q,
+                                "title": (r.get("title") or "Untitled").strip(),
+                                "snippet": (r.get("body") or "").strip(),
+                                "url": url,
+                            }
+
+                        await asyncio.sleep(1.0)
+
+                if not url_to_result:
+                    yield {
+                        "event": "status",
+                        "data": (
+                            f"Iteration {iteration}: no relevant "
+                            "results found. This may indicate rate "
+                            "limiting or poor query quality."
+                        ),
+                    }
+                    if iteration == 1 and len(sources) == 0:
+                        yield {
+                            "event": "error",
+                            "data": (
+                                "No relevant search results found. "
+                                "This may be due to DuckDuckGo rate "
+                                "limiting. Please try again in a few "
+                                "minutes, or add an Exa API key for "
+                                "more reliable research."
+                            ),
+                        }
+                        return
+                    learned_blob = "\n".join(
+                        [f"- {s.title}: {s.summary[:200]}" for s in sources[-10:]]
+                    )
+                    next_queries = await run_structured_string_list(
+                        model=runtime.model,
+                        api_key=runtime.api_key,
+                        base_url=runtime.base_url,
+                        system_prompt=DDG_RESEARCH_ADJACENT_QUERY_SYSTEM_PROMPT,
+                        user_prompt=(
+                            f"Research instructions:\n{runtime.instructions}\n\n"
+                            f"What we learned so far:\n{learned_blob}\n\n"
+                            f"Previous queries:\n"
+                            f"{', '.join(sorted(seen_queries))}\n\n"
+                            "Return JSON array of new DDG queries."
+                        ),
+                    )
+                    continue
+
+                remaining_total = runtime.max_sources - len(sources)
+                num_to_process = min(
+                    len(url_to_result),
+                    remaining_total,
+                    runtime.max_sources_per_iteration,
+                )
+                yield {
+                    "event": "status",
+                    "data": (
+                        f"Iteration {iteration}: "
+                        f"fetching {num_to_process} pages in parallel..."
+                    ),
+                }
+
+                for url in url_to_result:
+                    seen_urls.add(url)
+
+                sem = asyncio.Semaphore(6)
+                items_to_process = list(url_to_result.values())[:num_to_process]
+                tasks = [
+                    ddg_fetch_page_to_source(
+                        r,
+                        runtime=runtime,
+                        client=client,
+                        iteration=iteration,
+                        semaphore=sem,
+                    )
+                    for r in items_to_process
+                ]
+                results_list = await asyncio.gather(*tasks)
+
+                for src in results_list:
+                    if src is not None:
+                        sources.append(src)
+                        yield {
+                            "event": "source",
+                            "data": json.dumps(src.model_dump()),
+                        }
+
+                should_continue = iteration < min_iterations or (
+                    iteration < runtime.max_iterations
+                    and len(sources) < runtime.max_sources
+                )
+
+                if not should_continue:
+                    if len(sources) >= runtime.max_sources:
+                        yield {
+                            "event": "status",
+                            "data": (
+                                f"Reached max sources ({runtime.max_sources}) "
+                                f"after {iteration} iterations; "
+                                "synthesizing report..."
+                            ),
+                        }
+                    break
+
+                num_sources_for_context = min(15, len(sources))
+                learned_blob = "\n".join(
+                    [
+                        f"- {s.title} ({s.url}): {s.summary[:240]}"
+                        for s in sources[-num_sources_for_context:]
+                    ]
+                )
+
+                query_prompt = (
+                    f"Research instructions:\n{runtime.instructions}\n\n"
+                    f"What we've learned so far ({len(sources)} sources):\n"
+                    f"{learned_blob}\n\n"
+                    f"Previous search queries we've already tried:\n"
+                    f"{', '.join(sorted(list(seen_queries)[-20:]))}\n\n"
+                    "Generate NEW search queries that explore "
+                    "DIFFERENT aspects of the research topic. Focus on:\n"
+                    "- Specific subtopics we haven't covered yet\n"
+                    "- Alternative perspectives or approaches\n"
+                    "- Related but distinct concepts\n"
+                    "- Practical applications or examples\n\n"
+                    "Return a JSON array of 4-6 new, diverse search queries."
+                )
+
+                next_queries = await run_structured_string_list(
+                    model=runtime.model,
+                    api_key=runtime.api_key,
+                    base_url=runtime.base_url,
+                    system_prompt=DDG_RESEARCH_ADJACENT_QUERY_SYSTEM_PROMPT,
+                    user_prompt=query_prompt,
+                )
+
+                if not next_queries or len(next_queries) < 2:
+                    logger.warning(
+                        f"Iteration {iteration}: "
+                        "LLM didn't generate enough queries, "
+                        "creating fallback queries"
+                    )
+                    fallback_terms = [
+                        "recipe",
+                        "ingredients",
+                        "substitute",
+                        "adaptation",
+                        "variation",
+                        "how to",
+                        "tutorial",
+                    ]
+                    fallback_queries = []
+                    for term in fallback_terms[:4]:
+                        if term not in seen_queries:
+                            fallback_queries.append(f"{runtime.instructions} {term}")
+                    next_queries = (
+                        fallback_queries[:4]
+                        if fallback_queries
+                        else [runtime.instructions]
+                    )
+
+        if len(sources) < 3:
+            yield {
+                "event": "status",
+                "data": (
+                    f"Warning: Only found {len(sources)} relevant "
+                    "sources. This may indicate DuckDuckGo rate "
+                    "limiting. Results may be incomplete."
+                ),
+            }
+
+        yield {
+            "event": "status",
+            "data": "Synthesizing final report...",
+        }
+
+        if not sources:
+            yield {
+                "event": "error",
+                "data": (
+                    "No relevant sources found. This is likely due to "
+                    "DuckDuckGo rate limiting. Please try again in a "
+                    "few minutes, or add an Exa API key for more "
+                    "reliable research."
+                ),
+            }
+            return
+
+        sources_md = "\n".join(
+            [f"- [{s.title}]({s.url}): {s.summary}" for s in sources]
+        )
+
+        report = await ddg_synthesize_final_report(runtime, sources_md)
+
+        report_stripped = report.rstrip()
+        if (
+            report
+            and report_stripped
+            and not report_stripped.endswith((".", "!", "?", ":", "\n", "---", "```"))
+        ):
+            report += (
+                "\n\n*Note: Report may be incomplete due to response length limits.*"
+            )
+
+        yield {"event": "content", "data": report}
+        yield {
+            "event": "sources",
+            "data": json.dumps([{"title": s.title, "url": s.url} for s in sources]),
+        }
+        yield {"event": "done", "data": ""}
+
+    except Exception as e:
+        logger.error(f"DDG research failed: {e}")
+        logger.error(traceback.format_exc())
+        yield {"event": "error", "data": str(e)}
 
 
 # =============================================================================
@@ -213,503 +776,15 @@ def register_endpoints(app: Any) -> None:
 
         inject_admin_credentials(request)
 
-        max_iterations = max(1, min(request.max_iterations, 8))
-        max_sources = max(5, min(request.max_sources, 80))
-        max_queries_per_iteration = max(1, min(request.max_queries_per_iteration, 8))
-        max_results_per_query = max(1, min(request.max_results_per_query, 25))
-
-        max_sources_per_iteration = _max_sources_per_iteration(
-            max_sources, max_iterations
-        )
+        runtime = build_ddg_research_runtime(request)
 
         logger.info(
             "DDG research request: "
             f"instructions='{request.instructions[:100]}...', "
             f"model={request.model}, "
-            f"max_iterations={max_iterations}, "
-            f"max_sources={max_sources}, "
-            f"max_sources_per_iteration={max_sources_per_iteration}"
+            f"max_iterations={runtime.max_iterations}, "
+            f"max_sources={runtime.max_sources}, "
+            f"max_sources_per_iteration={runtime.max_sources_per_iteration}"
         )
 
-        async def generate():
-            from canvas_chat.app import (
-                _llm_json_array,
-                _llm_text,
-                fetch_url_directly,
-                fetch_url_via_jina,
-            )
-
-            try:
-                from ddgs import DDGS
-
-                instructions = request.instructions.strip()
-                context = (request.context or "").strip()
-
-                if not instructions:
-                    yield {"event": "error", "data": "Empty research instructions"}
-                    return
-
-                yield {
-                    "event": "status",
-                    "data": "Generating initial search queries...",
-                }
-
-                seed_user_prompt = (
-                    f"Research instructions:\n{instructions}\n\n"
-                    + (f"Context:\n{context[:2000]}\n\n" if context else "")
-                    + "Return JSON array of DDG search queries."
-                )
-                next_queries = await _llm_json_array(
-                    model=request.model,
-                    api_key=request.api_key,
-                    base_url=request.base_url,
-                    system_prompt=DDG_RESEARCH_QUERY_GEN_SYSTEM_PROMPT,
-                    user_prompt=seed_user_prompt,
-                )
-
-                if not next_queries:
-                    next_queries = [instructions[:120]]
-
-                seen_queries: set[str] = set()
-                seen_urls: set[str] = set()
-                sources: list[DDGResearchSource] = []
-                min_iterations = min(3, max_iterations)
-
-                async with httpx.AsyncClient(timeout=30.0) as client:
-                    for iteration in range(1, max_iterations + 1):
-                        iteration_queries = [
-                            q
-                            for q in next_queries
-                            if q.strip() and q.strip().lower() not in seen_queries
-                        ][:max_queries_per_iteration]
-
-                        if not iteration_queries:
-                            yield {
-                                "event": "status",
-                                "data": "No new queries to search; stopping early.",
-                            }
-                            break
-
-                        for q in iteration_queries:
-                            seen_queries.add(q.strip().lower())
-
-                        yield {
-                            "event": "status",
-                            "data": (
-                                f"Iteration {iteration}/{max_iterations}: "
-                                "searching DuckDuckGo..."
-                            ),
-                        }
-
-                        url_to_result: dict[str, dict] = {}
-
-                        async def search_with_retry(
-                            ddgs, query: str, max_retries: int = 3
-                        ) -> list[dict]:
-                            for attempt in range(max_retries):
-                                try:
-                                    results = list(
-                                        ddgs.text(
-                                            query,
-                                            max_results=max_results_per_query,
-                                        )
-                                    )
-                                    if results:
-                                        return results
-                                    if attempt < max_retries - 1:
-                                        wait_time = 2.0 * (2**attempt)
-                                        logger.warning(
-                                            f"DDG query returned empty results: "
-                                            f"{query} "
-                                            f"(attempt {attempt + 1}/{max_retries}, "
-                                            f"waiting {wait_time}s)"
-                                        )
-                                        await asyncio.sleep(wait_time)
-                                except Exception as e:
-                                    if attempt < max_retries - 1:
-                                        wait_time = 2.0 * (2**attempt)
-                                        logger.warning(
-                                            f"DDG query failed: {query} ({e}) "
-                                            f"(attempt {attempt + 1}/{max_retries}, "
-                                            f"waiting {wait_time}s)"
-                                        )
-                                        await asyncio.sleep(wait_time)
-                                    else:
-                                        logger.error(
-                                            f"DDG query failed after retries: "
-                                            f"{query} ({e})"
-                                        )
-                            return []
-
-                        with DDGS() as ddgs:
-                            for q in iteration_queries:
-                                results = await search_with_retry(ddgs, q)
-
-                                query_lower = q.lower()
-                                query_words = set(query_lower.split())
-                                relevant_results = []
-                                for r in results:
-                                    url = (r.get("href") or "").strip()
-                                    if not url:
-                                        continue
-                                    if url in url_to_result or url in seen_urls:
-                                        continue
-
-                                    title = (r.get("title") or "").lower()
-                                    snippet = (r.get("body") or "").lower()
-                                    combined_text = f"{title} {snippet}"
-
-                                    min_matches = 2 if len(query_words) > 2 else 1
-                                    matches = sum(
-                                        1
-                                        for word in query_words
-                                        if word in combined_text
-                                    )
-
-                                    if matches >= min_matches:
-                                        relevant_results.append(r)
-                                    else:
-                                        logger.debug(
-                                            f"Skipping irrelevant result for "
-                                            f"'{q}': {r.get('title', 'Untitled')}"
-                                        )
-
-                                for r in relevant_results:
-                                    url = (r.get("href") or "").strip()
-                                    url_to_result[url] = {
-                                        "query": q,
-                                        "title": (r.get("title") or "Untitled").strip(),
-                                        "snippet": (r.get("body") or "").strip(),
-                                        "url": url,
-                                    }
-
-                                await asyncio.sleep(1.0)
-
-                        if not url_to_result:
-                            yield {
-                                "event": "status",
-                                "data": (
-                                    f"Iteration {iteration}: no relevant "
-                                    "results found. This may indicate rate "
-                                    "limiting or poor query quality."
-                                ),
-                            }
-                            if iteration == 1 and len(sources) == 0:
-                                yield {
-                                    "event": "error",
-                                    "data": (
-                                        "No relevant search results found. "
-                                        "This may be due to DuckDuckGo rate "
-                                        "limiting. Please try again in a few "
-                                        "minutes, or add an Exa API key for "
-                                        "more reliable research."
-                                    ),
-                                }
-                                return
-                            learned_blob = "\n".join(
-                                [
-                                    f"- {s.title}: {s.summary[:200]}"
-                                    for s in sources[-10:]
-                                ]
-                            )
-                            next_queries = await _llm_json_array(
-                                model=request.model,
-                                api_key=request.api_key,
-                                base_url=request.base_url,
-                                system_prompt=DDG_RESEARCH_ADJACENT_QUERY_SYSTEM_PROMPT,
-                                user_prompt=(
-                                    f"Research instructions:\n{instructions}\n\n"
-                                    f"What we learned so far:\n{learned_blob}\n\n"
-                                    f"Previous queries:\n"
-                                    f"{', '.join(sorted(seen_queries))}\n\n"
-                                    "Return JSON array of new DDG queries."
-                                ),
-                            )
-                            continue
-
-                        remaining_total = max_sources - len(sources)
-                        num_to_process = min(
-                            len(url_to_result),
-                            remaining_total,
-                            max_sources_per_iteration,
-                        )
-                        yield {
-                            "event": "status",
-                            "data": (
-                                f"Iteration {iteration}: "
-                                f"fetching {num_to_process} pages in parallel..."
-                            ),
-                        }
-
-                        for url in url_to_result:
-                            seen_urls.add(url)
-
-                        sem = asyncio.Semaphore(6)
-
-                        async def process_one(
-                            r: dict,
-                            iter_num: int = iteration,
-                            semaphore: asyncio.Semaphore = sem,
-                        ) -> DDGResearchSource | None:
-                            url = r["url"]
-                            query = r["query"]
-                            snippet = r["snippet"]
-
-                            async with semaphore:
-                                try:
-                                    try:
-                                        title, content_md = await fetch_url_via_jina(
-                                            url, client
-                                        )
-                                    except Exception:
-                                        title, content_md = await fetch_url_directly(
-                                            url, client
-                                        )
-
-                                    content_md = (content_md or "").strip()
-                                    if not content_md:
-                                        return None
-
-                                    content_for_llm = content_md[:12000]
-
-                                    user_prompt = (
-                                        f"Research instructions:\n{instructions}\n\n"
-                                        + (
-                                            f"Context:\n{context[:2000]}\n\n"
-                                            if context
-                                            else ""
-                                        )
-                                        + (
-                                            f"Search query that found this page: "
-                                            f"{query}\n\n"
-                                        )
-                                        + f"Page title: {title}\n"
-                                        + f"URL: {url}\n"
-                                        + (
-                                            f"Snippet: {snippet}\n\n"
-                                            if snippet
-                                            else "\n"
-                                        )
-                                        + (
-                                            f"Page content (markdown):\n"
-                                            f"{content_for_llm}\n"
-                                        )
-                                    )
-
-                                    summary = await _llm_text(
-                                        model=request.model,
-                                        api_key=request.api_key,
-                                        base_url=request.base_url,
-                                        messages=[
-                                            {
-                                                "role": "system",
-                                                "content": (
-                                                    DDG_RESEARCH_PAGE_SUMMARY_SYSTEM_PROMPT
-                                                ),
-                                            },
-                                            {
-                                                "role": "user",
-                                                "content": user_prompt,
-                                            },
-                                        ],
-                                        temperature=0.3,
-                                        max_tokens=450,
-                                    )
-
-                                    final_title = (
-                                        title
-                                        if title and title != "Untitled"
-                                        else (r["title"] or "Untitled")
-                                    )
-
-                                    return DDGResearchSource(
-                                        url=url,
-                                        title=final_title,
-                                        snippet=snippet or None,
-                                        summary=summary,
-                                        iteration=iter_num,
-                                        query=query,
-                                    )
-
-                                except Exception as e:
-                                    logger.warning(
-                                        f"Failed to process URL: {url} ({e})"
-                                    )
-                                    return None
-
-                        items_to_process = list(url_to_result.values())[:num_to_process]
-                        tasks = [process_one(r) for r in items_to_process]
-                        results_list = await asyncio.gather(*tasks)
-
-                        for src in results_list:
-                            if src is not None:
-                                sources.append(src)
-                                yield {
-                                    "event": "source",
-                                    "data": json.dumps(src.model_dump()),
-                                }
-
-                        should_continue = iteration < min_iterations or (
-                            iteration < max_iterations and len(sources) < max_sources
-                        )
-
-                        if not should_continue:
-                            if len(sources) >= max_sources:
-                                yield {
-                                    "event": "status",
-                                    "data": (
-                                        f"Reached max sources ({max_sources}) "
-                                        f"after {iteration} iterations; "
-                                        "synthesizing report..."
-                                    ),
-                                }
-                            break
-
-                        num_sources_for_context = min(15, len(sources))
-                        learned_blob = "\n".join(
-                            [
-                                f"- {s.title} ({s.url}): {s.summary[:240]}"
-                                for s in sources[-num_sources_for_context:]
-                            ]
-                        )
-
-                        query_prompt = (
-                            f"Research instructions:\n{instructions}\n\n"
-                            f"What we've learned so far ({len(sources)} sources):\n"
-                            f"{learned_blob}\n\n"
-                            f"Previous search queries we've already tried:\n"
-                            f"{', '.join(sorted(list(seen_queries)[-20:]))}\n\n"
-                            "Generate NEW search queries that explore "
-                            "DIFFERENT aspects of the research topic. Focus on:\n"
-                            "- Specific subtopics we haven't covered yet\n"
-                            "- Alternative perspectives or approaches\n"
-                            "- Related but distinct concepts\n"
-                            "- Practical applications or examples\n\n"
-                            "Return a JSON array of 4-6 new, diverse search queries."
-                        )
-
-                        next_queries = await _llm_json_array(
-                            model=request.model,
-                            api_key=request.api_key,
-                            base_url=request.base_url,
-                            system_prompt=DDG_RESEARCH_ADJACENT_QUERY_SYSTEM_PROMPT,
-                            user_prompt=query_prompt,
-                        )
-
-                        if not next_queries or len(next_queries) < 2:
-                            logger.warning(
-                                f"Iteration {iteration}: "
-                                "LLM didn't generate enough queries, "
-                                "creating fallback queries"
-                            )
-                            fallback_terms = [
-                                "recipe",
-                                "ingredients",
-                                "substitute",
-                                "adaptation",
-                                "variation",
-                                "how to",
-                                "tutorial",
-                            ]
-                            fallback_queries = []
-                            for term in fallback_terms[:4]:
-                                if term not in seen_queries:
-                                    fallback_queries.append(f"{instructions} {term}")
-                            next_queries = (
-                                fallback_queries[:4]
-                                if fallback_queries
-                                else [instructions]
-                            )
-
-                if len(sources) < 3:
-                    yield {
-                        "event": "status",
-                        "data": (
-                            f"Warning: Only found {len(sources)} relevant "
-                            "sources. This may indicate DuckDuckGo rate "
-                            "limiting. Results may be incomplete."
-                        ),
-                    }
-
-                yield {
-                    "event": "status",
-                    "data": "Synthesizing final report...",
-                }
-
-                if not sources:
-                    yield {
-                        "event": "error",
-                        "data": (
-                            "No relevant sources found. This is likely due to "
-                            "DuckDuckGo rate limiting. Please try again in a "
-                            "few minutes, or add an Exa API key for more "
-                            "reliable research."
-                        ),
-                    }
-                    return
-
-                sources_md = "\n".join(
-                    [f"- [{s.title}]({s.url}): {s.summary}" for s in sources]
-                )
-                synthesis_user_prompt = (
-                    f"Research instructions:\n{instructions}\n\n"
-                    + (f"Context:\n{context[:2000]}\n\n" if context else "")
-                    + f"Sources (title, url, summary):\n{sources_md}\n"
-                )
-
-                try:
-                    report = await _llm_text(
-                        model=request.model,
-                        api_key=request.api_key,
-                        base_url=request.base_url,
-                        messages=[
-                            {
-                                "role": "system",
-                                "content": DDG_RESEARCH_SYNTHESIS_SYSTEM_PROMPT,
-                            },
-                            {
-                                "role": "user",
-                                "content": synthesis_user_prompt,
-                            },
-                        ],
-                        temperature=0.3,
-                    )
-                except Exception as e:
-                    logger.error(f"Report synthesis failed: {e}")
-                    report = (
-                        f"**Research Report**\n\n"
-                        f"*Note: Report generation encountered an error. "
-                        f"Below are the sources that were found:*\n\n"
-                        f"## Sources Found\n\n"
-                        f"{sources_md}\n\n"
-                        f"*Error: {str(e)}*"
-                    )
-
-                report_stripped = report.rstrip()
-                if (
-                    report
-                    and report_stripped
-                    and not report_stripped.endswith(
-                        (".", "!", "?", ":", "\n", "---", "```")
-                    )
-                ):
-                    report += (
-                        "\n\n*Note: Report may be incomplete "
-                        "due to response length limits.*"
-                    )
-
-                yield {"event": "content", "data": report}
-                yield {
-                    "event": "sources",
-                    "data": json.dumps(
-                        [{"title": s.title, "url": s.url} for s in sources]
-                    ),
-                }
-                yield {"event": "done", "data": ""}
-
-            except Exception as e:
-                logger.error(f"DDG research failed: {e}")
-                logger.error(traceback.format_exc())
-                yield {"event": "error", "data": str(e)}
-
-        return EventSourceResponse(generate())
+        return EventSourceResponse(ddg_research_event_stream(runtime))

--- a/src/canvas_chat/plugins/matrix_handler.py
+++ b/src/canvas_chat/plugins/matrix_handler.py
@@ -8,8 +8,8 @@ and filling matrix cells.
 import logging
 import traceback
 
+import litellm
 from fastapi import HTTPException
-from litellm import supports_response_schema
 from llamabot import AsyncStructuredBot
 from llamabot.components.messages import HumanMessage
 from pydantic import BaseModel, Field
@@ -108,7 +108,9 @@ Example 2 output: {{"rows": ["GitHub Copilot", "Tabnine"], "columns": ["Price", 
         try:
             api_key = get_api_key_for_provider(provider, request.api_key)
 
-            if not supports_response_schema(
+            # Use ``litellm.supports_response_schema`` (module attribute), not a
+            # function imported before ``app`` patches Copilot (see app.py).
+            if not litellm.supports_response_schema(
                 model=request.model, custom_llm_provider=None
             ):
                 raise HTTPException(

--- a/src/canvas_chat/plugins/matrix_handler.py
+++ b/src/canvas_chat/plugins/matrix_handler.py
@@ -5,15 +5,12 @@ Handles matrix-specific API endpoints for parsing rows/columns from context
 and filling matrix cells.
 """
 
-import asyncio
-import json
 import logging
-import re
 import traceback
 
-import litellm
 from fastapi import HTTPException
-from llamabot import StructuredBot
+from litellm import supports_response_schema
+from llamabot import AsyncStructuredBot
 from llamabot.components.messages import HumanMessage
 from pydantic import BaseModel, Field
 from sse_starlette.sse import EventSourceResponse
@@ -111,98 +108,50 @@ Example 2 output: {{"rows": ["GitHub Copilot", "Tabnine"], "columns": ["Price", 
         try:
             api_key = get_api_key_for_provider(provider, request.api_key)
 
-            supports_structured = litellm.supports_response_schema(
+            if not supports_response_schema(
                 model=request.model, custom_llm_provider=None
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "Parse-two-lists needs a model that supports structured JSON "
+                        "(response_schema). Pick a model that supports it for your "
+                        "provider, or switch provider."
+                    ),
+                )
+
+            prep = {
+                "model": request.model,
+                "messages": [],
+                "api_key": api_key,
+                "base_url": request.base_url,
+            }
+            prep = prepare_copilot_openai_request(prep, request.model, api_key)
+            extras = copilot_extras_for_bot(prep)
+            parse_lists_bot = AsyncStructuredBot(
+                system_prompt=system_prompt,
+                pydantic_model=MatrixTwoListsOutput,
+                model_name=prep["model"],
+                temperature=0.3,
+                stream_target="none",
+                api_key=prep.get("api_key"),
+                **extras,
             )
 
-            if supports_structured:
-                try:
-                    prep = {
-                        "model": request.model,
-                        "messages": [],
-                        "api_key": api_key,
-                        "base_url": request.base_url,
-                    }
-                    prep = prepare_copilot_openai_request(prep, request.model, api_key)
-                    extras = copilot_extras_for_bot(prep)
-                    parse_lists_bot = StructuredBot(
-                        system_prompt=system_prompt,
-                        pydantic_model=MatrixTwoListsOutput,
-                        model_name=prep["model"],
-                        temperature=0.3,
-                        stream_target="none",
-                        api_key=prep.get("api_key"),
-                        **extras,
-                    )
+            result = await parse_lists_bot(
+                HumanMessage(content=combined_content), num_attempts=5
+            )
+            if result is None:
+                raise HTTPException(
+                    status_code=502,
+                    detail="Could not obtain valid structured output after retries.",
+                )
+            return {"rows": result.rows, "columns": result.columns}
 
-                    def _parse_two_lists_run() -> MatrixTwoListsOutput:
-                        r = parse_lists_bot(
-                            HumanMessage(content=combined_content), num_attempts=5
-                        )
-                        if r is None:
-                            raise RuntimeError("StructuredBot returned None")
-                        return r
-
-                    result = await asyncio.to_thread(_parse_two_lists_run)
-                    return {"rows": result.rows, "columns": result.columns}
-                except Exception:
-                    logger.warning(
-                        "Structured parse-two-lists failed; falling back to text",
-                        exc_info=True,
-                    )
-
-            kwargs = {
-                "model": request.model,
-                "messages": [
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": combined_content},
-                ],
-                "temperature": 0.3,
-                "stream": False,
-            }
-            if api_key:
-                kwargs["api_key"] = api_key
-            if request.base_url:
-                kwargs["base_url"] = request.base_url
-            kwargs = prepare_copilot_openai_request(kwargs, request.model, api_key)
-
-            response = await litellm.acompletion(**kwargs)
-            title = (response.choices[0].message.content or "").strip()
-            title = title.strip("\"'")
-
-            logger.info(f"Parse-two-lists raw: {title[:200]!r}")
-
-            try:
-                parsed = json.loads(title)
-                return {
-                    "rows": parsed.get("rows", []),
-                    "columns": parsed.get("columns", []),
-                }
-            except json.JSONDecodeError:
-                rows_match = re.search(r'"rows"\s*:\s*\[([^\]]*)\]', title)
-                cols_match = re.search(r'"columns"\s*:\s*\[([^\]]*)\]', title)
-
-                rows = []
-                cols = []
-
-                if rows_match:
-                    rows = [
-                        m.strip().strip('"')
-                        for m in rows_match.group(1).split(",")
-                        if m.strip()
-                    ]
-
-                if cols_match:
-                    cols = [
-                        m.strip().strip('"')
-                        for m in cols_match.group(1).split(",")
-                        if m.strip()
-                    ]
-
-                return {"rows": rows, "columns": cols}
-
+        except HTTPException:
+            raise
         except Exception as e:
-            logger.error(f"Generate title failed: {e}")
+            logger.error(f"Parse-two-lists failed: {e}")
             logger.error(traceback.format_exc())
             raise HTTPException(status_code=500, detail=str(e)) from e
 
@@ -214,6 +163,7 @@ Example 2 output: {{"rows": ["GitHub Copilot", "Tabnine"], "columns": ["Price", 
         Returns SSE stream with the evaluation content.
         """
         from canvas_chat.app import (
+            _stream_text_deltas_async_simple_bot,
             extract_provider,
             get_api_key_for_provider,
             inject_admin_credentials,
@@ -231,8 +181,6 @@ Example 2 output: {{"rows": ["GitHub Copilot", "Tabnine"], "columns": ["Price", 
 
         async def generate():
             try:
-                import litellm
-
                 system_prompt = f"""You are evaluating items in a matrix.
 Matrix context: {request.context}
 
@@ -258,9 +206,7 @@ intersection of these two items. Do not repeat the item names in your response
 
                 kwargs = {
                     "model": request.model,
-                    "messages": messages,
                     "temperature": 0.5,
-                    "stream": True,
                 }
 
                 api_key = get_api_key_for_provider(provider, request.api_key)
@@ -272,12 +218,10 @@ intersection of these two items. Do not repeat the item names in your response
 
                 kwargs = prepare_copilot_openai_request(kwargs, request.model, api_key)
 
-                response = await litellm.acompletion(**kwargs)
-
-                async for chunk in response:
-                    if chunk.choices and chunk.choices[0].delta.content:
-                        content = chunk.choices[0].delta.content
-                        yield {"event": "message", "data": content}
+                async for content in _stream_text_deltas_async_simple_bot(
+                    messages, kwargs, temperature=0.5
+                ):
+                    yield {"event": "message", "data": content}
 
                 yield {"event": "done", "data": ""}
 

--- a/src/canvas_chat/plugins/matrix_handler.py
+++ b/src/canvas_chat/plugins/matrix_handler.py
@@ -5,13 +5,17 @@ Handles matrix-specific API endpoints for parsing rows/columns from context
 and filling matrix cells.
 """
 
+import asyncio
 import json
 import logging
 import re
 import traceback
 
+import litellm
 from fastapi import HTTPException
-from pydantic import BaseModel
+from llamabot import StructuredBot
+from llamabot.components.messages import HumanMessage
+from pydantic import BaseModel, Field
 from sse_starlette.sse import EventSourceResponse
 
 logger = logging.getLogger(__name__)
@@ -32,6 +36,13 @@ class Message(BaseModel):
 
     role: str
     content: str
+
+
+class MatrixTwoListsOutput(BaseModel):
+    """Structured output for parse-two-lists."""
+
+    rows: list[str] = Field(default_factory=list)
+    columns: list[str] = Field(default_factory=list)
 
 
 class MatrixFillRequest(BaseModel):
@@ -57,6 +68,7 @@ def register_endpoints(app):
         Returns two lists: one for rows, one for columns (max 10 each).
         """
         from canvas_chat.app import (
+            copilot_extras_for_bot,
             extract_provider,
             get_api_key_for_provider,
             inject_admin_credentials,
@@ -97,7 +109,47 @@ Example 2: "1. GitHub Copilot: $10/month... 2. Tabnine: Free tier available..."
 Example 2 output: {{"rows": ["GitHub Copilot", "Tabnine"], "columns": ["Price", "Features", "Python Support"]}}"""  # noqa: E501
 
         try:
-            import litellm
+            api_key = get_api_key_for_provider(provider, request.api_key)
+
+            supports_structured = litellm.supports_response_schema(
+                model=request.model, custom_llm_provider=None
+            )
+
+            if supports_structured:
+                try:
+                    prep = {
+                        "model": request.model,
+                        "messages": [],
+                        "api_key": api_key,
+                        "base_url": request.base_url,
+                    }
+                    prep = prepare_copilot_openai_request(prep, request.model, api_key)
+                    extras = copilot_extras_for_bot(prep)
+                    parse_lists_bot = StructuredBot(
+                        system_prompt=system_prompt,
+                        pydantic_model=MatrixTwoListsOutput,
+                        model_name=prep["model"],
+                        temperature=0.3,
+                        stream_target="none",
+                        api_key=prep.get("api_key"),
+                        **extras,
+                    )
+
+                    def _parse_two_lists_run() -> MatrixTwoListsOutput:
+                        r = parse_lists_bot(
+                            HumanMessage(content=combined_content), num_attempts=5
+                        )
+                        if r is None:
+                            raise RuntimeError("StructuredBot returned None")
+                        return r
+
+                    result = await asyncio.to_thread(_parse_two_lists_run)
+                    return {"rows": result.rows, "columns": result.columns}
+                except Exception:
+                    logger.warning(
+                        "Structured parse-two-lists failed; falling back to text",
+                        exc_info=True,
+                    )
 
             kwargs = {
                 "model": request.model,
@@ -106,23 +158,19 @@ Example 2 output: {{"rows": ["GitHub Copilot", "Tabnine"], "columns": ["Price", 
                     {"role": "user", "content": combined_content},
                 ],
                 "temperature": 0.3,
+                "stream": False,
             }
-
-            api_key = get_api_key_for_provider(provider, request.api_key)
             if api_key:
                 kwargs["api_key"] = api_key
-
             if request.base_url:
                 kwargs["base_url"] = request.base_url
-
             kwargs = prepare_copilot_openai_request(kwargs, request.model, api_key)
 
             response = await litellm.acompletion(**kwargs)
-            title = response.choices[0].message.content.strip()
-
+            title = (response.choices[0].message.content or "").strip()
             title = title.strip("\"'")
 
-            logger.info(f"Generated title: {title}")
+            logger.info(f"Parse-two-lists raw: {title[:200]!r}")
 
             try:
                 parsed = json.loads(title)

--- a/src/canvas_chat/plugins/pptx_endpoints.py
+++ b/src/canvas_chat/plugins/pptx_endpoints.py
@@ -19,6 +19,9 @@ from pathlib import Path
 from typing import Any
 
 from fastapi import File, UploadFile
+from litellm import supports_response_schema
+from llamabot import AsyncStructuredBot
+from llamabot.components.messages import HumanMessage
 from pydantic import BaseModel, Field
 from slugify import slugify
 from sse_starlette.sse import EventSourceResponse
@@ -39,38 +42,6 @@ logger = logging.getLogger(__name__)
 def _one_paragraph(text: str) -> str:
     """Normalize text to a single paragraph (no newlines, collapsed whitespace)."""
     return " ".join((text or "").strip().split())
-
-
-def _extract_json_object(text: str) -> dict[str, Any]:
-    """Parse a JSON object from LLM output (best-effort).
-
-    This is a fallback mechanism for models/providers that return `message.content`
-    as a string even when using structured output, or for non-structured models.
-    """
-    text = (text or "").strip()
-    if not text:
-        return {}
-
-    # Strict parse
-    try:
-        data = json.loads(text)
-        if isinstance(data, dict):
-            return data
-    except Exception:
-        pass
-
-    # Best-effort: find first {...} region
-    start = text.find("{")
-    end = text.rfind("}")
-    if start != -1 and end != -1 and end > start:
-        try:
-            data = json.loads(text[start : end + 1])
-            if isinstance(data, dict):
-                return data
-        except Exception:
-            return {}
-
-    return {}
 
 
 def _pptx_fallback_narrative_presets() -> list[dict[str, Any]]:
@@ -244,21 +215,23 @@ Rules:
 
         try:
             from canvas_chat.app import (
-                _llm_text,
-                litellm,
+                copilot_extras_for_bot,
                 prepare_copilot_openai_request,
             )
 
-            supports_structured = litellm.supports_response_schema(
+            if not supports_response_schema(
                 model=request.model, custom_llm_provider=None
-            )
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "PPTX caption/title requires a model that supports structured "
+                        "JSON (response_schema)."
+                    ),
+                )
 
             kwargs: dict[str, Any] = {
                 "model": request.model,
-                "messages": [
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt},
-                ],
                 "temperature": 0.2,
                 "max_tokens": 300,
             }
@@ -271,32 +244,26 @@ Rules:
                 kwargs, request.model, request.api_key
             )
 
-            if supports_structured:
-                kwargs["response_format"] = SlideCaptionTitleOutput
-                response = await litellm.acompletion(**kwargs)
-                content = response.choices[0].message.content
-                if isinstance(content, str):
-                    parsed = _extract_json_object(content)
-                    out = SlideCaptionTitleOutput.model_validate(parsed)
-                elif hasattr(content, "title") and hasattr(content, "caption"):
-                    out = SlideCaptionTitleOutput(
-                        title=content.title, caption=content.caption
-                    )
-                else:
-                    out = SlideCaptionTitleOutput.model_validate(content)
-            else:
-                text = await _llm_text(
-                    model=request.model,
-                    api_key=request.api_key,
-                    base_url=request.base_url,
-                    messages=[
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_prompt},
-                    ],
-                    temperature=0.2,
-                    max_tokens=300,
-                )
-                out = SlideCaptionTitleOutput.model_validate(_extract_json_object(text))
+            extras = copilot_extras_for_bot(kwargs)
+            completion_kwargs = dict(extras)
+            mt = kwargs.get("max_tokens")
+            if mt is not None:
+                completion_kwargs["max_tokens"] = mt
+            caption_bot = AsyncStructuredBot(
+                system_prompt=system_prompt,
+                pydantic_model=SlideCaptionTitleOutput,
+                model_name=kwargs["model"],
+                temperature=0.2,
+                stream_target="none",
+                api_key=kwargs.get("api_key"),
+                **completion_kwargs,
+            )
+            result = await caption_bot(
+                HumanMessage(content=user_prompt), num_attempts=5
+            )
+            if result is None:
+                raise RuntimeError("StructuredBot returned None")
+            out = SlideCaptionTitleOutput.model_validate(result)
 
             out.title = _one_paragraph(out.title).strip('"')
             out.caption = _one_paragraph(out.caption)
@@ -354,21 +321,23 @@ Rules:
 
         try:
             from canvas_chat.app import (
-                _llm_text,
-                litellm,
+                copilot_extras_for_bot,
                 prepare_copilot_openai_request,
             )
 
-            supports_structured = litellm.supports_response_schema(
+            if not supports_response_schema(
                 model=request.model, custom_llm_provider=None
-            )
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "PPTX deck caption/title requires a model that supports "
+                        "structured JSON (response_schema)."
+                    ),
+                )
 
             kwargs: dict[str, Any] = {
                 "model": request.model,
-                "messages": [
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt},
-                ],
                 "temperature": 0.2,
                 "max_tokens": 1200,
             }
@@ -381,31 +350,24 @@ Rules:
                 kwargs, request.model, request.api_key
             )
 
-            if supports_structured:
-                kwargs["response_format"] = DeckCaptionTitleOutput
-                response = await litellm.acompletion(**kwargs)
-                content = response.choices[0].message.content
-                if isinstance(content, str):
-                    out = DeckCaptionTitleOutput.model_validate(
-                        _extract_json_object(content)
-                    )
-                elif hasattr(content, "slides"):
-                    out = DeckCaptionTitleOutput(slides=content.slides)
-                else:
-                    out = DeckCaptionTitleOutput.model_validate(content)
-            else:
-                text = await _llm_text(
-                    model=request.model,
-                    api_key=request.api_key,
-                    base_url=request.base_url,
-                    messages=[
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_prompt},
-                    ],
-                    temperature=0.2,
-                    max_tokens=1200,
-                )
-                out = DeckCaptionTitleOutput.model_validate(_extract_json_object(text))
+            extras = copilot_extras_for_bot(kwargs)
+            completion_kwargs = dict(extras)
+            mt = kwargs.get("max_tokens")
+            if mt is not None:
+                completion_kwargs["max_tokens"] = mt
+            deck_bot = AsyncStructuredBot(
+                system_prompt=system_prompt,
+                pydantic_model=DeckCaptionTitleOutput,
+                model_name=kwargs["model"],
+                temperature=0.2,
+                stream_target="none",
+                api_key=kwargs.get("api_key"),
+                **completion_kwargs,
+            )
+            result = await deck_bot(HumanMessage(content=user_prompt), num_attempts=5)
+            if result is None:
+                raise RuntimeError("StructuredBot returned None")
+            out = DeckCaptionTitleOutput.model_validate(result)
 
             if len(out.slides) != len(prepared):
                 raise HTTPException(
@@ -482,21 +444,23 @@ Rules:
 
         try:
             from canvas_chat.app import (
-                _llm_text,
-                litellm,
+                copilot_extras_for_bot,
                 prepare_copilot_openai_request,
             )
 
-            supports_structured = litellm.supports_response_schema(
+            if not supports_response_schema(
                 model=request.model, custom_llm_provider=None
-            )
+            ):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "PPTX narrative presets require a model that supports "
+                        "structured JSON (response_schema)."
+                    ),
+                )
 
             kwargs: dict[str, Any] = {
                 "model": request.model,
-                "messages": [
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_prompt},
-                ],
                 "temperature": 0.3,
                 "max_tokens": 800,
             }
@@ -509,33 +473,26 @@ Rules:
                 kwargs, request.model, request.api_key
             )
 
-            if supports_structured:
-                kwargs["response_format"] = NarrativeStyleSuggestionsOutput
-                response = await litellm.acompletion(**kwargs)
-                content = response.choices[0].message.content
-                if isinstance(content, str):
-                    out = NarrativeStyleSuggestionsOutput.model_validate(
-                        _extract_json_object(content)
-                    )
-                elif hasattr(content, "presets"):
-                    out = NarrativeStyleSuggestionsOutput(presets=content.presets)
-                else:
-                    out = NarrativeStyleSuggestionsOutput.model_validate(content)
-            else:
-                text = await _llm_text(
-                    model=request.model,
-                    api_key=request.api_key,
-                    base_url=request.base_url,
-                    messages=[
-                        {"role": "system", "content": system_prompt},
-                        {"role": "user", "content": user_prompt},
-                    ],
-                    temperature=0.3,
-                    max_tokens=800,
-                )
-                out = NarrativeStyleSuggestionsOutput.model_validate(
-                    _extract_json_object(text)
-                )
+            extras = copilot_extras_for_bot(kwargs)
+            completion_kwargs = dict(extras)
+            mt = kwargs.get("max_tokens")
+            if mt is not None:
+                completion_kwargs["max_tokens"] = mt
+            narrative_bot = AsyncStructuredBot(
+                system_prompt=system_prompt,
+                pydantic_model=NarrativeStyleSuggestionsOutput,
+                model_name=kwargs["model"],
+                temperature=0.3,
+                stream_target="none",
+                api_key=kwargs.get("api_key"),
+                **completion_kwargs,
+            )
+            result = await narrative_bot(
+                HumanMessage(content=user_prompt), num_attempts=5
+            )
+            if result is None:
+                raise RuntimeError("StructuredBot returned None")
+            out = NarrativeStyleSuggestionsOutput.model_validate(result)
 
             presets: list[dict[str, Any]] = []
             for p in out.presets[:5]:
@@ -562,6 +519,8 @@ Rules:
             if not presets:
                 presets = _pptx_fallback_narrative_presets()
             return {"presets": presets}
+        except HTTPException:
+            raise
         except Exception as e:
             logger.warning(f"PPTX narrative style suggestions failed: {e}")
             return {"presets": _pptx_fallback_narrative_presets()}

--- a/src/canvas_chat/plugins/pptx_endpoints.py
+++ b/src/canvas_chat/plugins/pptx_endpoints.py
@@ -18,8 +18,8 @@ import traceback
 from pathlib import Path
 from typing import Any
 
+import litellm
 from fastapi import File, UploadFile
-from litellm import supports_response_schema
 from llamabot import AsyncStructuredBot
 from llamabot.components.messages import HumanMessage
 from pydantic import BaseModel, Field
@@ -219,7 +219,7 @@ Rules:
                 prepare_copilot_openai_request,
             )
 
-            if not supports_response_schema(
+            if not litellm.supports_response_schema(
                 model=request.model, custom_llm_provider=None
             ):
                 raise HTTPException(
@@ -325,7 +325,7 @@ Rules:
                 prepare_copilot_openai_request,
             )
 
-            if not supports_response_schema(
+            if not litellm.supports_response_schema(
                 model=request.model, custom_llm_provider=None
             ):
                 raise HTTPException(
@@ -448,7 +448,7 @@ Rules:
                 prepare_copilot_openai_request,
             )
 
-            if not supports_response_schema(
+            if not litellm.supports_response_schema(
                 model=request.model, custom_llm_provider=None
             ):
                 raise HTTPException(

--- a/src/canvas_chat/static/css/nodes.css
+++ b/src/canvas_chat/static/css/nodes.css
@@ -1669,6 +1669,24 @@
     display: none;
 }
 
+/* Research node: log lines use the drawer (.code-output-panel-body) as the only scroll container */
+.research-activity-log {
+    margin: 0;
+    padding: 0;
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 0.72rem;
+    line-height: 1.45;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.research-activity-status {
+    margin-top: 8px;
+    font-size: 0.7rem;
+    color: var(--color-text-tertiary, #888);
+    font-style: italic;
+}
+
 .code-output-panel-content {
     min-height: 0;
 }

--- a/src/canvas_chat/static/js/canvas.js
+++ b/src/canvas_chat/static/js/canvas.js
@@ -2466,6 +2466,32 @@ class Canvas {
     }
 
     /**
+     * Ensure the bottom output panel exists for this node when the node protocol's hasOutput() is true,
+     * then refresh its body. Use when activity may start before the panel was rendered (e.g. first SSE chunk).
+     * @spec NODE-REQ-019
+     * @param {string} nodeId - The node ID
+     * @param {Object} node - Current graph node (must match {@link wrapNode} data)
+     */
+    ensureOutputPanelContent(nodeId, node) {
+        const wrapped = wrapNode(node);
+        if (!wrapped.hasOutput || typeof wrapped.hasOutput !== 'function') {
+            return;
+        }
+        if (!wrapped.hasOutput()) {
+            return;
+        }
+        const wrapper = this.nodeElements.get(nodeId);
+        if (!wrapper) {
+            return;
+        }
+        if (this.outputPanels.get(nodeId)) {
+            this.updateOutputPanelContent(nodeId, node);
+        } else {
+            this.renderOutputPanel(node, wrapper);
+        }
+    }
+
+    /**
      * Update output panel toggle button state
      * @param {string} nodeId - The node ID
      * @param {boolean} expanded - Whether panel is expanded

--- a/src/canvas_chat/static/js/chat.js
+++ b/src/canvas_chat/static/js/chat.js
@@ -331,9 +331,12 @@ class Chat {
      * Summarize a branch of conversation
      * @param {Array<ChatMessage>} messages - Conversation messages
      * @param {string} model - Model ID
+     * @param {object} [options] - Optional summarization hints (backend structured output)
+     * @param {string} [options.summaryType] - Free-text summary style or focus
+     * @param {string} [options.summaryLength] - Free-text length guidance
      * @returns {Promise<string>} Summary text
      */
-    async summarize(messages, model) {
+    async summarize(messages, model, options = {}) {
         const apiKey = await this.ensureCopilotAuthFresh(model);
         const baseUrl = this.getBaseUrl();
 
@@ -346,6 +349,13 @@ class Chat {
 
             if (baseUrl) {
                 requestBody.base_url = baseUrl;
+            }
+
+            if (options.summaryType) {
+                requestBody.summary_type = options.summaryType;
+            }
+            if (options.summaryLength) {
+                requestBody.summary_length = options.summaryLength;
             }
 
             const response = await fetch(apiUrl('/api/summarize'), {

--- a/src/canvas_chat/static/js/plugins/research-node.js
+++ b/src/canvas_chat/static/js/plugins/research-node.js
@@ -52,6 +52,29 @@ class ResearchNode extends BaseNode {
     getActions() {
         return [Actions.REPLY, Actions.CREATE_FLASHCARDS, Actions.COPY];
     }
+
+    /**
+     * Show the slide-out panel when there is a research activity log (streaming or completed).
+     * @spec NODE-REQ-019
+     * @returns {boolean}
+     */
+    hasOutput() {
+        const log = (this.node.researchActivityLog || '').trim();
+        return log.length > 0;
+    }
+
+    /**
+     * Render streaming / completed research status lines (search queries, sources, etc.).
+     * @spec NODE-REQ-019
+     * @param {Canvas} canvas - Canvas instance
+     * @returns {string} HTML for the output panel body
+     */
+    renderOutputPanel(canvas) {
+        const log = this.node.researchActivityLog || '';
+        const active = !!this.node.researchActivityActive;
+        const escaped = canvas.escapeHtml(log);
+        return `<pre class="research-activity-log" tabindex="0" aria-label="Research activity">${escaped}</pre>${active ? '<div class="research-activity-status" aria-live="polite">Running…</div>' : ''}`;
+    }
 }
 
 NodeRegistry.register({

--- a/src/canvas_chat/static/js/plugins/research.js
+++ b/src/canvas_chat/static/js/plugins/research.js
@@ -11,6 +11,41 @@ import { readSSEStream, normalizeText } from '../sse.js';
 import { apiUrl } from '../utils.js';
 import { FeaturePlugin } from '../feature-plugin.js';
 
+/** @type {number} */
+const MAX_RESEARCH_ACTIVITY_LINES = 300;
+
+/**
+ * Append a line to the research activity log, trimming oldest lines when over budget.
+ * @param {string|undefined} currentLog
+ * @param {string} line
+ * @returns {string}
+ */
+function appendResearchActivityLine(currentLog, line) {
+    const trimmed = (line || '').trim();
+    if (!trimmed) {
+        return currentLog || '';
+    }
+    const prev = currentLog || '';
+    const lines = prev ? prev.split('\n') : [];
+    lines.push(trimmed);
+    while (lines.length > MAX_RESEARCH_ACTIVITY_LINES) {
+        lines.shift();
+    }
+    return lines.join('\n');
+}
+
+/**
+ * @param {string} s
+ * @param {number} max
+ * @returns {string}
+ */
+function truncateForActivityLog(s, max = 140) {
+    if (!s || s.length <= max) {
+        return s;
+    }
+    return `${s.slice(0, max - 1)}…`;
+}
+
 /**
  * ResearchFeature - Handles search and research commands with Exa/DuckDuckGo.
  * Extends FeaturePlugin to integrate with the plugin architecture.
@@ -33,6 +68,19 @@ class ResearchFeature extends FeaturePlugin {
      */
     async onLoad() {
         console.log('[ResearchFeature] Loaded');
+    }
+
+    /**
+     * Refresh or create the research activity output panel after graph updates.
+     * @spec RSCH-REQ-005
+     * @param {string} nodeId
+     */
+    _refreshResearchActivityPanel(nodeId) {
+        const node = this.graph.getNode(nodeId);
+        if (!node) {
+            return;
+        }
+        this.canvas.ensureOutputPanelContent(nodeId, node);
     }
 
     /**
@@ -244,7 +292,11 @@ class ResearchFeature extends FeaturePlugin {
             // Reset content to show we're restarting
             const restartContent = `**Research${providerLabel}:** ${instructions}\n\n*Restarting research...*`;
             this.canvas.updateNodeContent(existingNodeId, restartContent, true);
-            this.graph.updateNode(existingNodeId, { content: restartContent });
+            this.graph.updateNode(existingNodeId, {
+                content: restartContent,
+                researchActivityLog: '',
+                researchActivityActive: false,
+            });
         } else {
             // Create new research node
             // Get selected nodes for positioning (optional)
@@ -387,24 +439,28 @@ class ResearchFeature extends FeaturePlugin {
             }
             let reportContent = reportHeader;
             let sources = [];
-            let lastStatus = '';
-            let ddgSourcesMd = '';
-            let ddgSourceCount = 0;
             let ddgFinalReport = '';
+
+            // While streaming: keep the node body minimal (topic + short hint). Status, sources, and
+            // per-source lines live only in the activity drawer — avoids duplicating the same text.
+            const streamingPlaceholderBody = `${reportHeader}\n\n*In progress…*`;
+
+            this.graph.updateNode(nodeId, {
+                researchActivityActive: true,
+                researchActivityLog: appendResearchActivityLine('', 'Starting research…'),
+                content: streamingPlaceholderBody,
+            });
+            this.canvas.updateNodeContent(nodeId, streamingPlaceholderBody, true);
+            this._refreshResearchActivityPanel(nodeId);
 
             await readSSEStream(response, {
                 onEvent: (eventType, data) => {
                     if (eventType === 'status') {
-                        lastStatus = data.trim();
-                        if (!hasExa) {
-                            const sourcesBlock =
-                                ddgSourceCount > 0 ? `## Sources (${ddgSourceCount})\n\n${ddgSourcesMd}` : '';
-                            const statusContent = `${reportHeader}*${lastStatus}*\n\n${sourcesBlock}`.trim();
-                            this.canvas.updateNodeContent(nodeId, statusContent, true);
-                        } else {
-                            const statusContent = `${reportHeader}*${lastStatus}*`;
-                            this.canvas.updateNodeContent(nodeId, statusContent, true);
-                        }
+                        const line = data.trim();
+                        const n = this.graph.getNode(nodeId);
+                        const nextLog = appendResearchActivityLine(n?.researchActivityLog || '', line);
+                        this.graph.updateNode(nodeId, { researchActivityLog: nextLog });
+                        this._refreshResearchActivityPanel(nodeId);
                     } else if (eventType === 'content') {
                         if (!hasExa) {
                             // DDG fallback sends the final report as one payload
@@ -422,24 +478,16 @@ class ResearchFeature extends FeaturePlugin {
                             this.graph.updateNode(nodeId, { content: reportContent });
                         }
                     } else if (eventType === 'source') {
-                        // DDG fallback emits individual sources as JSON
+                        // DDG fallback emits individual sources as JSON (activity log only; not the node body)
                         try {
                             const source = JSON.parse(data);
-                            ddgSourceCount += 1;
-
                             const title = source.title || 'Untitled';
                             const url = source.url || '';
-                            const summary = source.summary || '';
-                            const query = source.query ? `\n\n*Query:* \`${source.query}\`` : '';
-
-                            ddgSourcesMd += `### [${title}](${url})${query}\n\n${summary}\n\n---\n\n`;
-
-                            // While the loop runs, show status + growing sources list
-                            const sourcesBlock = `## Sources (${ddgSourceCount})\n\n${ddgSourcesMd}`;
-                            const statusBlock = lastStatus ? `*${lastStatus}*\n\n` : '';
-                            const content = `${reportHeader}${statusBlock}${sourcesBlock}`;
-                            this.canvas.updateNodeContent(nodeId, content, true);
-                            this.graph.updateNode(nodeId, { content: content });
+                            const srcLine = `Source: ${title}${url ? ` — ${truncateForActivityLog(url)}` : ''}`;
+                            const nSrc = this.graph.getNode(nodeId);
+                            const logAfterSrc = appendResearchActivityLine(nSrc?.researchActivityLog || '', srcLine);
+                            this.graph.updateNode(nodeId, { researchActivityLog: logAfterSrc });
+                            this._refreshResearchActivityPanel(nodeId);
                         } catch (e) {
                             console.error('Failed to parse DDG source event:', e);
                         }
@@ -454,6 +502,9 @@ class ResearchFeature extends FeaturePlugin {
                 onDone: () => {
                     // Clean up streaming state
                     this.streamingManager.unregister(nodeId);
+
+                    this.graph.updateNode(nodeId, { researchActivityActive: false });
+                    this._refreshResearchActivityPanel(nodeId);
 
                     if (!hasExa && ddgFinalReport) {
                         reportContent = reportHeader + ddgFinalReport;
@@ -479,10 +530,14 @@ class ResearchFeature extends FeaturePlugin {
                     // Clean up streaming state on error
                     this.streamingManager.unregister(nodeId);
 
-                    // Re-throw if not an abort error
-                    if (err.name !== 'AbortError') {
-                        throw err;
+                    if (err.name === 'AbortError') {
+                        const n = this.graph.getNode(nodeId);
+                        const log = appendResearchActivityLine(n?.researchActivityLog || '', 'Stopped.');
+                        this.graph.updateNode(nodeId, { researchActivityLog: log, researchActivityActive: false });
+                        this._refreshResearchActivityPanel(nodeId);
+                        return;
                     }
+                    throw err;
                 },
             });
 
@@ -494,11 +549,19 @@ class ResearchFeature extends FeaturePlugin {
             // Check if it was aborted (user clicked stop)
             // StreamingManager handles stopped indicator via default onStop behavior
             if (err.name === 'AbortError') {
+                const n = this.graph.getNode(nodeId);
+                const log = appendResearchActivityLine(n?.researchActivityLog || '', 'Stopped.');
+                this.graph.updateNode(nodeId, { researchActivityLog: log, researchActivityActive: false });
+                this._refreshResearchActivityPanel(nodeId);
                 this.saveSession();
                 return;
             }
 
             // Other errors - use captured instructions to avoid closure issues
+            const nErr = this.graph.getNode(nodeId);
+            const logErr = appendResearchActivityLine(nErr?.researchActivityLog || '', `Error: ${err.message}`);
+            this.graph.updateNode(nodeId, { researchActivityLog: logErr, researchActivityActive: false });
+            this._refreshResearchActivityPanel(nodeId);
             const errorContent = `**Research${providerLabel}:** ${instructions}\n\n*Error: ${err.message}*`;
             this.canvas.updateNodeContent(nodeId, errorContent, false);
             this.graph.updateNode(nodeId, { content: errorContent });

--- a/tests/test_ddg_endpoints.py
+++ b/tests/test_ddg_endpoints.py
@@ -1,10 +1,13 @@
 """Tests for DDG endpoints plugin (per-iteration cap and related logic)."""
 
-from canvas_chat.plugins.ddg_endpoints import _max_sources_per_iteration
+from canvas_chat.plugins.ddg_endpoints import (
+    clip_page_markdown_to_input_token_budget,
+    max_sources_per_iteration,
+)
 
 
 class TestMaxSourcesPerIteration:
-    """Unit tests for _max_sources_per_iteration.
+    """Unit tests for max_sources_per_iteration.
 
     Ensures the per-iteration cap formula is correct so sources are spread
     across iterations for better query diversity. Protects against
@@ -13,26 +16,63 @@ class TestMaxSourcesPerIteration:
 
     def test_defaults_40_sources_4_iterations(self):
         """Default research params: 40 sources over 4 iterations -> 10 per iteration."""
-        assert _max_sources_per_iteration(40, 4) == 10
+        assert max_sources_per_iteration(40, 4) == 10
 
     def test_80_sources_4_iterations(self):
         """80 sources over 4 iterations -> 20 per iteration."""
-        assert _max_sources_per_iteration(80, 4) == 20
+        assert max_sources_per_iteration(80, 4) == 20
 
     def test_small_total_one_iteration(self):
         """5 sources, 1 iteration -> 5 (floor is 5)."""
-        assert _max_sources_per_iteration(5, 1) == 5
+        assert max_sources_per_iteration(5, 1) == 5
 
     def test_ceiling_division_20_sources_3_iterations(self):
         """20 sources over 3 iterations -> ceil(20/3) = 7 per iteration."""
-        assert _max_sources_per_iteration(20, 3) == 7
+        assert max_sources_per_iteration(20, 3) == 7
 
     def test_minimum_5_per_iteration(self):
         """Result is always at least 5 even when division would be smaller."""
-        assert _max_sources_per_iteration(8, 4) == 5  # 8/4=2, but min is 5
-        assert _max_sources_per_iteration(1, 1) == 5
+        assert max_sources_per_iteration(8, 4) == 5  # 8/4=2, but min is 5
+        assert max_sources_per_iteration(1, 1) == 5
 
     def test_even_split(self):
         """When max_sources is divisible by max_iterations, result is exact."""
-        assert _max_sources_per_iteration(60, 4) == 15
-        assert _max_sources_per_iteration(12, 3) == 5  # 12/3=4, but min is 5
+        assert max_sources_per_iteration(60, 4) == 15
+        assert max_sources_per_iteration(12, 3) == 5  # 12/3=4, but min is 5
+
+
+class TestClipPageMarkdownToInputTokenBudget:
+    """Unit tests for clip_page_markdown_to_input_token_budget."""
+
+    def test_empty_returns_empty(self):
+        out = clip_page_markdown_to_input_token_budget(
+            "", model="gpt-4o", max_input_tokens=100
+        )
+        assert out == ""
+
+    def test_zero_budget_returns_empty(self):
+        assert (
+            clip_page_markdown_to_input_token_budget(
+                "hello world", model="gpt-4o", max_input_tokens=0
+            )
+            == ""
+        )
+
+    def test_short_text_unchanged(self):
+        s = "Short page."
+        assert (
+            clip_page_markdown_to_input_token_budget(
+                s, model="openai/gpt-4o-mini", max_input_tokens=3000
+            )
+            == s
+        )
+
+    def test_long_text_truncates_under_tiny_budget(self):
+        blob = "word " * 50000
+        out = clip_page_markdown_to_input_token_budget(
+            blob,
+            model="openai/gpt-4o-mini",
+            max_input_tokens=20,
+        )
+        assert len(out) < len(blob)
+        assert len(out) > 0

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -13,6 +13,8 @@ from canvas_chat.app import (
     Message,
     PdfResult,
     RefineQueryRequest,
+    SummarizeOutput,
+    SummarizeRequest,
     extract_provider,
 )
 from canvas_chat.plugins.ddg_endpoints import (
@@ -119,6 +121,25 @@ def test_refine_query_request_missing_required():
 
     with pytest.raises(ValidationError):
         RefineQueryRequest(user_query="some query")
+
+
+def test_summarize_request_optional_guidance_and_structured_output():
+    """Optional summary_type/summary_length; SummarizeOutput has one field."""
+    r = SummarizeRequest(
+        messages=[Message(role="user", content="Hello")],
+        model="openai/gpt-4o-mini",
+        summary_type="bullet outline of decisions",
+        summary_length="max 5 bullets",
+    )
+    assert r.summary_type == "bullet outline of decisions"
+    assert r.summary_length == "max 5 bullets"
+
+    r_min = SummarizeRequest(messages=[Message(role="user", content="Hi")])
+    assert r_min.summary_type is None
+    assert r_min.summary_length is None
+
+    out = SummarizeOutput(summary="A concise summary.")
+    assert out.summary == "A concise summary."
 
 
 # --- CommitteeRequest tests ---

--- a/tests/test_node_protocols.js
+++ b/tests/test_node_protocols.js
@@ -596,6 +596,45 @@ test('renderContent: MatrixNode returns full HTML structure', () => {
 });
 
 // ============================================================
+// ResearchNode output panel
+// ============================================================
+
+test('ResearchNode: hasOutput is false without activity log', () => {
+    const node = { type: NodeType.RESEARCH, id: 'r1', content: 'x' };
+    const wrapped = wrapNode(node);
+    assertTrue(!wrapped.hasOutput());
+});
+
+test('ResearchNode: hasOutput and renderOutputPanel when activity log present', () => {
+    const node = {
+        type: NodeType.RESEARCH,
+        id: 'r1',
+        content: 'x',
+        researchActivityLog: 'Searching…',
+        researchActivityActive: true,
+    };
+    const wrapped = wrapNode(node);
+    assertTrue(wrapped.hasOutput());
+    const html = wrapped.renderOutputPanel(mockCanvas);
+    assertTrue(html.includes('aria-label="Research activity"'));
+    assertTrue(html.includes('Searching'));
+    assertTrue(html.includes('Running'));
+});
+
+test('ResearchNode: renderOutputPanel escapes HTML in log', () => {
+    const node = {
+        type: NodeType.RESEARCH,
+        id: 'r1',
+        researchActivityLog: '<script>x</script>',
+        researchActivityActive: false,
+    };
+    const wrapped = wrapNode(node);
+    const html = wrapped.renderOutputPanel(mockCanvas);
+    assertTrue(!html.includes('<script>'));
+    assertTrue(html.includes('&lt;script&gt;'));
+});
+
+// ============================================================
 // CodeNode Tests (Modal-based editing)
 // ============================================================
 


### PR DESCRIPTION
## Summary

This pull request lands the **llamabot backend proxy** migration (async bots, shared message helpers, DDG deep-research refactor) and adds a **research activity output panel** so streaming status and per-source lines appear in the slide-out drawer without duplicating them in the research node body.

## Changes

### Backend (llamabot / LiteLLM)

- **`llm_messages.py`**: Maps OpenAI-style dicts / Pydantic messages to llamabot `BaseMessage` tuples.
- **`app.py`**: Uses `AsyncSimpleBot` / structured bots for the right flows; LiteLLM remains for Copilot prep, token counting, and streaming paths that still use `litellm.acompletion` where appropriate.
- **Plugins**: `code_handler.py`, `matrix_handler.py`, and `pptx_endpoints.py` updated for the new completion helpers.
- **DDG research** (`ddg_endpoints.py`): Module-level `ddg_research_event_stream`, public helpers (`build_ddg_research_runtime`, `ddg_fetch_page_to_source`, `ddg_synthesize_final_report`, etc.), and `clip_page_markdown_to_input_token_budget` with `DDG_PAGE_BODY_MAX_INPUT_TOKENS` instead of a raw character slice.
- **Frontend**: Small `chat.js` adjustments aligned with backend behavior.
- **Docs**: LLD/EARS under `docs/designs/llamabot-backend-proxy/`; `AGENTS.md` map and constants updated.
- **Dependencies**: `llamabot>=0.18.0` in `pyproject.toml`; `pixi.lock` refreshed.

### Research UX (activity drawer)

- **`plugins/research-node.js`**: `hasOutput` / `renderOutputPanel`; activity log in drawer (`@spec` NODE-REQ-019).
- **`plugins/research.js`**: Append SSE `status` and DDG `source` lines to `researchActivityLog`; while streaming, node body shows only **topic + *In progress…*** (no duplicate status/sources in the card).
- **`canvas.js`**: `ensureOutputPanelContent` for first-chunk panel creation.
- **`nodes.css`**: Flat `.research-activity-log` (drawer is the scroll container).
- **Specs / design**: NODE-REQ-019, RSCH-REQ-005; HLD §4.4, research LLD, `docs/how-to/deep-research.md`.
- **Tests**: `tests/test_node_protocols.js` (ResearchNode panel + escaping).

## Tests

- `pixi run test` (Python).
- `pixi run test-js` / `node tests/run_tests.js` for touched JS tests.

## Notes

- Branch includes prior commits (docs LLD/EARS, backend migration, DDG refactor) plus **`feat(research): activity drawer, no duplicate streaming in node`**.
