### PR TITLE
feat(agent): add tag_node tool for voice-controlled node tagging

### DIFF
--- a/src/canvas_chat/app.py
+++ b/src/canvas_chat/app.py
@@ -329,6 +329,7 @@ class AgentViewportNode(BaseModel):
     type: str
     title: str = ""
     content: str = ""
+    tags: list[str] = []
 
 
 class AgentRequest(BaseModel):
@@ -430,6 +431,67 @@ AGENT_TOOLS = [
             },
         },
     },
+    {
+        "type": "function",
+        "function": {
+            "name": "tag_node",
+            "description": (
+                "Add, remove, create, or rename tags on canvas nodes. "
+                "Tags are color-coded labels that help organize nodes. "
+                "Use action='add' to apply an existing tag to nodes, "
+                "action='remove' to remove a tag from nodes, "
+                "action='create' to create a new tag "
+                "(optionally applying it to nodes), "
+                "action='rename' to assign or change a tag's "
+                "display name by its color."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "enum": ["add", "remove", "create", "rename"],
+                        "description": (
+                            "The tag operation: "
+                            "'add' = apply existing tag to nodes, "
+                            "'remove' = remove tag from nodes, "
+                            "'create' = create a new tag "
+                            "(optionally applying to nodes), "
+                            "'rename' = assign or change a tag's "
+                            "display name by its color"
+                        ),
+                    },
+                    "tag_name": {
+                        "type": "string",
+                        "description": (
+                            "Tag name. For add/remove: must match "
+                            "an existing tag name. For create/rename: "
+                            "the new display name for the tag."
+                        ),
+                    },
+                    "tag_color_name": {
+                        "type": "string",
+                        "description": (
+                            "Color name for identifying a tag slot "
+                            "(e.g. 'red', 'green', 'blue'). "
+                            "Used with 'rename' to specify which "
+                            "color slot to name. The system maps "
+                            "common color names to hex values."
+                        ),
+                    },
+                    "node_ids": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": (
+                            "Node IDs to apply the tag to. "
+                            "Required for add/remove. Optional for create."
+                        ),
+                    },
+                },
+                "required": ["action", "tag_name"],
+            },
+        },
+    },
 ]
 
 AGENT_SYSTEM_PROMPT = (
@@ -446,6 +508,15 @@ AGENT_SYSTEM_PROMPT = (
     "Use link_from to specify which search result refs "
     "this note synthesizes (e.g. link_from: ['ref-0', 'ref-2']).\n"
     "- generate_image: Creates an image node on the canvas.\n"
+    "- tag_node: Add, remove, create, or rename tags on canvas nodes.\n"
+    "  Tags are color-coded labels that help organize nodes.\n"
+    "  Use action='add' with node_ids to tag nodes,\n"
+    "  action='remove' to untag, action='create' to make a new tag,\n"
+    "  action='rename' with tag_color_name to name/rename a tag by its color.\n"
+    "  When the user refers to a tag by color (e.g. 'the green tag'), "
+    "use tag_color_name.\n"
+    "  When the user refers to a tag by name (e.g. 'Important'), "
+    "use tag_name.\n"
     "\n"
     "Canvas context: The user can see nodes on their canvas. "
     "Nodes visible in their viewport are provided as context.\n"
@@ -1899,6 +1970,36 @@ async def _agent_execute_tool(
             "node_create": node_data,
         }
 
+    elif tool_name == "tag_node":
+        action = tool_args.get("action", "")
+        tag_name = tool_args.get("tag_name", "")
+        tag_color_name = tool_args.get("tag_color_name", "")
+        node_ids = tool_args.get("node_ids", [])
+
+        if not tag_name:
+            return {
+                "type": "error",
+                "content": "tag_name is required",
+            }
+
+        if action in ("add", "remove") and not node_ids:
+            return {
+                "type": "error",
+                "content": "node_ids is required for add/remove actions",
+            }
+
+        desc = f"{len(node_ids)} node(s)" if node_ids else "tag"
+        return {
+            "type": "tag",
+            "content": f"Tag '{tag_name}' {action} applied to {desc}",
+            "tag_update": {
+                "action": action,
+                "tag_name": tag_name,
+                "tag_color_name": tag_color_name,
+                "node_ids": node_ids,
+            },
+        }
+
     return {"type": "text", "content": f"Unknown tool: {tool_name}"}
 
 
@@ -1946,8 +2047,9 @@ async def agent(request: AgentRequest, http_request: Request):
         for node in request.viewport_context:
             label = node.title or node.type
             content_preview = node.content[:500] if node.content else "(empty)"
+            tag_str = f" [tags: {', '.join(node.tags)}]" if node.tags else ""
             context_lines.append(
-                f"[{node.type}] {label} (id: {node.id}):\n{content_preview}"
+                f"[{node.type}] {label} (id: {node.id}){tag_str}:\n{content_preview}"
             )
         system_prompt += "\n\n## Visible Canvas Nodes\n\n" + "\n\n".join(context_lines)
 
@@ -2116,6 +2218,12 @@ async def agent(request: AgentRequest, http_request: Request):
                                 "data": json.dumps(result["node_create"]),
                             }
 
+                        if "tag_update" in result and result.get("type") != "error":
+                            yield {
+                                "event": "tag_update",
+                                "data": json.dumps(result["tag_update"]),
+                            }
+
                         yield {
                             "event": "tool_result",
                             "data": json.dumps(
@@ -2230,11 +2338,35 @@ async def ws_agent(websocket: WebSocket):
         for node in viewport_context_raw:
             label = node.get("title", "") or node.get("type", "")
             content_preview = (node.get("content", "") or "")[:500]
+            node_tags = node.get("tags", [])
+            tag_str = f" [tags: {', '.join(node_tags)}]" if node_tags else ""
             context_lines.append(
                 f"[{node.get('type')}] {label} "
-                f"(id: {node.get('id')}):\n{content_preview}"
+                f"(id: {node.get('id')}){tag_str}:\n{content_preview}"
             )
         system_prompt += "\n\n## Visible Canvas Nodes\n\n" + "\n\n".join(context_lines)
+
+    available_tags = start_msg.get("available_tags", [])
+    if available_tags:
+        tag_lines = [f"- {t['name']} (color: {t['color']})" for t in available_tags]
+        system_prompt += "\n\n## Available Tags\n\n" + "\n".join(tag_lines)
+
+    free_colors = start_msg.get("available_colors", [])
+    if free_colors:
+        system_prompt += (
+            f"\n\nFree tag colors for creating new tags: {len(free_colors)} available"
+        )
+    else:
+        system_prompt += (
+            "\n\nAll 8 tag slots are in use. Remove a tag before creating a new one."
+        )
+
+    system_prompt += (
+        "\n\nTag color names: red=#ffc9c9, orange=#ffd8a8, yellow=#fff3bf, "
+        "green=#c0eb75, blue=#a5d8ff, purple=#d0bfff, pink=#fcc2d7, "
+        "gray=#e9ecef. When the user says 'the green tag', "
+        "use tag_color_name='green'."
+    )
 
     try:
         api_key = openai_api_key or gemini_api_key or ""
@@ -2318,6 +2450,9 @@ async def ws_agent(websocket: WebSocket):
                     await send_event("node_create", node_data)
             elif "node_create" in result and result.get("type") != "error":
                 await send_event("node_create", result["node_create"])
+
+            if "tag_update" in result and result.get("type") != "error":
+                await send_event("tag_update", result["tag_update"])
 
             await send_event(
                 "tool_result",

--- a/src/canvas_chat/static/js/agent-utils.js
+++ b/src/canvas_chat/static/js/agent-utils.js
@@ -6,18 +6,30 @@
  * and code execution logic without duplicating code.
  */
 
-import { getDefaultNodeSize } from './graph-types.js';
+import { getDefaultNodeSize, TAG_COLORS } from './graph-types.js';
+
+const COLOR_NAME_MAP = {
+    'red': '#ffc9c9',
+    'orange': '#ffd8a8',
+    'yellow': '#fff3bf',
+    'green': '#c0eb75',
+    'blue': '#a5d8ff',
+    'purple': '#d0bfff',
+    'pink': '#fcc2d7',
+    'gray': '#e9ecef',
+    'grey': '#e9ecef',
+};
 
 /**
  * Gather visible viewport context for LLM awareness.
  *
  * @param {Object} graph - CRDTGraph instance
  * @param {Object} canvas - Canvas instance
- * @returns {Array<Object>} Array of visible node summaries
+ * @returns {Object} { nodes: Array, available_tags: Array, available_colors: Array }
  */
 function gatherViewportContext(graph, canvas) {
     const viewBox = canvas.viewBox;
-    if (!viewBox) return [];
+    if (!viewBox) return { nodes: [], available_tags: [], available_colors: [] };
 
     const allNodes = graph.getAllNodes();
     const visible = allNodes.filter((node) => {
@@ -33,12 +45,32 @@ function gatherViewportContext(graph, canvas) {
         );
     });
 
-    return visible.map((node) => ({
-        id: node.id,
-        type: node.type,
-        title: node.title || '',
-        content: (node.content || '').substring(0, 2000),
+    const allTags = graph.getAllTags ? graph.getAllTags() : {};
+    const availableTags = Object.values(allTags).map((t) => ({
+        name: t.name,
+        color: t.color,
     }));
+    const usedColors = new Set(Object.keys(allTags));
+    const availableColors = TAG_COLORS.filter((c) => !usedColors.has(c));
+
+    const nodes = visible.map((node) => {
+        const nodeTagColors = node.tags || [];
+        const nodeTagNames = nodeTagColors
+            .map((color) => {
+                const tag = allTags[color];
+                return tag ? tag.name : null;
+            })
+            .filter(Boolean);
+        return {
+            id: node.id,
+            type: node.type,
+            title: node.title || '',
+            content: (node.content || '').substring(0, 2000),
+            tags: nodeTagNames,
+        };
+    });
+
+    return { nodes, available_tags: availableTags, available_colors: availableColors };
 }
 
 /**
@@ -271,4 +303,96 @@ async function executeCodeOnNode(
     }
 }
 
-export { createNodeFromInstruction, executeCodeOnNode, gatherViewportContext };
+/**
+ * Apply a tag update instruction from the backend agent tool.
+ *
+ * Handles add, remove, create, and rename tag operations
+ * by resolving tag names to colors and mutating the graph.
+ *
+ * @param {Object} instruction - { action, tag_name, tag_color_name, node_ids }
+ * @param {Object} graph - CRDTGraph instance
+ * @param {Object} canvas - Canvas instance
+ * @param {Function} saveSession - Save session callback
+ * @param {Function} showToast - Toast notification callback
+ */
+function applyTagUpdate(instruction, graph, canvas, saveSession, showToast) {
+    const action = instruction.action;
+    const tagName = instruction.tag_name;
+    const tagColorName = instruction.tag_color_name || '';
+    const nodeIds = instruction.node_ids || [];
+
+    if (action === 'rename') {
+        const color =
+            COLOR_NAME_MAP[tagColorName.toLowerCase()] || tagColorName;
+        const existingTag = graph.getTag ? graph.getTag(color) : null;
+        if (existingTag) {
+            graph.updateTag(color, tagName);
+        } else {
+            graph.createTag(color, tagName);
+        }
+        canvas.renderGraph();
+        saveSession();
+        return;
+    }
+
+    if (action === 'create') {
+        const existingTags = graph.getAllTags ? graph.getAllTags() : {};
+        const usedColors = new Set(Object.keys(existingTags));
+        const freeColor = TAG_COLORS.find((c) => !usedColors.has(c));
+
+        if (!freeColor) {
+            if (showToast) showToast('All 8 tag slots are in use');
+            return;
+        }
+
+        graph.createTag(freeColor, tagName);
+
+        if (nodeIds.length > 0) {
+            for (const nodeId of nodeIds) {
+                graph.addTagToNode(nodeId, freeColor);
+            }
+        }
+
+        canvas.renderGraph();
+        saveSession();
+        return;
+    }
+
+    const allTags = graph.getAllTags ? graph.getAllTags() : {};
+    const tagEntry = Object.entries(allTags).find(
+        ([_, t]) => t.name.toLowerCase() === tagName.toLowerCase()
+    );
+
+    if (!tagEntry) {
+        const available = Object.values(allTags)
+            .map((t) => t.name)
+            .join(', ');
+        if (showToast)
+            showToast(`Tag "${tagName}" not found. Available: ${available}`);
+        return;
+    }
+
+    const [color] = tagEntry;
+
+    for (const nodeId of nodeIds) {
+        const node = graph.getNode(nodeId);
+        if (!node) continue;
+
+        if (action === 'add') {
+            graph.addTagToNode(nodeId, color);
+        } else if (action === 'remove') {
+            graph.removeTagFromNode(nodeId, color);
+        }
+    }
+
+    canvas.renderGraph();
+    saveSession();
+}
+
+export {
+    applyTagUpdate,
+    COLOR_NAME_MAP,
+    createNodeFromInstruction,
+    executeCodeOnNode,
+    gatherViewportContext,
+};

--- a/src/canvas_chat/static/js/plugins/agent.js
+++ b/src/canvas_chat/static/js/plugins/agent.js
@@ -16,6 +16,7 @@ import { EdgeType, NodeType, createEdge, createNode } from '../graph-types.js';
 import { apiUrl } from '../utils.js';
 import { readSSEStream } from '../sse.js';
 import {
+    applyTagUpdate as _applyTagUpdate,
     createNodeFromInstruction as _createNodeFromInstruction,
     executeCodeOnNode as _executeCodeOnNode,
     gatherViewportContext as _gatherViewportContext,
@@ -92,7 +93,7 @@ class AgentFeature extends FeaturePlugin {
         this.graph.addEdge(agentEdge);
         this.updateCollapseButtonForNode(humanNode.id);
 
-        const viewportContext = this.gatherViewportContext();
+        const ctx = this.gatherViewportContext();
 
         const apiMessages = [{ role: 'user', content: message }];
 
@@ -121,7 +122,7 @@ class AgentFeature extends FeaturePlugin {
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     messages: apiMessages,
-                    viewport_context: viewportContext,
+                    viewport_context: ctx.nodes || ctx,
                     model: llmRequest.model,
                     api_key: llmRequest.api_key || null,
                     base_url: llmRequest.base_url || null,
@@ -189,6 +190,19 @@ class AgentFeature extends FeaturePlugin {
                         } catch (e) {
                             console.warn('[Agent] Failed to parse node_create:', e);
                         }
+                    } else if (eventType === 'tag_update') {
+                        try {
+                            const tagInstruction = JSON.parse(data);
+                            _applyTagUpdate(
+                                tagInstruction,
+                                this.graph,
+                                this.canvas,
+                                () => this.saveSession(),
+                                (msg) => this.showToast(msg)
+                            );
+                        } catch (e) {
+                            console.warn('[Agent] Failed to parse tag_update:', e);
+                        }
                     }
                 },
                 onDone: () => {
@@ -223,7 +237,7 @@ class AgentFeature extends FeaturePlugin {
     }
 
     /**
-     * @returns {Array<Object>}
+     * @returns {Object}
      */
     gatherViewportContext() {
         return _gatherViewportContext(this.graph, this.canvas);

--- a/src/canvas_chat/static/js/plugins/realtime-agent.js
+++ b/src/canvas_chat/static/js/plugins/realtime-agent.js
@@ -11,7 +11,7 @@
 
 import { FeaturePlugin } from '../feature-plugin.js';
 import { EdgeType, NodeType, createEdge, createNode } from '../graph-types.js';
-import { createNodeFromInstruction, gatherViewportContext } from '../agent-utils.js';
+import { applyTagUpdate, createNodeFromInstruction, gatherViewportContext } from '../agent-utils.js';
 
 /**
  *
@@ -225,7 +225,7 @@ class RealtimeAgentPlugin extends FeaturePlugin {
         this.agentNodeId = agentNode.id;
 
         this.ws.onopen = () => {
-            const viewportContext = gatherViewportContext(this.graph, this.canvas);
+            const ctx = gatherViewportContext(this.graph, this.canvas);
             const openaiBaseUrl = this.storage?.getBaseUrl() || null;
             const voiceProvider = this.storage?.getVoiceProvider() || 'auto';
             this.ws.send(JSON.stringify({
@@ -234,7 +234,9 @@ class RealtimeAgentPlugin extends FeaturePlugin {
                 gemini_api_key: geminiApiKey,
                 openai_base_url: openaiBaseUrl,
                 voice_provider: voiceProvider,
-                viewport_context: viewportContext,
+                viewport_context: ctx.nodes || ctx,
+                available_tags: ctx.available_tags || [],
+                available_colors: ctx.available_colors || [],
             }));
         };
 
@@ -324,6 +326,18 @@ class RealtimeAgentPlugin extends FeaturePlugin {
                         lastToolParentId.value = newId;
                     }
                 }
+                break;
+            }
+
+            case 'tag_update': {
+                const tagInstruction = typeof data === 'string' ? JSON.parse(data) : data;
+                applyTagUpdate(
+                    tagInstruction,
+                    this.graph,
+                    this.canvas,
+                    () => this.saveSession(),
+                    (msg) => this.showToast(msg)
+                );
                 break;
             }
 

--- a/tests/test_agent_plugin.js
+++ b/tests/test_agent_plugin.js
@@ -156,7 +156,10 @@ await asyncTest('AgentFeature.gatherViewportContext returns empty with no canvas
     });
     const feature = harness.registry.getFeature('agent');
     const ctx = feature.gatherViewportContext();
-    assertTrue(Array.isArray(ctx), 'Should return an array');
+    assertTrue(typeof ctx === 'object', 'Should return an object');
+    assertTrue(Array.isArray(ctx.nodes), 'Should have a nodes array');
+    assertTrue(Array.isArray(ctx.available_tags), 'Should have an available_tags array');
+    assertTrue(Array.isArray(ctx.available_colors), 'Should have an available_colors array');
 });
 
 console.log('\n=== All Agent Feature tests passed ===\n');


### PR DESCRIPTION
## Summary

Adds a `tag_node` agent tool that enables voice-controlled node tagging via `/mic` (WebSocket) and `/agent` (SSE). Users can say things like "tag the node that has the plot as Important" or "give the green tag the name Review" and the LLM calls the tool to apply the change on the canvas in real-time.

Closes #278

## Root Cause

No agent tool existed for modifying existing nodes. All 4 existing tools (`search_web`, `execute_code`, `create_note`, `generate_image`) only create new nodes. Tags are a core organizational feature with no voice/agent access.

## Solution

### Architecture: Backend pass-through, frontend execution

Tags live entirely in the client-side CRDT graph. The backend has no tag state, so:
- **Backend** validates parameters and returns a `tag_update` instruction (no tag logic)
- **Frontend** does all the work: name→color resolution, slot availability, graph mutation, re-render

### Tool: `tag_node`

| Parameter | Required | Description |
|-----------|----------|-------------|
| `action` | Yes | `add`, `remove`, `create`, or `rename` |
| `tag_name` | Yes | Tag display name |
| `tag_color_name` | No | Color name for rename (e.g. "green" → #c0eb75) |
| `node_ids` | No* | Target node IDs (*required for add/remove) |

### User stories covered

- **US-1**: Tag a node by describing it ("tag the node with the plot as Important")
- **US-2**: Name a tag by color ("give the green tag the name 'Review'")
- **US-3**: Tag multiple nodes ("tag all search results as 'Source'")
- **US-4**: Create + apply in one step ("create a tag called 'Follow-up' and tag this node")
- **US-5**: Remove a tag ("remove the Important tag from that note")

## Changes Breakdown

### Backend (`src/canvas_chat/app.py`)
- Add `tag_node` to `AGENT_TOOLS` with 4-action enum and color-name support
- Add pass-through handler in `_agent_execute_tool()` → returns `tag_update` instruction
- Add `tag_update` dispatch in both SSE (~line 2217) and WebSocket (~line 2421) paths
- Add `tags` field to `AgentViewportNode` Pydantic model
- Inject tag catalog + color-name map into voice mode system prompt
- Include per-node tag names in viewport context for both SSE and WS paths

### Frontend (`src/canvas_chat/static/js/agent-utils.js`)
- `gatherViewportContext()` now returns `{ nodes, available_tags, available_colors }` with per-node tag names
- Add `COLOR_NAME_MAP` (red→#ffc9c9, green→#c0eb75, etc.) for voice-friendly references
- Add shared `applyTagUpdate()` function handling all 4 actions

### Frontend (`src/canvas_chat/static/js/plugins/realtime-agent.js`)
- Import and handle `tag_update` WebSocket message → calls `applyTagUpdate()`
- Send `available_tags` and `available_colors` in `session_start`

### Frontend (`src/canvas_chat/static/js/plugins/agent.js`)
- Import and handle `tag_update` SSE event → calls `applyTagUpdate()`
- Adapt to new `gatherViewportContext()` return shape

### Tests
- Updated `test_agent_plugin.js` to validate new `{ nodes, available_tags, available_colors }` return shape

## Tests

- **Python**: 186 passed (no regressions)
- **JavaScript**: 81 passed (1 test updated for new return shape)
- **Pre-commit hooks**: All passed (ruff, ruff-format, eslint, trailing whitespace)

## Manual Testing

1. Start dev server: `pixi run dev`
2. Create some nodes and tags on the canvas
3. Open voice mode (`/mic` or click mic button)
4. Try: "Tag the [node description] as [tag name]"
5. Try: "Give the green tag the name 'Review'"
6. Try: "Create a tag called 'Follow-up' and tag this note"
