### PR TITLE
feat(search): redesign /search with results carousel drawer + curated reply context

### DIFF
--- a/.opencode/skill/canvas-chat-integration-check/references/api_reference.md
+++ b/.opencode/skill/canvas-chat-integration-check/references/api_reference.md
@@ -19,3 +19,21 @@ Keep this file updated whenever new cross-component dependencies are discovered.
 2. Scan the related bullet(s) and review the listed files.
 3. Confirm all linked components are updated or explicitly not needed.
 4. Add new bullets when new cross-component dependencies are discovered or when a gap is found.
+
+## Output-panel event handler constraint
+
+- **Output-panel drawer re-rendering** → `canvas.js` has TWO event-binding paths with asymmetric handler-type support:
+  - `applyProtocolEventBindings` (~line 2593): handles BOTH **string** handlers (`this.emit(handler, node.id)`) AND **function** handlers.
+  - `updateOutputPanelContent` (~line 2420): handles ONLY **function** handlers (gated by `if (typeof handler === 'function')`).
+- **Consequence**: any plugin whose output-panel drawer is re-rendered via `updateOutputPanelContent` (the path used by `ensureOutputPanelContent` ← `_refreshSearchPanel` and similar refresh flows) MUST register **function handlers** (`canvas.emit('eventName', nodeId)`), NOT string handlers. String handlers are **silently lost** on drawer re-render — no error, just dead buttons.
+- **Verification**: when wiring event handlers on a custom node with an output panel, check whether the drawer goes through `updateOutputPanelContent`. If yes → use function handlers. If only initial render (`applyProtocolEventBindings`) → string handlers are fine.
+- **Known instance**: `SearchNode` protocol (`plugins/search-node.js`) uses function handlers for this reason. The JSDoc comment there ("We use function handlers because the output-panel binding path invokes functions only") is correct.
+
+## Node content: display vs model update
+
+- **Content display + model are separate** → `canvas.updateNodeContent(nodeId, content, false)` updates the **DOM/view** (node body text); `graph.updateNode(nodeId, {content})` updates the **model** (Y.Text / CRDT). **Neither auto-triggers the other.** To update BOTH the displayed body AND the persisted model, call **BOTH**.
+  - Calling only `graph.updateNode({content})` → the canvas body DOM is **stale** (old text persists, survives until a re-render).
+  - Calling only `canvas.updateNodeContent` → the model is **stale** (changes lost on save/reload).
+- **Verify the pairing convention** by checking other call sites: `research.js` `handleSearch` pairs them (`canvas.updateNodeContent(..., false); graph.updateNode(...)`) because neither suffices alone.
+- **Known bug instance**: `_searchViewContent` called `graph.updateNode({content})` to restore a node body from a transient `Fetching content…` status but never called `canvas.updateNodeContent`, so `Fetching content…` stuck on the SEARCH node body permanently after a View-content fetch. Fix: restore the DOM via `canvas.updateNodeContent(nodeId, node.content, false)` after any transient/status content staging.
+- **Rule of thumb**: when updating node content, grep for existing `updateNodeContent` + `graph.updateNode` pairings and mirror **both** calls.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ This includes:
 - 2026-07-14: **Reply-to-selected fix** — `handleSend()` captures `selectedIds` and passes them to `sendChatMessage(content, parentIds)` and `runAgent(message, parentIds)`. Both use `createLinkedNode` to create edges from selected nodes to the new human node. The `/agent` slash command handler also passes selection.
 - 2026-07-14: **Focus-centric layout** — `focusCentricLayout(focusNodeId, dimensions, navHistory)` in `crdt-graph.js` dynamically reorganizes the graph on j/k navigation using a **spine-based algorithm**. The spine (focus → parents → grandparents, focus → children → grandchildren) is pinned vertically at focus.cx for straight edges. When multiple parents/children exist, the **most recently visited** (from nav history, capped at 50) goes on the spine; fallback for first visit: oldest `created_at`. Other parents/children become branches spread by subtree half-widths. BFS with sibling expansion assigns layers. Triggered from `handleNodeNavigate` when layout algorithm is 'vertical'. Design docs: `docs/explanation/auto-layout.md`.
 - 2026-07-14: **Layout code consolidation** — `getNodeSize`, `DEFAULT_WIDTH`, `DEFAULT_HEIGHT`, `START_X`, `START_Y` are now imported from `layout.js` by all layout methods in `crdt-graph.js` (previously duplicated 4-5 times with drift). Each method still defines its own algorithm-specific `HORIZONTAL_GAP` and `VERTICAL_GAP` locally since these vary by algorithm (50/80/120 for horizontal, 40/60 for vertical). If adding a new layout method, import from `layout.js` — do NOT redeclare `getNodeSize` or dimension constants.
+- 2026-07-16: **Search results drawer + carousel (redesigned /search)** — `/search` no longer creates a REFERENCE-node fan-out. Results live in a carousel drawer (output panel) on the SEARCH node, stored as a JSON string in `node.searchResults` (`[{title,url,snippet,selected,expanded}]`) + `node.searchCarouselIndex`. `SearchNode` protocol (`plugins/search-node.js`) renders the carousel + emits canvas events; `ResearchFeature` (`plugins/research.js`) owns the logic via `getCanvasEventHandlers()` (`searchPrevResult`/`searchNextResult`/`searchToggleSelect`/`searchViewContent`). "View content" fetches the page (`fetchUrlContent` from `web-grounding.js`) and creates an opt-in child REFERENCE node (`url` field set for dedup). Reply context: `CRDTGraph.resolveContextWithSearchResults(nodeIds)` (in `crdt-graph.js`) — for each SEARCH node in the ancestor context, injects selected results (snippet) OR the expanded child's full page text (dedup by url); `App.sendChatMessage` calls it instead of `resolveContext`. Per-result context is clipped to `SEARCH_RESULT_CONTEXT_MAX_CHARS` (6000). Reusable collapse API: `App.setNodeCollapsed(nodeId, bool)` exposed on `AppContext` as `collapseNode`/`expandNode` (wraps the existing generic collapse mechanism; `handleNodeCollapse` is now a thin toggle around it).
 
 **Python commands:** Use `pixi run python` when running project Python commands so the pixi environment and dependencies are active.
 
@@ -112,7 +113,7 @@ canvas-chat/
 | `src/canvas_chat/static/js/app.js`         | Main application, orchestrates everything                                 | Slash commands, keyboard shortcuts, App class methods, graph breadcrumb (`getNavigableParents` / `getNavigableChildren`, `#relationship-panel` / `#relationship-breadcrumb`) |
 | `src/canvas_chat/static/js/canvas.js`      | SVG canvas, pan/zoom, node/edge rendering with defensive edge deferral    | Node appearance, drag behavior, viewport logic, node event handlers, edge rendering, deferred edge queue |
 | `src/canvas_chat/static/js/graph-types.js` | Node/edge types, factory functions                                        | Node types, edge types, createNode/createEdge utilities                                                  |
-| `src/canvas_chat/static/js/crdt-graph.js`  | CRDT-backed graph (Yjs), graph traversal                                  | Graph data model, `createLinkedNode`, `autoPosition`, `verticalTreeLayout`, graph traversal                      |
+| `src/canvas_chat/static/js/crdt-graph.js`  | CRDT-backed graph (Yjs), graph traversal                                  | Graph data model, `createLinkedNode`, `autoPosition`, `verticalTreeLayout`, `resolveContext` / `resolveContextWithSearchResults`, graph traversal                      |
 | `src/canvas_chat/static/js/layout.js`      | Pure layout functions for overlap detection                               | Overlap detection, overlap resolution, `resolveHorizontalOverlaps`, node positioning algorithms                                       |
 | `src/canvas_chat/static/js/chat.js`        | LLM API calls, streaming                                                  | API integration, message formatting, token estimation                                                    |
 | `src/canvas_chat/static/js/storage.js`     | localStorage persistence                                                  | Session storage, API key storage, settings                                                               |
@@ -143,7 +144,7 @@ canvas-chat/
 | `src/canvas_chat/static/js/committee.js`               | CommitteeFeature class             | Multi-LLM consultation, synthesis                                                   |
 | `src/canvas_chat/static/js/matrix.js`                  | MatrixFeature class                | Comparison matrix creation, cell filling                                            |
 | `src/canvas_chat/static/js/factcheck.js`               | FactcheckFeature class             | Claim verification, web search integration                                          |
-| `src/canvas_chat/static/js/plugins/research.js`        | ResearchFeature class              | `/research`, `/search`; DDG/Exa SSE; activity log in ResearchNode output panel       |
+| `src/canvas_chat/static/js/plugins/research.js`        | ResearchFeature class              | `/research`, `/search`; DDG/Exa SSE; activity log in ResearchNode output panel; `/search` stores results in `node.searchResults` (carousel drawer) + carousel canvas-event handlers (`searchPrev/Next/ToggleSelect/ViewContent`) |
 | `src/canvas_chat/static/js/plugins/agent.js`           | AgentFeature class                 | `/agent` agentic mode; tool-using ReAct loop with viewport context; Plotly default   |
 | `src/canvas_chat/static/js/plugins/research-node.js`   | ResearchNode protocol              | Research node header/actions; bottom drawer shows streaming research activity lines  |
 | `src/canvas_chat/static/js/code-feature.js`            | CodeFeature class                  | Self-healing code execution                                                         |
@@ -232,6 +233,8 @@ canvas-chat/
 | Zoom wheel sensitivity                     | `storage.js` (`canvas-chat-zoom-wheel-sensitivity`), `utils.js` (`DEFAULT_ZOOM_WHEEL_SENSITIVITY` = 50) | Settings → Canvas; slider 50 = former “max” step, 100 = stronger; live `input` updates canvas |
 | CSS variables                              | `style.css:10-75`                                          | Colors, sizing, theming                                                         |
 | `DDG_PAGE_BODY_MAX_INPUT_TOKENS`           | `ddg_endpoints.py`                                         | Input token budget for fetched page markdown before per-page LLM summarize (clipped via `clip_page_markdown_to_input_token_budget`) |
+| `SEARCH_RESULT_CONTEXT_MAX_CHARS`          | `crdt-graph.js`                                            | Per-result char cap when injecting a search result into reply context via `resolveContextWithSearchResults` (default 6000) |
+| `SEARCH_PAGE_BODY_MAX_CHARS`               | `plugins/research.js`                                      | Max chars of a fetched page stored on a "View content" child REFERENCE node (default 8000) |
 
 ### Zoom levels (semantic zoom)
 
@@ -856,6 +859,7 @@ pixi run npx cypress run --browser electron --headless --spec cypress/e2e/matrix
 - `cypress/e2e/url_fetch_no_ui_break.cy.js` - URL fetch: dangerous HTML does not break UI
 - `cypress/e2e/html_slides.cy.js` - HTML slides node (/slides with pasted HTML, toolbar, blob URL iframe)
 - `cypress/e2e/reply_to_selected.cy.js` - Reply-to-selected edge creation (single + multi-parent merge)
+- `cypress/e2e/search_carousel.cy.js` - `/search` results carousel drawer (navigate, context checkbox, View content)
 
 ### Unit tests
 
@@ -878,6 +882,7 @@ Write unit tests for logic that does not require API calls:
 - `tests/test_vertical_layout.js` - Vertical tree layout algorithm and type-aware `autoPosition`
 - `tests/test_graph_types.js` - Node creation functions and default node sizes
 - `tests/test_crdt_graph.js` - Graph traversal and visibility functions
+- `tests/test_search_context.js` - `resolveContextWithSearchResults` (search results in reply context)
 - `tests/test_matrix.js` - Matrix rendering and concurrent cell updates
 - `tests/test_flashcards.js` - SM-2 algorithm and flashcard logic
 - `tests/test_storage.js` - localStorage functions

--- a/cypress/e2e/ddg_search.cy.js
+++ b/cypress/e2e/ddg_search.cy.js
@@ -10,7 +10,7 @@ describe('DDG Search', { tags: '@ai' }, () => {
         }).as('ddgSearch');
     });
 
-    it('creates search node and reference nodes when using /search without Exa key', () => {
+    it('creates a search node with a results carousel drawer (no fan-out nodes)', () => {
         cy.get('#chat-input').type('/search test query');
         cy.get('#send-btn').click();
 
@@ -21,8 +21,12 @@ describe('DDG Search', { tags: '@ai' }, () => {
             .and('contain', 'DuckDuckGo')
             .and('contain', 'Found 2 results');
 
-        cy.get('.node.reference').should('have.length', 2);
-        cy.get('.node.reference').first().should('contain', 'Example Result 1').and('contain', 'Snippet one.');
+        // Results live in the carousel drawer on the search node — no fan-out.
+        cy.get('.node.reference').should('have.length', 0);
+        cy.get('.search-carousel').should('be.visible');
+        cy.get('.search-carousel-counter').should('contain', '1 / 2');
+        cy.get('.search-carousel-title').should('contain', 'Example Result 1');
+        cy.get('.search-carousel-snippet').should('contain', 'Snippet one.');
     });
 
     it('shows error in search node when DDG search fails', () => {

--- a/cypress/e2e/search_carousel.cy.js
+++ b/cypress/e2e/search_carousel.cy.js
@@ -1,0 +1,75 @@
+/**
+ * E2E: Search results carousel drawer interactions.
+ *
+ * Covers the redesigned /search: results render in a carousel drawer on the
+ * SEARCH node. Verifies next/prev navigation, the include-in-context checkbox,
+ * and the "View content" action which fetches the page and creates an opt-in
+ * child reference node.
+ *
+ * APIs mocked for determinism:
+ * - /api/ddg/search (fixture)
+ * - /api/fetch-url (page text for "View content")
+ */
+describe('Search results carousel', { tags: '@ai' }, () => {
+    beforeEach(() => {
+        cy.clearLocalStorage();
+        cy.clearIndexedDB();
+        cy.visit('/');
+        cy.wait(1000); // Wait for plugins to load
+
+        cy.intercept('POST', '**/api/ddg/search', {
+            fixture: 'ddg-search-response.json',
+        }).as('ddgSearch');
+
+        cy.intercept('POST', '**/api/fetch-url', {
+            statusCode: 200,
+            body: { title: 'Example Result 1', content: 'FULL PAGE BODY TEXT' },
+        }).as('fetchUrl');
+    });
+
+    it('navigates results with next/prev', () => {
+        cy.get('#chat-input').type('/search test query');
+        cy.get('#send-btn').click();
+        cy.wait('@ddgSearch');
+
+        cy.get('.search-carousel-counter').should('contain', '1 / 2');
+        cy.get('.search-carousel-title').should('contain', 'Example Result 1');
+
+        // Next -> second result
+        cy.get('.search-next').click();
+        cy.get('.search-carousel-counter').should('contain', '2 / 2');
+        cy.get('.search-carousel-title').should('contain', 'Example Result 2');
+
+        // Prev -> back to first
+        cy.get('.search-prev').click();
+        cy.get('.search-carousel-title').should('contain', 'Example Result 1');
+    });
+
+    it('toggles include-in-context checkbox', () => {
+        cy.get('#chat-input').type('/search test query');
+        cy.get('#send-btn').click();
+        cy.wait('@ddgSearch');
+
+        // Defaults to selected (checked)
+        cy.get('.search-toggle-select').should('be.checked');
+        cy.get('.search-toggle-select').uncheck();
+        cy.get('.search-toggle-select').should('not.be.checked');
+    });
+
+    it('View content fetches the page and creates an opt-in child reference node', () => {
+        cy.get('#chat-input').type('/search test query');
+        cy.get('#send-btn').click();
+        cy.wait('@ddgSearch');
+
+        // No reference nodes initially
+        cy.get('.node.reference').should('have.length', 0);
+
+        cy.get('.search-view-content').click();
+        cy.wait('@fetchUrl');
+
+        // A child reference node is created carrying the fetched page text
+        cy.get('.node.reference', { timeout: 10000 })
+            .should('have.length', 1)
+            .and('contain', 'FULL PAGE BODY TEXT');
+    });
+});

--- a/docs/how-to/web-search.md
+++ b/docs/how-to/web-search.md
@@ -36,16 +36,14 @@ Type `/search` followed by your query in the chat input:
 Press Enter. Canvas Chat will:
 
 1. Create a SEARCH node showing your query
-2. Call the Exa API to find relevant results
-3. Create REFERENCE nodes for each search result (up to 5)
-4. Connect them to the search node with dashed lines
+2. Call the search provider (Exa or DuckDuckGo) to find relevant results
+3. Show the results in a **carousel drawer** beneath the search node (no extra nodes cluttering the canvas)
 
-Each reference node shows:
+The search node body shows the query and the result count. The drawer hosts one result at a time. Each result shows:
 
 - The page title
 - The URL
 - A snippet of the content
-- Published date and author (when available)
 
 ## Context-aware search
 
@@ -63,38 +61,33 @@ The search node will show both your original query and the refined version.
 
 Without context, "how does this work?" is too vague to search. By providing context (the selected node), the AI resolves pronouns like "this" into specific technical terms, producing better search results.
 
-## Working with search results
+## Working with search results (carousel drawer)
 
-### Read a snippet
+Open the drawer beneath a SEARCH node (it appears automatically after a search) to browse and curate results.
 
-Click any REFERENCE node to see the title, URL, and preview text.
+### Navigate results
 
-### Fetch full content
+Use the **◀ / ▶** buttons (or step through) to move between results one at a time, PowerPoint-style. The counter shows e.g. `2 / 5`.
 
-Click the **"Fetch & Summarize"** button on a reference node to:
+### Choose what feeds your replies
 
-1. Fetch the full page content via Exa
-2. Create a FETCH_RESULT node with the complete text
-3. Generate an AI summary automatically
+Each result has a **Context** checkbox. Checked results are included as context when you reply to the SEARCH node. All results start checked; uncheck the ones you don't need to keep your prompts focused.
 
-This creates two new nodes connected to the reference:
+### Open a page's full text
 
-- **Fetch result** (full content as markdown)
-- **Summary** (concise AI-generated summary)
+Click **View content** on a result to fetch the page and open it as an opt-in child reference node showing the full page text. This is the only time a separate node is created — the canvas stays clean until you decide a result is worth reading in depth. The child node links back to the search node and can be collapsed like any other node.
 
 ### Reply to results
 
-Select one or more reference nodes and type in the chat input to ask questions about those specific results. The AI will use the snippets as context.
-
-For deeper analysis, fetch the full content first, then ask questions.
+Select the SEARCH node (or reply to it) and type your question. The AI automatically uses your **checked** results as context. For any result you've opened with **View content**, the full page text is used instead of the snippet — so expand the results you care about before asking for deeper analysis.
 
 ## Search positioning
 
 Search nodes are positioned automatically:
 
-- If you have nodes selected: search appears to the right of them
-- If nothing is selected: search appears to the right of the most recent leaf node
-- Reference nodes fan out to the right of the search node
+- If you have nodes selected: the search appears to the right of them
+- If nothing is selected: the search appears to the right of the most recent leaf node
+- Results stay inside the search node's drawer; a child node is only created when you use **View content**
 
 ## Tips
 
@@ -109,12 +102,12 @@ Search nodes are positioned automatically:
 2. Select the relevant nodes
 3. Type `/search what are alternatives?` — the AI resolves "alternatives" based on your conversation
 
-**Fetch selectively** - Don't fetch all results. Read the snippets first, then fetch only the most promising 1-2 pages to avoid clutter.
+**Curate before you ask** - Browse the carousel, uncheck irrelevant results, and use View content on the 1-2 best pages. Replies then draw on exactly the material you chose.
 
 **Use in research workflows:**
 
 1. Start with `/search` to find sources
-2. Fetch full content for 2-3 best results
+2. Open the best 2-3 results with View content
 3. Use `/research` for comprehensive synthesis (see [How to conduct deep research](deep-research.md))
 
 ## Limits
@@ -122,5 +115,5 @@ Search nodes are positioned automatically:
 - Maximum 5-10 search results per query
 - DuckDuckGo provides basic search (no API key needed)
 - Exa provides neural search with richer content (API key required)
-- Fetch & Summarize requires an LLM provider API key
+- View content fetches up to 8000 characters of page text per result
 - The `/research` command requires an Exa API key (no fallback)

--- a/docs/reference/app-context-api.md
+++ b/docs/reference/app-context-api.md
@@ -697,6 +697,32 @@ context.updateCollapseButtonForNode?.(nodeId);
 
 **Note:** Use optional chaining (`?.`) as it may be undefined in tests.
 
+### collapseNode() / expandNode()
+
+```javascript
+context.collapseNode(nodeId: string, collapsed: boolean = true): void
+context.expandNode(nodeId: string): void  // shorthand for collapseNode(nodeId, false)
+```
+
+Explicitly set a node's collapsed state (non-toggling). This is the canonical,
+reusable collapse entry point — it persists the state to the graph, refreshes
+all node/edge visibility, updates the collapse button, and saves the session.
+Works for any node type.
+
+**Usage:**
+
+```javascript
+// Collapse a node after creating child nodes that would clutter the canvas
+context.collapseNode?.(searchNodeId, true);
+
+// Expand again later
+context.expandNode?.(searchNodeId);
+```
+
+**Note:** Use optional chaining (`?.`) as they may be undefined in tests. Prefer
+these over re-implementing collapse logic; `handleNodeCollapse` (the header
+button / `-` keybinding handler) is a thin toggle around `collapseNode`.
+
 ## Design rationale
 
 ### Why AppContext?

--- a/src/canvas_chat/static/css/nodes.css
+++ b/src/canvas_chat/static/css/nodes.css
@@ -1687,6 +1687,105 @@
     font-style: italic;
 }
 
+/* Search node: results carousel inside the output-panel drawer */
+.search-carousel {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    font-size: 0.78rem;
+    line-height: 1.4;
+}
+
+.search-carousel-result {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    overflow: hidden;
+}
+
+.search-carousel-title {
+    font-weight: 600;
+    word-break: break-word;
+}
+
+.search-carousel-url {
+    font-family: var(--font-mono, ui-monospace, monospace);
+    font-size: 0.7rem;
+    color: var(--color-text-tertiary, #888);
+    word-break: break-all;
+}
+
+.search-carousel-snippet {
+    color: var(--color-text-secondary, #555);
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 7em;
+    overflow-y: auto;
+}
+
+.search-carousel-controls {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.search-carousel-select {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    cursor: pointer;
+    user-select: none;
+    font-size: 0.74rem;
+    color: var(--color-text-secondary, #555);
+}
+
+.search-view-content {
+    margin-left: auto;
+    padding: 3px 10px;
+    font-size: 0.74rem;
+    border: 1px solid var(--color-border, #e8e8e8);
+    border-radius: 6px;
+    background: var(--color-bg-secondary, #f8f8f8);
+    cursor: pointer;
+}
+
+.search-view-content:hover {
+    background: var(--color-accent-light, #eef4ff);
+}
+
+.search-view-content:disabled {
+    opacity: 0.6;
+    cursor: progress;
+}
+
+.search-carousel-nav {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 10px;
+    padding-top: 2px;
+}
+
+.search-carousel-nav button {
+    padding: 2px 8px;
+    font-size: 0.74rem;
+    border: 1px solid var(--color-border, #e8e8e8);
+    border-radius: 6px;
+    background: var(--color-bg-secondary, #f8f8f8);
+    cursor: pointer;
+}
+
+.search-carousel-nav button:hover {
+    background: var(--color-accent-light, #eef4ff);
+}
+
+.search-carousel-counter {
+    font-size: 0.72rem;
+    color: var(--color-text-tertiary, #888);
+    font-variant-numeric: tabular-nums;
+}
+
 .code-output-panel-content {
     min-height: 0;
 }

--- a/src/canvas_chat/static/js/app.js
+++ b/src/canvas_chat/static/js/app.js
@@ -1669,7 +1669,7 @@ class App {
         this.canvas.zoomToSelectionAnimated([aiNode.id], 0.8, 300);
         this.updateCollapseButtonForNode(humanNode.id);
 
-        const context = this.graph.resolveContext([humanNode.id]);
+        const context = this.graph.resolveContextWithSearchResults([humanNode.id]);
         const messages = buildMessagesForApi(context);
         const abortController = new AbortController();
 
@@ -1992,20 +1992,30 @@ class App {
     handleNodeCollapse(nodeId) {
         const node = this.graph.getNode(nodeId);
         if (!node) return;
+        this.setNodeCollapsed(nodeId, !node.collapsed);
+    }
 
-        // Toggle collapsed state
-        node.collapsed = !node.collapsed;
+    /**
+     * Explicitly set a node's collapsed state (non-toggling). This is the
+     * canonical, reusable collapse entry point — used by handleNodeCollapse
+     * and exposed to plugins via AppContext (collapseNode/expandNode) so any
+     * feature can collapse/expand nodes of any type.
+     * @param {string} nodeId
+     * @param {boolean} collapsed
+     */
+    setNodeCollapsed(nodeId, collapsed) {
+        const node = this.graph.getNode(nodeId);
+        if (!node) return;
 
-        // Persist the collapsed state to the graph
-        this.graph.updateNode(nodeId, { collapsed: node.collapsed });
+        this.graph.updateNode(nodeId, { collapsed });
 
         // Update visibility of all nodes
         this.updateAllNodeVisibility();
 
         // Update the collapse button for this node
         const children = this.graph.getChildren(nodeId);
-        const hiddenCount = node.collapsed ? this.graph.countHiddenDescendants(nodeId) : 0;
-        this.canvas.updateCollapseButton(nodeId, children.length > 0, node.collapsed, hiddenCount);
+        const hiddenCount = collapsed ? this.graph.countHiddenDescendants(nodeId) : 0;
+        this.canvas.updateCollapseButton(nodeId, children.length > 0, collapsed, hiddenCount);
 
         // Save session
         this.saveSession();
@@ -2609,7 +2619,7 @@ class App {
                 this.updateCollapseButtonForNode(humanNode.id);
 
                 // Build context and stream LLM response
-                const context = this.graph.resolveContext([humanNode.id]);
+                const context = this.graph.resolveContextWithSearchResults([humanNode.id]);
                 const messages = buildMessagesForApi(context);
 
                 // Create AbortController for this stream
@@ -2682,7 +2692,7 @@ class App {
         const parentNode = this.graph.getNode(nodeId);
 
         // Get context up to this node (includes the node itself and all ancestors)
-        const context = this.graph.resolveContext([nodeId]);
+        const context = this.graph.resolveContextWithSearchResults([nodeId]);
 
         if (context.length < 1) {
             alert('No content to summarize');

--- a/src/canvas_chat/static/js/crdt-graph.js
+++ b/src/canvas_chat/static/js/crdt-graph.js
@@ -15,6 +15,23 @@ import { EventEmitter } from './event-emitter.js';
 import { NodeType, TAG_COLORS, createNode, createEdge, EdgeType, getDefaultNodeSize } from './graph-types.js';
 import { resolveOverlaps, resolveHorizontalOverlaps, wouldOverlapNodes, getNodeSize as _getNodeSize, DEFAULT_WIDTH, DEFAULT_HEIGHT, LAYOUT_START_X as START_X, LAYOUT_START_Y as START_Y } from './layout.js';
 
+/**
+ * Max characters of a single search result injected into reply context.
+ * Bounds per-result cost so one large page cannot dominate the prompt.
+ * @type {number}
+ */
+const SEARCH_RESULT_CONTEXT_MAX_CHARS = 6000;
+
+/**
+ * Clip a string to the context budget, appending an ellipsis when truncated.
+ * @param {string} text
+ * @returns {string}
+ */
+function clipForContext(text) {
+    if (!text || text.length <= SEARCH_RESULT_CONTEXT_MAX_CHARS) return text || '';
+    return `${text.slice(0, SEARCH_RESULT_CONTEXT_MAX_CHARS - 1)}…`;
+}
+
 // =============================================================================
 // Type Imports (JSDoc)
 // =============================================================================
@@ -1487,6 +1504,63 @@ class CRDTGraph extends EventEmitter {
             }
             return msg;
         });
+    }
+
+    /**
+     * Resolve context like {@link resolveContext}, then enrich it with any SEARCH
+     * node's curated results: for each SEARCH node present in the ancestor
+     * context, append its `selected` results. If a result has an expanded child
+     * REFERENCE node (created via "View content"), the child's full page text
+     * replaces the snippet; otherwise the snippet is used. Child nodes already
+     * reached via the ancestor walk are not duplicated.
+     *
+     * Result state is stored on the SEARCH node as a JSON string in
+     * `searchResults` (`[{title,url,snippet,selected,expanded}]`).
+     * @param {string[]} nodeIds
+     * @returns {Array<{role:string,content:string,nodeId:string}>}
+     */
+    resolveContextWithSearchResults(nodeIds) {
+        const messages = this.resolveContext(nodeIds);
+        const seenNodeIds = new Set(messages.map((m) => m.nodeId));
+        const coveredUrls = new Set();
+        const extra = [];
+
+        for (const msg of [...messages]) {
+            const node = this.getNode(msg.nodeId);
+            if (!node || node.type !== NodeType.SEARCH) continue;
+
+            let results = [];
+            try {
+                const parsed = JSON.parse(node.searchResults || '[]');
+                if (Array.isArray(parsed)) results = parsed;
+            } catch {
+                results = [];
+            }
+
+            // Index expanded child REFERENCE nodes by url (full text wins).
+            const childByUrl = new Map();
+            for (const child of this.getChildren(node.id)) {
+                if (child.type === NodeType.REFERENCE && child.url) {
+                    childByUrl.set(child.url, child);
+                }
+            }
+
+            for (const r of results) {
+                if (r.selected === false || !r.url || coveredUrls.has(r.url)) continue;
+                coveredUrls.add(r.url);
+                const child = childByUrl.get(r.url);
+                if (child) {
+                    if (seenNodeIds.has(child.id)) continue;
+                    seenNodeIds.add(child.id);
+                    const body = clipForContext(child.content || '');
+                    extra.push({ role: 'user', content: body, nodeId: child.id });
+                } else {
+                    const content = `**[${r.title || ''}](${r.url})**\n\n${clipForContext(r.snippet || '')}`;
+                    extra.push({ role: 'user', content, nodeId: `${node.id}:search:${r.url}` });
+                }
+            }
+        }
+        return [...messages, ...extra];
     }
 
     /**

--- a/src/canvas_chat/static/js/feature-plugin.js
+++ b/src/canvas_chat/static/js/feature-plugin.js
@@ -39,6 +39,9 @@ class AppContext {
         this.updateCollapseButtonForNode = app.updateCollapseButtonForNode
             ? app.updateCollapseButtonForNode.bind(app)
             : null;
+        // Reusable collapse/expand entry points (see App.setNodeCollapsed).
+        this.collapseNode = app.setNodeCollapsed ? app.setNodeCollapsed.bind(app) : null;
+        this.expandNode = app.setNodeCollapsed ? (nodeId) => app.setNodeCollapsed(nodeId, false) : null;
         this.buildLLMRequest = app.buildLLMRequest.bind(app);
         this.generateNodeSummary = app.generateNodeSummary ? app.generateNodeSummary.bind(app) : null;
 
@@ -152,6 +155,8 @@ class FeaturePlugin {
         this.saveSession = context.saveSession;
         this.updateEmptyState = context.updateEmptyState;
         this.updateCollapseButtonForNode = context.updateCollapseButtonForNode;
+        this.collapseNode = context.collapseNode;
+        this.expandNode = context.expandNode;
         this.buildLLMRequest = context.buildLLMRequest;
         this.generateNodeSummary = context.generateNodeSummary;
 

--- a/src/canvas_chat/static/js/plugins/research.js
+++ b/src/canvas_chat/static/js/plugins/research.js
@@ -10,9 +10,17 @@ import { storage } from '../storage.js';
 import { readSSEStream, normalizeText } from '../sse.js';
 import { apiUrl } from '../utils.js';
 import { FeaturePlugin } from '../feature-plugin.js';
+import { fetchUrlContent } from '../web-grounding.js';
 
 /** @type {number} */
 const MAX_RESEARCH_ACTIVITY_LINES = 300;
+
+/**
+ * Max characters of a fetched page stored on a "View content" child node.
+ * Bounds per-result size for both display and reply-context injection.
+ * @type {number}
+ */
+const SEARCH_PAGE_BODY_MAX_CHARS = 8000;
 
 /**
  * Append a line to the research activity log, trimming oldest lines when over budget.
@@ -83,13 +91,198 @@ class ResearchFeature extends FeaturePlugin {
         this.canvas.ensureOutputPanelContent(nodeId, node);
     }
 
+    // ------------------------------------------------------------------------
+    // Search results carousel (drawer on the SEARCH node)
+    // ------------------------------------------------------------------------
+    // The SearchNode protocol renders the carousel and emits canvas events;
+    // ResearchFeature owns the logic below. Result state lives on the node as a
+    // JSON string (`searchResults`) plus `searchCarouselIndex`.
+
     /**
-     * Handle search command.
-     * @param {string} query - The user's search query
-     * @param {string} context - Optional context to help refine the query (e.g., selected text)
+     * Canvas event handlers for the search results carousel.
+     * @returns {Object}
      */
+    getCanvasEventHandlers() {
+        return {
+            searchPrevResult: (nodeId) => this._searchStep(nodeId, -1),
+            searchNextResult: (nodeId) => this._searchStep(nodeId, 1),
+            searchToggleSelect: (nodeId) => this._searchToggleSelect(nodeId),
+            searchViewContent: (nodeId) => this._searchViewContent(nodeId),
+        };
+    }
+
     /**
-     * Handle the /search command
+     * Refresh (or create) the SEARCH node's results drawer after a state change.
+     * @param {string} nodeId
+     */
+    _refreshSearchPanel(nodeId) {
+        const node = this.graph.getNode(nodeId);
+        if (!node) return;
+        this.canvas.ensureOutputPanelContent(nodeId, node);
+    }
+
+    /**
+     * Read this node's search results array (parsed from JSON; [] on failure).
+     * @param {string} nodeId
+     * @returns {Array<Object>}
+     */
+    _getSearchResults(nodeId) {
+        const node = this.graph.getNode(nodeId);
+        if (!node || !node.searchResults) return [];
+        try {
+            const parsed = JSON.parse(node.searchResults);
+            return Array.isArray(parsed) ? parsed : [];
+        } catch {
+            return [];
+        }
+    }
+
+    /**
+     * Persist search results back to the node and refresh the drawer.
+     * @param {string} nodeId
+     * @param {Array<Object>} results
+     */
+    _setSearchResults(nodeId, results) {
+        this.graph.updateNode(nodeId, { searchResults: JSON.stringify(results) });
+        this._refreshSearchPanel(nodeId);
+        this.saveSession();
+    }
+
+    /**
+     * Move the carousel by `delta`, clamping to the result range.
+     * @param {string} nodeId
+     * @param {number} delta
+     */
+    _searchStep(nodeId, delta) {
+        const results = this._getSearchResults(nodeId);
+        if (results.length === 0) return;
+        const current = Number(this.graph.getNode(nodeId).searchCarouselIndex) || 0;
+        const next = Math.max(0, Math.min(results.length - 1, current + delta));
+        if (next === current) return;
+        this.graph.updateNode(nodeId, { searchCarouselIndex: next });
+        this._refreshSearchPanel(nodeId);
+        this.saveSession();
+    }
+
+    /**
+     * Toggle the current result's `selected` flag (include-in-context).
+     * @param {string} nodeId
+     */
+    _searchToggleSelect(nodeId) {
+        const node = this.graph.getNode(nodeId);
+        const results = this._getSearchResults(nodeId);
+        const idx = Math.min(Number(node.searchCarouselIndex) || 0, results.length - 1);
+        if (idx < 0 || idx >= results.length) return;
+        results[idx] = { ...results[idx], selected: !results[idx].selected };
+        this._setSearchResults(nodeId, results);
+    }
+
+    /**
+     * Fetch the current result's page and create an opt-in child REFERENCE node
+     * showing the page text, linked to the SEARCH node. Marks the result
+     * `expanded` so the carousel reflects state and context uses the full text.
+     *
+     * Robustness: an in-flight `fetching` flag (stored on the result) guards
+     * against double-click duplicates; the latest results are re-read before
+     * writing back so concurrent checkbox toggles aren't clobbered; a failed
+     * fetch does not flip `expanded` (so the user can retry).
+     * @param {string} nodeId
+     */
+    async _searchViewContent(nodeId) {
+        const node = this.graph.getNode(nodeId);
+        if (!node) return;
+        const results = this._getSearchResults(nodeId);
+        const idx = Math.min(Number(node.searchCarouselIndex) || 0, results.length - 1);
+        const result = results[idx];
+        if (!result || !result.url) return;
+        if (result.fetching) return; // in-flight guard against duplicate child nodes
+
+        // Already expanded: focus the existing child. If the child was deleted,
+        // reset the stale flag and fall through to re-fetch.
+        if (result.expanded) {
+            const child = this._findExpandedChild(nodeId, result.url);
+            if (child) {
+                this.canvas.zoomToSelectionAnimated([child.id], 0.8, 300);
+                return;
+            }
+        }
+
+        // Mark in-flight and refresh the drawer (button shows "Fetching…").
+        this._updateResult(nodeId, idx, { fetching: true });
+
+        let pageText = '';
+        try {
+            const fetched = await fetchUrlContent(result.url);
+            pageText = (fetched && fetched.content) || '';
+        } catch (err) {
+            console.warn('[ResearchFeature] view-content fetch failed:', err);
+        } finally {
+            // Re-read the latest results so we don't clobber checkbox toggles
+            // made during the await, then clear the in-flight flag.
+            const latest = this._getSearchResults(nodeId);
+            if (latest[idx]) {
+                latest[idx] = { ...latest[idx], fetching: false, expanded: pageText.length > 0 };
+                this.graph.updateNode(nodeId, { searchResults: JSON.stringify(latest) });
+                this._refreshSearchPanel(nodeId);
+            }
+        }
+
+        // Nothing to show if the fetch failed — the result stays expandable.
+        if (!pageText) return;
+
+        if (pageText.length > SEARCH_PAGE_BODY_MAX_CHARS) {
+            pageText = pageText.slice(0, SEARCH_PAGE_BODY_MAX_CHARS);
+        }
+
+        // Create the child REFERENCE node carrying the page text (+ url for dedup).
+        // autoPosition stacks each new child instead of overlapping them.
+        const pos = this.graph.autoPosition([nodeId], NodeType.REFERENCE);
+        const childNode = createNode(
+            NodeType.REFERENCE,
+            `**[${result.title}](${result.url})**\n\n${pageText}`
+        );
+        childNode.url = result.url;
+        childNode.position = pos;
+        this.graph.addNode(childNode);
+        const edge = createEdge(nodeId, childNode.id, EdgeType.SEARCH_RESULT);
+        this.graph.addEdge(edge);
+        this.canvas.renderNode(childNode);
+        this.canvas.renderEdge(edge, this.graph.getNode(nodeId).position, childNode.position);
+        this.updateCollapseButtonForNode?.(nodeId);
+
+        this.canvas.zoomToSelectionAnimated([childNode.id], 0.8, 300);
+        this.saveSession();
+    }
+
+    /**
+     * Merge a patch into one result entry, re-reading the latest array first so
+     * concurrent edits to other entries are preserved.
+     * @param {string} nodeId
+     * @param {number} idx
+     * @param {Object} patch
+     */
+    _updateResult(nodeId, idx, patch) {
+        const latest = this._getSearchResults(nodeId);
+        if (!latest[idx]) return;
+        latest[idx] = { ...latest[idx], ...patch };
+        this.graph.updateNode(nodeId, { searchResults: JSON.stringify(latest) });
+        this._refreshSearchPanel(nodeId);
+    }
+
+    /**
+     * Find an existing expanded child REFERENCE node for a URL, if any.
+     * @param {string} parentId
+     * @param {string} url
+     * @returns {Object|undefined}
+     */
+    _findExpandedChild(parentId, url) {
+        return this.graph.getChildren(parentId).find((c) => c.type === NodeType.REFERENCE && c.url === url);
+    }
+
+    /**
+     * Handle the /search command: store results in a carousel drawer on a single
+     * SEARCH node (no REFERENCE-node fan-out). See getCanvasEventHandlers for the
+     * carousel interactions (prev/next, context checkbox, view content).
      * @param {string} command - The slash command (e.g., '/search')
      * @param {string} args - Text after the command
      * @param {Object} contextObj - Additional context (e.g., { text: selectedNodesContent })
@@ -209,26 +402,22 @@ class ResearchFeature extends FeaturePlugin {
             this.canvas.updateNodeContent(searchNode.id, searchContent, false);
             this.graph.updateNode(searchNode.id, { content: searchContent });
 
-            // Create reference nodes for each result
-            let offsetY = 0;
-            for (const result of data.results) {
-                const resultContent = `**[${result.title}](${result.url})**\n\n${result.snippet}${result.published_date ? `\n\n*${result.published_date}*` : ''}`;
-
-                const resultNode = createNode(NodeType.REFERENCE, resultContent, {
-                    position: {
-                        x: searchNode.position.x + 400,
-                        y: searchNode.position.y + offsetY,
-                    },
-                });
-
-                this.graph.addNode(resultNode);
-
-                // Edge from search to result
-                const edge = createEdge(searchNode.id, resultNode.id, EdgeType.SEARCH_RESULT);
-                this.graph.addEdge(edge);
-
-                offsetY += 200; // Space between result nodes
-            }
+            // Store results on the node as a JSON string (CRDT-safe primitive).
+            // All results default to selected=true so they feed reply context;
+            // the user curates via the drawer checkboxes. No fan-out nodes are
+            // created — results live in the SEARCH node's carousel drawer.
+            const searchResults = (data.results || []).map((r) => ({
+                title: r.title || '',
+                url: r.url || '',
+                snippet: r.snippet || '',
+                selected: true,
+                expanded: false,
+            }));
+            this.graph.updateNode(searchNode.id, {
+                searchResults: JSON.stringify(searchResults),
+                searchCarouselIndex: 0,
+            });
+            this._refreshSearchPanel(searchNode.id);
 
             this.saveSession();
         } catch (err) {

--- a/src/canvas_chat/static/js/plugins/search-node.js
+++ b/src/canvas_chat/static/js/plugins/search-node.js
@@ -2,18 +2,40 @@
  * Search Node Plugin (Built-in)
  *
  * Provides search nodes for web search queries.
- * Search nodes display the search query and are created by ResearchFeature
- * when users run the /search command.
+ * Search nodes display the search query in the node body and host a carousel
+ * of results in the output-panel drawer. Each carousel slide shows one result
+ * (title, URL, snippet) with a checkbox to include it in reply context and a
+ * "View content" button that fetches the page and creates an opt-in child node.
+ *
+ * Result data is stored on the node as a JSON string in `searchResults`
+ * (`[{ title, url, snippet, selected, expanded }]`) plus `searchCarouselIndex`.
+ * The ResearchFeature owns the carousel interactions via canvas events
+ * (`searchPrevResult`, `searchNextResult`, `searchToggleSelect`, `searchViewContent`).
  */
 import { BaseNode } from '../node-protocols.js';
 import { NodeRegistry } from '../node-registry.js';
 
 /**
- * SearchNode - Protocol for search queries
+ * Parse the searchResults JSON string on a node into an array (empty on failure).
+ * @param {Object} node
+ * @returns {Array<{title:string,url:string,snippet:string,selected:boolean,expanded:boolean}>}
+ */
+function getResults(node) {
+    if (!node || !node.searchResults) return [];
+    try {
+        const parsed = JSON.parse(node.searchResults);
+        return Array.isArray(parsed) ? parsed : [];
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * SearchNode - Protocol for search queries with a results carousel drawer.
  */
 class SearchNode extends BaseNode {
     /**
-     * Get the type label for this node
+     * Get the type label for this node.
      * @returns {string}
      */
     getTypeLabel() {
@@ -21,11 +43,80 @@ class SearchNode extends BaseNode {
     }
 
     /**
-     * Get the type icon for this node
+     * Get the type icon for this node.
      * @returns {string}
      */
     getTypeIcon() {
         return '🔍';
+    }
+
+    /**
+     * Show the results drawer when this node has search results.
+     * @returns {boolean}
+     */
+    hasOutput() {
+        return getResults(this.node).length > 0;
+    }
+
+    /**
+     * Render the results carousel inside the output panel.
+     * One result at a time with prev/next, a context checkbox, and a
+     * "View content" button. Buttons emit canvas events (handled by ResearchFeature).
+     * @param {Object} canvas - Canvas instance (for escapeHtml)
+     * @returns {string} HTML for the output panel body
+     */
+    renderOutputPanel(canvas) {
+        const results = getResults(this.node);
+        if (results.length === 0) return '';
+        const idx = Math.min(Number(this.node.searchCarouselIndex) || 0, results.length - 1);
+        const r = results[idx];
+        if (!r) return '';
+
+        const selected = r.selected !== false;
+        const expanded = !!r.expanded;
+        const fetching = !!r.fetching;
+        const escaped = (s) => canvas.escapeHtml(s == null ? '' : String(s));
+        const viewLabel = expanded ? 'View node' : fetching ? 'Fetching…' : 'View content';
+
+        return `
+            <div class="search-carousel" data-index="${idx}">
+                <div class="search-carousel-result">
+                    <div class="search-carousel-title">${escaped(r.title) || '<em>(no title)</em>'}</div>
+                    <div class="search-carousel-url">${escaped(r.url)}</div>
+                    <div class="search-carousel-snippet">${escaped(r.snippet)}</div>
+                </div>
+                <div class="search-carousel-controls">
+                    <label class="search-carousel-select" title="Include this result in reply context">
+                        <input type="checkbox" class="search-toggle-select" ${selected ? 'checked' : ''}>
+                        <span>Context</span>
+                    </label>
+                    <button type="button" class="search-view-content" title="Fetch the page and open it as a child node" ${fetching ? 'disabled' : ''}>${escaped(viewLabel)}</button>
+                </div>
+                <div class="search-carousel-nav">
+                    <button type="button" class="search-prev" title="Previous result">◀</button>
+                    <span class="search-carousel-counter">${idx + 1} / ${results.length}</span>
+                    <button type="button" class="search-next" title="Next result">▶</button>
+                </div>
+            </div>
+        `;
+    }
+
+    /**
+     * Event bindings for the carousel, applied to the output panel body.
+     * Each handler emits a canvas event (with the node id); the ResearchFeature
+     * owns the actual logic via getCanvasEventHandlers(). We use function
+     * handlers (canvas.emit) rather than string handlers because the
+     * output-panel binding path invokes functions only.
+     * @returns {Array<Object>}
+     */
+    getEventBindings() {
+        const emit = (name) => (nodeId, _e, canvas) => canvas?.emit?.(name, nodeId);
+        return [
+            { selector: '.search-prev', handler: emit('searchPrevResult') },
+            { selector: '.search-next', handler: emit('searchNextResult') },
+            { selector: '.search-toggle-select', event: 'change', handler: emit('searchToggleSelect') },
+            { selector: '.search-view-content', handler: emit('searchViewContent') },
+        ];
     }
 }
 

--- a/tests/test_search_context.js
+++ b/tests/test_search_context.js
@@ -1,0 +1,115 @@
+/**
+ * Tests for CRDTGraph.resolveContextWithSearchResults.
+ *
+ * Verifies that replying to a SEARCH node pulls the node's curated results into
+ * the LLM context: selected snippets by default, and the full page text of any
+ * result that has been expanded into a child REFERENCE node ("View content").
+ *
+ * These exercise the REAL resolveContextWithSearchResults on a real CRDTGraph
+ * (via TestGraph), not a copy.
+ */
+import {
+    test,
+    assertEqual,
+    assertTrue,
+    NodeType,
+    TestGraph,
+    createTestNode,
+    createTestEdge,
+} from './test_setup.js';
+
+/**
+ * Build a SEARCH node carrying a searchResults JSON payload.
+ * @param {string} id
+ * @param {Array<Object>} results
+ * @returns {Object}
+ */
+function searchNodeWith(id, results) {
+    const node = createTestNode(id, NodeType.SEARCH, `Search: "q"`);
+    node.searchResults = JSON.stringify(results);
+    node.searchCarouselIndex = 0;
+    return node;
+}
+
+test('Search context: selected results are included as context', () => {
+    const graph = new TestGraph();
+    const search = searchNodeWith('S', [
+        { title: 'A', url: 'http://a', snippet: 'snip A', selected: true, expanded: false },
+        { title: 'B', url: 'http://b', snippet: 'snip B', selected: true, expanded: false },
+    ]);
+    const human = createTestNode('H', NodeType.HUMAN, 'reply');
+    graph.addNode(search);
+    graph.addNode(human);
+    graph.addEdge(createTestEdge('S', 'H', 'reply'));
+
+    const ctx = graph.resolveContextWithSearchResults(['H']);
+
+    // human + search + 2 result snippets
+    assertEqual(ctx.length, 4);
+    const joined = ctx.map((m) => m.content).join('\n');
+    assertTrue(joined.includes('snip A'), 'snippet A should be in context');
+    assertTrue(joined.includes('snip B'), 'snippet B should be in context');
+});
+
+test('Search context: unselected results are excluded', () => {
+    const graph = new TestGraph();
+    const search = searchNodeWith('S', [
+        { title: 'A', url: 'http://a', snippet: 'snip A', selected: true, expanded: false },
+        { title: 'B', url: 'http://b', snippet: 'snip B', selected: false, expanded: false },
+    ]);
+    const human = createTestNode('H', NodeType.HUMAN, 'reply');
+    graph.addNode(search);
+    graph.addNode(human);
+    graph.addEdge(createTestEdge('S', 'H', 'reply'));
+
+    const ctx = graph.resolveContextWithSearchResults(['H']);
+    const joined = ctx.map((m) => m.content).join('\n');
+    assertTrue(joined.includes('snip A'), 'selected A included');
+    assertTrue(!joined.includes('snip B'), 'unselected B excluded');
+});
+
+test('Search context: expanded child node text replaces snippet (and dedups by url)', () => {
+    const graph = new TestGraph();
+    const search = searchNodeWith('S', [
+        { title: 'A', url: 'http://a', snippet: 'snip A', selected: true, expanded: true },
+    ]);
+    const child = createTestNode('C', NodeType.REFERENCE, '**[A](http://a)**\n\nFULL PAGE TEXT');
+    child.url = 'http://a';
+    const human = createTestNode('H', NodeType.HUMAN, 'reply');
+    graph.addNode(search);
+    graph.addNode(child);
+    graph.addNode(human);
+    graph.addEdge(createTestEdge('S', 'C', 'search_result'));
+    graph.addEdge(createTestEdge('S', 'H', 'reply'));
+
+    const ctx = graph.resolveContextWithSearchResults(['H']);
+    const joined = ctx.map((m) => m.content).join('\n');
+    assertTrue(joined.includes('FULL PAGE TEXT'), 'expanded child full text included');
+    assertTrue(!joined.includes('snip A'), 'snippet not duplicated when child exists');
+});
+
+test('Search context: no SEARCH ancestor behaves like resolveContext', () => {
+    const graph = new TestGraph();
+    const a = createTestNode('A', NodeType.HUMAN, 'hi');
+    const b = createTestNode('B', NodeType.HUMAN, 'reply');
+    graph.addNode(a);
+    graph.addNode(b);
+    graph.addEdge(createTestEdge('A', 'B', 'reply'));
+
+    const base = graph.resolveContext(['B']);
+    const enriched = graph.resolveContextWithSearchResults(['B']);
+    assertEqual(base.length, enriched.length);
+});
+
+test('Search context: SEARCH node without searchResults does not crash or add extras', () => {
+    const graph = new TestGraph();
+    const search = createTestNode('S', NodeType.SEARCH, 'Search: "q"'); // no searchResults field
+    const human = createTestNode('H', NodeType.HUMAN, 'reply');
+    graph.addNode(search);
+    graph.addNode(human);
+    graph.addEdge(createTestEdge('S', 'H', 'reply'));
+
+    const base = graph.resolveContext(['H']);
+    const enriched = graph.resolveContextWithSearchResults(['H']);
+    assertEqual(base.length, enriched.length); // no extras, no crash
+});


### PR DESCRIPTION
## Summary

Redesigns `/search` so results no longer fan out as REFERENCE nodes that clutter the canvas. Instead, results live in a **carousel drawer** on a single SEARCH node. Each result can be curated for reply context via a checkbox, and expanded into an opt-in child node via **View content**. Replying to a SEARCH node now automatically injects the curated results (snippet, or the expanded page's full text) into the LLM context — the ergonomic gap that motivated this change.

Design credit: Will Sanger (drawer + carousel + checkbox + view-content concept).

## Outcomes

- **(a) Reply context** — `CRDTGraph.resolveContextWithSearchResults` injects a SEARCH node's selected results into the reply context. For results expanded via View content, the child node's full page text replaces the snippet (dedup by URL; per-result char cap `SEARCH_RESULT_CONTEXT_MAX_CHARS` = 6000). Wired into `sendChatMessage`, `handleNodeBranch`, and `handleNodeSummarize`.
- **(b) No more fan-out** — `/search` creates one SEARCH node; results render in a PowerPoint-style carousel drawer (◀/▶, counter, Context checkbox, View content). Backward compatible: old SEARCH nodes (no `searchResults`) render exactly as before.
- **(c) Reusable collapse API** — `App.setNodeCollapsed(nodeId, bool)` exposed on `AppContext` as `collapseNode` / `expandNode`, so any plugin can collapse/expand any node type. Used here when expanded results fan out into child nodes.

## Changes breakdown

| Area | File | Change |
|------|------|--------|
| Carousel UI | `plugins/search-node.js` | `hasOutput`/`renderOutputPanel` carousel + `getEventBindings` (function handlers emitting canvas events) |
| Feature logic | `plugins/research.js` | `handleSearch` stores `searchResults` JSON (no fan-out); `getCanvasEventHandlers` + handlers (prev/next/toggle/viewContent) |
| Context resolver | `crdt-graph.js` | `resolveContextWithSearchResults` + `clipForContext` |
| Wiring | `app.js` | 3 reply paths use the new resolver; `setNodeCollapsed` (handleNodeCollapse refactored to a thin toggle) |
| Plugin API | `feature-plugin.js` | expose `collapseNode`/`expandNode` |
| Styles | `css/nodes.css` | `.search-carousel-*` |

## View content robustness

- In-flight `fetching` flag guards against double-click duplicate children.
- Results are re-read before write-back so concurrent checkbox toggles aren't clobbered.
- Fetching state shows in the carousel button (node body is never mutated, so nothing gets stuck).
- A failed fetch leaves the result retryable; a deleted expanded child re-fetches on next click.
- Child nodes are `autoPosition`ed (no overlap).

## Tests

- **Unit:** `tests/test_search_context.js` — `resolveContextWithSearchResults` (selected/excluded, expanded-child-supersedes-snippet, dedup, backward compat). All 83 JS test files pass.
- **E2E:** `cypress/e2e/search_carousel.cy.js` (navigate, checkbox, view content); updated `ddg_search.cy.js` for the no-fan-out behavior. Both pass against the live dev server, plus `reply_to_selected` / `note_node` regression.

## Docs

- `docs/how-to/web-search.md` rewritten for the drawer workflow.
- `docs/reference/app-context-api.md` — `collapseNode`/`expandNode`.
- `AGENTS.md` — dated note + codebase-map/constants/test updates.

## Review

Reviewed by three parallel read-only subagents (core correctness, code organization/minimal-diff, edge-cases/integration), then a verification pass. All blocker/major findings fixed: the primary `sendChatMessage` wiring, double-click/lost-update/stuck-state bugs in View content, child overlap, failed-fetch state, and a CSS whitespace revert.

## Manual testing

Run `pixi run dev`, then `/search <query>`. Open the drawer, browse with ◀/▶, toggle Context checkboxes, click View content to expand a page, and reply to the SEARCH node to confirm the AI sees the curated results.
