### PR TITLE
fix(layout): overlapping nodes in disconnected subgraphs (autoPosition clamp bug)

### DIFF
--- a/src/canvas_chat/static/js/crdt-graph.js
+++ b/src/canvas_chat/static/js/crdt-graph.js
@@ -1714,8 +1714,8 @@ class CRDTGraph extends EventEmitter {
         let initialX, initialY;
 
         if (parentIds.length === 0) {
-            initialX = 100;
-            initialY = 100;
+            initialX = START_X;
+            initialY = START_Y;
         } else {
             const parents = parentIds.map((id) => this.getNode(id)).filter(Boolean);
 
@@ -1741,22 +1741,28 @@ class CRDTGraph extends EventEmitter {
             }
         }
 
-        const candidatePos = { x: initialX, y: initialY };
         const allNodes = this.getAllNodes();
+        const shiftStep = NODE_WIDTH + HORIZONTAL_GAP;
+        // Clamp the ideal position on-screen first; this is also the base for any
+        // rightward shift. Rightward-only (not alternating): a leftward shift near
+        // the left edge would be clamped back to START_X and land on whatever node
+        // already sits there — reintroducing the overlap (this previously stacked
+        // siblings and even overlapped nodes across disconnected subgraphs). This
+        // mirrors the per-layer resolveHorizontalOverlaps rightward sweep.
+        const baseX = Math.max(START_X, initialX);
+        const candidatePos = { x: baseX, y: initialY };
 
         let attempts = 0;
         const maxAttempts = 20;
-        const shiftStep = NODE_WIDTH + HORIZONTAL_GAP;
-
-        while (attempts < maxAttempts && wouldOverlapNodes(candidatePos, NODE_WIDTH, NODE_HEIGHT, allNodes)) {
-            const direction = attempts % 2 === 0 ? 1 : -1;
-            const magnitude = Math.ceil((attempts + 1) / 2);
-            candidatePos.x = initialX + direction * magnitude * shiftStep;
+        while (
+            attempts < maxAttempts &&
+            wouldOverlapNodes(candidatePos, NODE_WIDTH, NODE_HEIGHT, allNodes)
+        ) {
+            candidatePos.x = baseX + (attempts + 1) * shiftStep;
             attempts++;
         }
 
-        if (candidatePos.x < 100) candidatePos.x = 100;
-        if (candidatePos.y < 100) candidatePos.y = 100;
+        if (candidatePos.y < START_Y) candidatePos.y = START_Y;
 
         return candidatePos;
     }

--- a/tests/test_vertical_layout.js
+++ b/tests/test_vertical_layout.js
@@ -91,6 +91,54 @@ test('autoPosition: createLinkedNode centers AI under HUMAN correctly', () => {
     assertEqual(aiCenter, humanCenter);
 });
 
+// Regression: https://github.com/ericmjl/canvas-chat/issues — nodes overlapping
+// in the default (incremental) tree view. autoPosition's left-edge clamp used to
+// snap an off-canvas-left "clear" position back to START_X, landing a second
+// child (or a node from a different subgraph) on top of an existing node.
+function rectsOverlap(a, b) {
+    const aw = a.width || 420;
+    const ah = a.height || 200;
+    const bw = b.width || 420;
+    const bh = b.height || 200;
+    return !(
+        a.position.x + aw < b.position.x ||
+        a.position.x > b.position.x + bw ||
+        a.position.y + ah < b.position.y ||
+        a.position.y > b.position.y + bh
+    );
+}
+
+test('autoPosition: second child of left-edge parent does not overlap first', () => {
+    const graph = new TestGraph();
+    const root = graph.createLinkedNode(NodeType.HUMAN, 'root', []);
+    const first = graph.createLinkedNode(NodeType.AI, 'first', [root.id]);
+    const second = graph.createLinkedNode(NodeType.AI, 'second', [root.id]);
+    assertFalse(rectsOverlap(first, second), 'second child must not stack on the first');
+    // Second child should be shifted right of the first.
+    const firstRight = first.position.x + 640;
+    assertTrue(second.position.x >= firstRight, `second (${second.position.x}) should be right of first (${firstRight})`);
+});
+
+test('autoPosition: new subgraph child does not overlap an existing laid-out subgraph', () => {
+    const graph = new TestGraph();
+    // Subgraph A: root + 3 children, then Apply Layout spreads them into a row.
+    const a0 = createTestNode('A0', NodeType.HUMAN);
+    graph.addNode(a0);
+    for (let i = 1; i <= 3; i++) {
+        const c = createTestNode('A' + i, NodeType.AI);
+        graph.addNode(c);
+        graph.addEdge(createTestEdge('A0', 'A' + i));
+    }
+    graph.verticalTreeLayout();
+    // Start a disconnected subgraph B incrementally.
+    const b0 = graph.createLinkedNode(NodeType.HUMAN, 'B0', []);
+    const b1 = graph.createLinkedNode(NodeType.AI, 'B1', [b0.id]);
+    // B's child must not overlap ANY node of subgraph A.
+    for (const id of ['A0', 'A1', 'A2', 'A3']) {
+        assertFalse(rectsOverlap(b1, graph.getNode(id)), `B1 must not overlap ${id}`);
+    }
+});
+
 // ============================================================
 // verticalTreeLayout: basic structure tests
 // ============================================================


### PR DESCRIPTION
## Summary

Fixes nodes overlapping in the default top-down tree view, **including across disconnected subgraphs**. The root cause was in incremental node placement (`autoPosition`), not in `verticalTreeLayout`.

## Root cause

`CRDTGraph.autoPosition` (`crdt-graph.js`) is what actually places nodes in the default view (full `verticalTreeLayout` only runs on "Apply Layout"; `scheduleAutoLayout` is an intentional no-op). Its overlap-avoidance loop used an **alternating left/right** search, and when it found a "clear" slot off-canvas to the **left** (x < 100), the loop accepted it — then the post-loop clamp `if (candidatePos.x < 100) candidatePos.x = 100` **snapped it back to x=100**, landing the node on whatever already sat there.

Because the clamp is subgraph-agnostic, this:
- **stacked siblings** of a left-edge parent (2nd child lands on the 1st), and
- **overlapped nodes across disconnected subgraphs** — after Apply Layout spreads subgraph A into a row (A1@100, A2@790, A3@1480), starting a new subgraph B clamps B's child back to x=100 onto A1. (The user's "between different subgraphs" report was literal.)

`verticalTreeLayout` itself is overlap-free (verified for far-apart subgraphs) — its per-layer `resolveHorizontalOverlaps` correctly separates nodes.

## RCA procedure

1. Reproduced empirically (`autoPosition` → two children both at `100,360`; `verticalTreeLayout` → no overlap).
2. Two read-only subagents checked the RCA from different angles and reached consensus — one confirmed the exact arithmetic; the other **caught that the cross-subgraph case is genuine** (not just siblings), correcting my initial scope.
3. Fix → two more subagents reviewed (correctness + regressions): both PASS, no regressions, recommend merge.

## Fix

Replace the alternating left/right search + post-clamp with a **rightward-only sweep anchored at `START_X`**: clamp the ideal centered position on-screen first (`baseX = max(START_X, initialX)`), then shift right by one `shiftStep` at a time until non-overlapping. This:
- guarantees the returned position is both on-screen (x ≥ START_X) **and** non-overlapping (or best-effort after `maxAttempts`, pre-existing behavior),
- makes incremental placement **consistent** with `resolveHorizontalOverlaps` (also a rightward sweep), eliminating the fan-out jitter the old alternating search could cause,
- uses the named `START_X`/`START_Y` constants instead of magic `100`.

## Changes

- `src/canvas_chat/static/js/crdt-graph.js` — `autoPosition` loop rewritten (and root-branch literals → `START_X`/`START_Y`).
- `tests/test_vertical_layout.js` — two regression tests:
  - "second child of left-edge parent does not overlap first" (fails on old code, passes on fix)
  - "new subgraph child does not overlap an existing laid-out subgraph" (fails on old code, passes on fix)

## Tests

Full JS suite: **82/82 files pass** (on `main`; the 83rd belongs to the search-PR branch). Both new tests verified to fail on the old `autoPosition` and pass on the fix.

## Manual check

On a canvas, build a subgraph with a branching root, apply layout, then start a second disconnected conversation — children no longer stack/overlap.
