### PR TITLE
fix(layout): focusCentricLayout overlapping disconnected subgraphs on navigation

### DIFF
--- a/src/canvas_chat/static/js/crdt-graph.js
+++ b/src/canvas_chat/static/js/crdt-graph.js
@@ -2146,6 +2146,65 @@ class CRDTGraph extends EventEmitter {
             }
         }
 
+        // Disconnected subgraphs (not reached by the focus BFS) would otherwise
+        // keep stale positions and overlap the rearranged component. Assign each
+        // disconnected component its own block of layers BELOW the focus component,
+        // layered from the component's own roots (top-down orientation preserved),
+        // so the existing per-layer Y-separation and resolveHorizontalOverlaps
+        // position them without overlap.
+        let focusMaxLayer = -Infinity;
+        for (const l of layers.values()) focusMaxLayer = Math.max(focusMaxLayer, l);
+        const connected = new Set(layers.keys());
+        const handled = new Set(connected);
+        let nextLayer = focusMaxLayer + 1;
+        for (const start of allNodes) {
+            if (handled.has(start.id)) continue;
+            // Gather this disconnected component (undirected).
+            const compNodes = new Set([start.id]);
+            const gatherQ = [start.id];
+            while (gatherQ.length > 0) {
+                const id = gatherQ.shift();
+                for (const nb of [...this.getParents(id), ...this.getChildren(id)]) {
+                    if (connected.has(nb.id) || compNodes.has(nb.id)) continue;
+                    compNodes.add(nb.id);
+                    gatherQ.push(nb.id);
+                }
+            }
+            // Layer by topological depth from in-component roots.
+            const compParents = (id) => this.getParents(id).filter((p) => compNodes.has(p.id));
+            const rel = new Map();
+            const roots = [...compNodes].filter((id) => compParents(id).length === 0);
+            const seed = roots.length > 0 ? roots : [...compNodes];
+            const bfsQ = [];
+            for (const r of seed) {
+                rel.set(r, 0);
+                bfsQ.push(r);
+            }
+            let head = 0;
+            while (head < bfsQ.length) {
+                const id = bfsQ[head++];
+                const d = rel.get(id);
+                for (const c of this.getChildren(id)) {
+                    if (!compNodes.has(c.id) || rel.has(c.id)) continue;
+                    rel.set(c.id, d + 1);
+                    bfsQ.push(c.id);
+                }
+            }
+            // Cycles / multi-parent stragglers: fall back to max(parent depth) + 1.
+            let compMaxRel = 0;
+            for (const id of compNodes) {
+                let r = rel.get(id);
+                if (r === undefined) {
+                    const ps = compParents(id).filter((p) => rel.has(p.id));
+                    r = ps.length > 0 ? Math.max(...ps.map((p) => rel.get(p.id))) + 1 : 0;
+                }
+                layers.set(id, nextLayer + r);
+                handled.add(id);
+                compMaxRel = Math.max(compMaxRel, r);
+            }
+            nextLayer += compMaxRel + 1;
+        }
+
         // Step 2: Group nodes by layer, compute Y
         const layerNodes = new Map();
         for (const [nodeId, layer] of layers) {

--- a/tests/test_vertical_layout.js
+++ b/tests/test_vertical_layout.js
@@ -756,6 +756,44 @@ test('focusCentricLayout: stable across repeated navigation', () => {
     }
 });
 
+test('focusCentricLayout: disconnected subgraphs do not overlap the focus component', () => {
+    // Navigating to a focus node must not leave disconnected subgraphs at stale
+    // positions that the rearranged focus component then overlaps.
+    const graph = new TestGraph();
+    const edges = [
+        ['A', 'B'], ['B', 'D'], ['A', 'C'], ['C', 'E'], ['E', 'F'],
+        ['F', 'G'], ['F', 'H'], ['H', 'I'], ['J', 'K'], // J->K is disconnected
+    ];
+    for (const id of ['A','B','C','D','E','F','G','H','I','J','K']) {
+        graph.addNode(createTestNode(id, NodeType.HUMAN));
+    }
+    for (const [s, t] of edges) graph.addEdge(createTestEdge(s, t));
+    graph.verticalTreeLayout();
+
+    // Simulate navigating A -> C.
+    graph.focusCentricLayout('C', new Map(), ['A', 'C']);
+
+    const ids = ['A','B','C','D','E','F','G','H','I','J','K'];
+    const sz = (n) => ({ w: n.width || 420, h: n.height || 200 });
+    const overlap = (a, b) => {
+        const sa = sz(a), sb = sz(b);
+        return !(a.position.x + sa.w < b.position.x || a.position.x > b.position.x + sb.w ||
+                 a.position.y + sa.h < b.position.y || a.position.y > b.position.y + sb.h);
+    };
+    for (let i = 0; i < ids.length; i++) {
+        for (let j = i + 1; j < ids.length; j++) {
+            const a = graph.getNode(ids[i]);
+            const b = graph.getNode(ids[j]);
+            assertFalse(overlap(a, b), `${ids[i]} must not overlap ${ids[j]} after focus layout`);
+        }
+    }
+    // Disconnected J->K must keep top-down orientation (parent J above child K).
+    assertTrue(
+        graph.getNode('J').position.y < graph.getNode('K').position.y,
+        'Disconnected parent J should be above child K',
+    );
+});
+
 // ============================================================
 // Runner (test_setup collects tests; run them here)
 // ============================================================


### PR DESCRIPTION
## Summary

Fixes nodes overlapping after **j/k navigation** when the canvas has disconnected subgraphs. Distinct root cause from #289 (that was `autoPosition` incremental placement; this is `focusCentricLayout` navigation layout).

## Root cause

`focusCentricLayout` (`crdt-graph.js`) runs when you navigate with j/k (app.js:1972). It reorganizes only the focus node's **connected component**: its BFS starts at the focus and traverses parents/children/siblings, so **disconnected subgraphs were never reached, never added to `layers`**, and Step 4 only repositions nodes in `layers`. Disconnected nodes kept stale positions while the focus component rearranged around the focus — landing on top of them.

Reproduced with the reporter's graph:
```
A->B->D, A->C->E->F->{G, H->I}, plus disconnected J->K
```
Navigate A→C → `A` was moved to `(570,100)`, exactly where disconnected `J` already sat → `A<->J` overlap (J/K never moved).

## Fix

After the focus BFS, assign each disconnected component its own block of layers **below** the focus component (`nextLayer = focusMaxLayer + 1`, incrementing per component), layered from the component's **in-component roots** (BFS from roots; cycle/multi-parent stragglers fall back to `max(parent depth)+1`). The existing per-layer Y-separation and `resolveHorizontalOverlaps` then position them with no overlap, and root-based layering preserves top-down orientation (parent above child).

- **No-op for fully-connected graphs** (the outer loop skips every node) → no regression to the 14 existing `focusCentricLayout` tests.
- First attempt inverted J/K orientation (BFS started from an arbitrary node, sometimes a leaf); root-based layering corrected it.

## Verification (procedure: diagnose → 2 subagents → fix → 2 subagents)

- Reproduced empirically before and after the fix (no overlaps after; J above K).
- Two read-only subagents reviewed the fix (correctness/edge-cases + regressions): both **PASS — safe to merge**. Edge cases verified: isolated nodes, cycles, multiple disconnected components, focus-adjacent nodes. No interference with spine selection; linear performance; `keepViewport:true` means the camera stays on the focus.
- Full JS suite: **82/82 pass**; `test_vertical_layout.js`: 30/30 incl. the new regression test.

## Changes

- `src/canvas_chat/static/js/crdt-graph.js` — disconnected-component layer assignment added to `focusCentricLayout`.
- `tests/test_vertical_layout.js` — regression test (the reporter's graph; asserts no overlaps + J above K after `focusCentricLayout('C')`).

## Non-blocking notes from review

- Cycles-with-tails land flat (canvas-chat graphs are DAGs, so unlikely). Pre-existing: `focusCentricLayout` doesn't clamp X to `START_X` (unrelated to this fix).
